### PR TITLE
Making scope parameter optional at the token endpoint 

### DIFF
--- a/src/IdentityServer4/Extensions/StringsExtensions.cs
+++ b/src/IdentityServer4/Extensions/StringsExtensions.cs
@@ -19,6 +19,11 @@ namespace IdentityServer4.Extensions
         [DebuggerStepThrough]
         public static string ToSpaceSeparatedString(this IEnumerable<string> list)
         {
+            if (list == null)
+            {
+                return "";
+            }
+
             var sb = new StringBuilder(100);
 
             foreach (var element in list)

--- a/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
@@ -30,6 +30,17 @@ namespace IdentityServer4.IntegrationTests.Clients
                         "api1", "api2"
                     }
                 },
+                new Client
+                {
+                    ClientId = "client.no_default_scopes",
+                    ClientSecrets = new List<Secret>
+                    {
+                        new Secret("secret".Sha256())
+                    },
+
+                    AllowedGrantTypes = GrantTypes.ClientCredentials,
+                    AllowAccessToAllScopes = true
+                },
 
                 ///////////////////////////////////////////
                 // Console Resource Owner Flow Sample

--- a/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_Valid.cs
+++ b/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_Valid.cs
@@ -108,6 +108,23 @@ namespace IdentityServer4.UnitTests.Validation.TokenRequest
 
         [Fact]
         [Trait("Category", Category)]
+        public async Task Valid_ClientCredentials_Request_with_default_Scopes()
+        {
+            var client = await _clients.FindClientByIdAsync("client_restricted");
+
+            var validator = Factory.CreateTokenRequestValidator();
+
+            var parameters = new NameValueCollection();
+            parameters.Add(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.ClientCredentials);
+            
+
+            var result = await validator.ValidateRequestAsync(parameters, client);
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
         public async Task Valid_ClientCredentials_Request_for_Implicit_and_ClientCredentials_Client()
         {
             var client = await _clients.FindClientByIdAsync("implicit_and_client_creds_client");


### PR DESCRIPTION
(for client credentials, password and extension grants)

* if allowed scopes is configured, client can omit scope parameter
* if only `AllowAccessToAllScopes` is configured, client must specify scopes explicitly