### PR TITLE
Support for public clients

### DIFF
--- a/src/IdentityServer4/Constants.cs
+++ b/src/IdentityServer4/Constants.cs
@@ -249,6 +249,7 @@ namespace IdentityServer4
 
         public static class ParsedSecretTypes
         {
+            public const string NoSecret = "NoSecret";
             public const string SharedSecret = "SharedSecret";
             public const string X509Certificate = "X509Certificate";
         }

--- a/src/IdentityServer4/Models/Client.cs
+++ b/src/IdentityServer4/Models/Client.cs
@@ -32,6 +32,11 @@ namespace IdentityServer4.Models
         public List<Secret> ClientSecrets { get; set; } = new List<Secret>();
 
         /// <summary>
+        /// If set to true, no client secret is needed to request tokens at the token endpoint
+        /// </summary>
+        public bool PublicClient { get; set; } = false;
+
+        /// <summary>
         /// Client display name (used for logging and consent screen)
         /// </summary>
         public string ClientName { get; set; }

--- a/src/IdentityServer4/Validation/BasicAuthenticationSecretParser.cs
+++ b/src/IdentityServer4/Validation/BasicAuthenticationSecretParser.cs
@@ -26,10 +26,10 @@ namespace IdentityServer4.Validation
         /// Creates the parser with a reference to identity server options
         /// </summary>
         /// <param name="options">IdentityServer options</param>
-        public BasicAuthenticationSecretParser(IdentityServerOptions options, ILoggerFactory loggerFactory)
+        public BasicAuthenticationSecretParser(IdentityServerOptions options, ILogger<BasicAuthenticationSecretParser> logger)
         {
             _options = options;
-            _logger = loggerFactory.CreateLogger<BasicAuthenticationSecretParser>();
+            _logger = logger;
         }
 
         public string AuthenticationMethod

--- a/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
@@ -10,6 +10,7 @@ using Xunit;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Http;
+using UnitTests.Common;
 
 namespace IdentityServer4.Tests.Validation.Secrets
 {
@@ -22,7 +23,7 @@ namespace IdentityServer4.Tests.Validation.Secrets
         public BasicAuthenticationSecretParsing()
         {
             _options = new IdentityServerOptions();
-            _parser = new BasicAuthenticationSecretParser(_options, new LoggerFactory());
+            _parser = new BasicAuthenticationSecretParser(_options, TestLogger.Create<BasicAuthenticationSecretParser>());
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Validation/Secrets/ClientSecretValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/ClientSecretValidation.cs
@@ -1,0 +1,73 @@
+﻿using FluentAssertions;
+using IdentityServer4.Tests.Validation;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Validation.Secrets
+{
+    public class ClientSecretValidation
+    {
+        const string Category = "Secrets - Client Secret Validator";
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task confidential_client_with_correct_secret_should_be_able_to_request_token()
+        {
+            var validator = Factory.CreateClientSecretValidator();
+
+            var context = new DefaultHttpContext();
+            var body = "client_id=roclient&client_secret=secret";
+
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+            context.Request.ContentType = "application/x-www-form-urlencoded";
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsError.Should().BeFalse();
+            result.Client.ClientId.Should().Be("roclient");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task confidential_client_with_incorrect_secret_should_not_be_able_to_request_token()
+        {
+            var validator = Factory.CreateClientSecretValidator();
+
+            var context = new DefaultHttpContext();
+            var body = "client_id=roclient&client_secret=invalid";
+
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+            context.Request.ContentType = "application/x-www-form-urlencoded";
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsError.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task public_client_without_secret_should_be_able_to_request_token()
+        {
+            var validator = Factory.CreateClientSecretValidator();
+
+            var context = new DefaultHttpContext();
+            var body = "client_id=roclient.public";
+
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+            context.Request.ContentType = "application/x-www-form-urlencoded";
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsError.Should().BeFalse();
+            result.Client.ClientId.Should().Be("roclient.public");
+            result.Client.PublicClient.Should().BeTrue();
+        }
+
+    }
+}

--- a/test/IdentityServer.UnitTests/Validation/Secrets/FormPostCredentialParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/FormPostCredentialParsing.cs
@@ -25,7 +25,7 @@ namespace IdentityServer4.Tests.Validation.Secrets
         }
 
         [Fact]
-        public async void EmptyOwinEnvironment()
+        public async void EmptyContext()
         {
             var context = new DefaultHttpContext();
             context.Request.Body = new MemoryStream();
@@ -111,7 +111,8 @@ namespace IdentityServer4.Tests.Validation.Secrets
 
             var secret = await _parser.ParseAsync(context);
 
-            secret.Should().BeNull();
+            secret.Should().NotBeNull();
+            secret.Type.Should().Be(Constants.ParsedSecretTypes.NoSecret);
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -182,5 +182,35 @@ namespace IdentityServer4.Tests.Validation
 
             return validator;
         }
+
+        public static ClientSecretValidator CreateClientSecretValidator(IClientStore clients = null, SecretParser parser = null, SecretValidator validator = null)
+        {
+            var options = TestIdentityServerOptions.Create();
+            if (clients == null) clients = new InMemoryClientStore(TestClients.Get());
+
+            if (parser == null)
+            {
+                var parsers = new List<ISecretParser>
+                {
+                    new BasicAuthenticationSecretParser(options, TestLogger.Create<BasicAuthenticationSecretParser>()),
+                    new PostBodySecretParser(options, TestLogger.Create<PostBodySecretParser>())
+                };
+
+                parser = new SecretParser(parsers, TestLogger.Create<SecretParser>());
+            }
+
+            if (validator == null)
+            {
+                var validators = new List<ISecretValidator>
+                {
+                    new HashedSharedSecretValidator(TestLogger.Create<HashedSharedSecretValidator>()),
+                    new PlainTextSharedSecretValidator(TestLogger.Create<PlainTextSharedSecretValidator>())
+                };
+
+                validator = new SecretValidator(validators, TestLogger.Create<SecretValidator>());
+            }
+
+            return new ClientSecretValidator(clients, parser, validator, new TestEventService(), TestLogger.Create<ClientSecretValidator>());
+        }
     }
 }

--- a/test/IdentityServer.UnitTests/Validation/Setup/TestClients.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/TestClients.cs
@@ -201,6 +201,16 @@ namespace IdentityServer4.Tests.Validation
                     },
                     new Client
                     {
+                        ClientName = "Resource Owner Client - Public",
+                        Enabled = true,
+                        ClientId = "roclient.public",
+                        PublicClient = true,
+                        
+                        AllowedGrantTypes = GrantTypes.ResourceOwnerPassword,
+                        AllowAccessToAllScopes = true,
+                    },
+                    new Client
+                    {
                         ClientName = "Resource Owner Client",
                         Enabled = true,
                         ClientId = "roclient_absolute_refresh_expiration_one_time_only",


### PR DESCRIPTION
Public clients don't need a client secret to request tokens from the token endpoint