### PR TITLE
Convert the JSON ScopesString into seperate claims

### DIFF
--- a/src/IdentityServer4/Configuration/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/Configuration/Options/IdentityServerOptions.cs
@@ -45,6 +45,8 @@ namespace IdentityServer4.Core.Configuration
         /// </value>
         public string IssuerUri { get; set; }
 
+        public string ProxyServerBaseUrl { get; set; }
+
         /// <summary>
         /// Gets or sets the X.509 certificate (and corresponding private key) for signing security tokens.
         /// </summary>

--- a/src/IdentityServer4/Extensions/IdentityServerContextExtensions.cs
+++ b/src/IdentityServer4/Extensions/IdentityServerContextExtensions.cs
@@ -46,7 +46,12 @@ namespace IdentityServer4.Core.Hosting
         /// <returns></returns>
         public static string GetIdentityServerBaseUrl(this IdentityServerContext context)
         {
-            return context.GetHost() + context.GetBasePath();
+            var url = context.Options.ProxyServerBaseUrl;
+            if (url.IsMissing())
+            {
+                return context.GetHost() + context.GetBasePath();
+            }
+            return url;
         }
 
         public static string GetIssuerUri(this IdentityServerContext context)


### PR DESCRIPTION
I noticed a strange, in my opinion wrong behavior in the TokenValidator class.
Let’s say you have requested a valid access_token with more than one scope, for example „openid“, „profile“, „email“ and „api1“

The convert of the JSON ScopesString into seperate claims is not correctly implemented. As it is at the moment it works only if you have an access_token with only one „openid“ scope.

