### PR TITLE
Bug Fix

### DIFF
--- a/src/IdentityServer4/Models/Contexts/ProfileDataRequestContext.cs
+++ b/src/IdentityServer4/Models/Contexts/ProfileDataRequestContext.cs
@@ -81,7 +81,7 @@ namespace IdentityServer4.Models
             Client = client;
             Caller = caller;
 
-            if (requestedClaimTypes == null)
+            if (requestedClaimTypes == null || !requestedClaimTypes.Any())
             {
                 AllClaimsRequested = true;
             }


### PR DESCRIPTION
requestedClaimTypes was being passed in non-null as an empty collection. This was causing RequestedClaimTypes to be set which ultimately ended in a missing 'sub' claim error message in the browser.