### PR TITLE
Use Path.Combine for cross-platform certificate path

### DIFF
--- a/test/UnitTests/TestCert.cs
+++ b/test/UnitTests/TestCert.cs
@@ -11,7 +11,7 @@ namespace IdentityServer4.Tests
     {
         public static X509Certificate2 Load()
         {
-            var cert = PlatformServices.Default.Application.ApplicationBasePath + "\\idsrv3test.pfx";
+            var cert = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "idsrv3test.pfx");
 
             // todo
             return new X509Certificate2(cert, "idsrv3test");


### PR DESCRIPTION
With this fix, unit tests also pass on OS X when running 'dnx test'.