### PR TITLE
Ref links fix

### DIFF
--- a/docs/start/clients.rst
+++ b/docs/start/clients.rst
@@ -77,7 +77,7 @@ This client uses the so called implicit flow to request an identity and access t
         },
     };
 
-.. _start_clients_mvc:
+.. _start-clients-mvc:
 Defining a server-side web application (e.g. MVC) for use authentication and delegated API access
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Interactive server side (or native desktop/mobile) applications use the hybrid flow.

--- a/docs/start/clients.rst
+++ b/docs/start/clients.rst
@@ -77,7 +77,7 @@ This client uses the so called implicit flow to request an identity and access t
         },
     };
 
-.. _start-clients-mvc:
+.. _startClientsMVC:
 
 Defining a server-side web application (e.g. MVC) for use authentication and delegated API access
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/start/clients.rst
+++ b/docs/start/clients.rst
@@ -78,6 +78,7 @@ This client uses the so called implicit flow to request an identity and access t
     };
 
 .. _start-clients-mvc:
+
 Defining a server-side web application (e.g. MVC) for use authentication and delegated API access
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Interactive server side (or native desktop/mobile) applications use the hybrid flow.

--- a/docs/start/mvc.rst
+++ b/docs/start/mvc.rst
@@ -3,7 +3,7 @@ Connecting an MVC Application
 
 You can integrate identityserver into your MVC application to authenticate users and request access token.
 
-An MVC application typically uses the hybrid flow - use :ref:`this <start_clients_mvc>` sample
+An MVC application typically uses the hybrid flow - use :ref:`this <_start_clients_mvc>` sample
 to register the client.
 
 In your MVC application startup, you can use the standard Microsoft ASP.NET OpenID Connect middleware to connect to identityserver::

--- a/docs/start/mvc.rst
+++ b/docs/start/mvc.rst
@@ -3,7 +3,7 @@ Connecting an MVC Application
 
 You can integrate identityserver into your MVC application to authenticate users and request access token.
 
-An MVC application typically uses the hybrid flow - use :ref:`this <_start_clients_mvc>` sample
+An MVC application typically uses the hybrid flow - use :ref:`this <start-clients-mvc>` sample
 to register the client.
 
 In your MVC application startup, you can use the standard Microsoft ASP.NET OpenID Connect middleware to connect to identityserver::

--- a/docs/start/mvc.rst
+++ b/docs/start/mvc.rst
@@ -3,7 +3,7 @@ Connecting an MVC Application
 
 You can integrate identityserver into your MVC application to authenticate users and request access token.
 
-An MVC application typically uses the hybrid flow - use :ref:`this <start-clients-mvc>` sample
+An MVC application typically uses the hybrid flow - use :ref:`this <startClientsMVC>` sample
 to register the client.
 
 In your MVC application startup, you can use the standard Microsoft ASP.NET OpenID Connect middleware to connect to identityserver::


### PR DESCRIPTION
I think this fixes #182 and #185.  See my build of the docs here, with the references working:

http://netchrisidentityserver4.readthedocs.io/en/dev/start/mvc.html

I had to remove both the internal underscores _and_ the dashes.  Those didn't seem to work either.  I ended up making the reference name "startClientsMVC" instead of "start-clients-mvc" (as suggested in [the docs](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-targets)).

(HT to @mpoettgen on the "underscores are bad" idea)

Sorry for the multiple commits here.  This is the nature of the beast when you need to change/commit/build to see how the docs come out on the other end.