### PR TITLE
Added PublicOrigin back to IdentityServerOptions

### DIFF
--- a/src/IdentityServer4/Configuration/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/Configuration/Options/IdentityServerOptions.cs
@@ -38,6 +38,14 @@ namespace IdentityServer4.Core.Configuration
         public string SiteName { get; set; }
 
         /// <summary>
+        /// Gets or sets the public origin for IdentityServer (e.g. "https://yourserver:1234").
+        /// </summary>
+        /// <value>
+        /// The name of the public origin.
+        /// </value>
+        public string PublicOrigin { get; set; }
+
+        /// <summary>
         /// Gets or sets the unique name of this server instance, e.g. https://myissuer.com
         /// </summary>
         /// <value>

--- a/src/IdentityServer4/Hosting/BaseUrlMiddleware.cs
+++ b/src/IdentityServer4/Hosting/BaseUrlMiddleware.cs
@@ -3,6 +3,7 @@
 
 using IdentityServer4.Core.Extensions;
 using Microsoft.AspNetCore.Http;
+using System;
 using System.Threading.Tasks;
 
 namespace IdentityServer4.Core.Hosting
@@ -19,6 +20,14 @@ namespace IdentityServer4.Core.Hosting
         public async Task Invoke(HttpContext context, IdentityServerContext idsrvContext)
         {
             var request = context.Request;
+
+            if (!string.IsNullOrEmpty(idsrvContext.Options.PublicOrigin))
+            {
+                var origin = new Uri(idsrvContext.Options.PublicOrigin);
+
+                request.Scheme = origin.Scheme;
+                request.Host = new HostString(origin.Authority);
+            }
 
             var host = request.Scheme + "://" + request.Host.Value;
             idsrvContext.SetHost(host);


### PR DESCRIPTION
Added PublicOrigin back to IdentityServerOptions and modified the BaseUrlMiddleware to set the request context host to use this if present. This enables proper origin domains when sitting behind a proxy.