### PR TITLE
.NET Core RC2 - .NET 4.6 Support

### DIFF
--- a/src/IdentityServer4/project.json
+++ b/src/IdentityServer4/project.json
@@ -17,14 +17,16 @@
     "Microsoft.AspNetCore.Cors": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-rc2-final",
     "IdentityModel": "2.0.0-beta1",
-    "System.IdentityModel.Tokens.Jwt": "5.0.0-rc2-305061149",
-    "System.Collections.Specialized": "4.0.1-rc2-24027",
-    "System.Dynamic.Runtime": "4.0.11-rc2-24027"
+    "System.IdentityModel.Tokens.Jwt": "5.0.0-rc2-305061149"
   },
 
   "frameworks": {
-    "netstandard1.5": {
-      "imports": "dnxcore50"
+    "net46": { },
+    "netstandard1.4": {
+      "dependencies": {
+        "System.Collections.Specialized": "4.0.1-rc2-24027",
+        "System.Dynamic.Runtime": "4.0.11-rc2-24027"
+      }
     }
   }
 }


### PR DESCRIPTION
Please add .NET 4.6 support. These change requires the changes from pull request https://github.com/IdentityModel/IdentityModelv2/pull/3 