### PR TITLE
More Quickstart refactor

### DIFF
--- a/src/Host/Configuration/Clients.cs
+++ b/src/Host/Configuration/Clients.cs
@@ -1,4 +1,7 @@
-﻿using IdentityServer4.Models;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityServer4.Models;
 using System.Collections.Generic;
 
 namespace Host.Configuration

--- a/src/Host/Configuration/Scopes.cs
+++ b/src/Host/Configuration/Scopes.cs
@@ -1,4 +1,7 @@
-﻿using IdentityServer4.Models;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityServer4.Models;
 using System.Collections.Generic;
 
 namespace Host.Configuration

--- a/src/Host/Configuration/Users.cs
+++ b/src/Host/Configuration/Users.cs
@@ -1,4 +1,7 @@
-﻿using IdentityModel;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityModel;
 using IdentityServer4;
 using IdentityServer4.Quickstart;
 using System.Collections.Generic;

--- a/src/Host/Controllers/AccountController.cs
+++ b/src/Host/Controllers/AccountController.cs
@@ -1,8 +1,5 @@
-﻿using Host.Models;
-using Host.Services;
-using IdentityModel;
-using IdentityServer4;
-using IdentityServer4.Quickstart;
+﻿using IdentityModel;
+using IdentityServer4.Quickstart.UI.Models;
 using IdentityServer4.Services;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.Mvc;
@@ -13,7 +10,7 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 
-namespace Host.Controllers
+namespace IdentityServer4.Quickstart.UI.Controllers
 {
     public class AccountController : Controller
     {

--- a/src/Host/Controllers/AccountController.cs
+++ b/src/Host/Controllers/AccountController.cs
@@ -1,4 +1,7 @@
-﻿using IdentityModel;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityModel;
 using IdentityServer4.Quickstart.UI.Models;
 using IdentityServer4.Services;
 using Microsoft.AspNetCore.Http.Authentication;

--- a/src/Host/Controllers/ConsentController.cs
+++ b/src/Host/Controllers/ConsentController.cs
@@ -5,9 +5,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using IdentityServer4.Models;
 using IdentityServer4.Stores;
-using Host.Models;
+using IdentityServer4.Quickstart.UI.Models;
 
-namespace Host.Controllers
+namespace IdentityServer4.Quickstart.UI.Controllers
 {
     public class ConsentController : Controller
     {

--- a/src/Host/Controllers/ConsentController.cs
+++ b/src/Host/Controllers/ConsentController.cs
@@ -1,4 +1,7 @@
-﻿using IdentityServer4.Services;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityServer4.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Linq;

--- a/src/Host/Controllers/HomeController.cs
+++ b/src/Host/Controllers/HomeController.cs
@@ -1,9 +1,9 @@
-﻿using Host.Models;
+﻿using IdentityServer4.Quickstart.UI.Models;
 using IdentityServer4.Services;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 
-namespace Host.Controllers
+namespace IdentityServer4.Quickstart.UI.Controllers
 {
     public class HomeController : Controller
     {

--- a/src/Host/Controllers/HomeController.cs
+++ b/src/Host/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
-﻿using IdentityServer4.Quickstart.UI.Models;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityServer4.Quickstart.UI.Models;
 using IdentityServer4.Services;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;

--- a/src/Host/Models/ConsentInputModel.cs
+++ b/src/Host/Models/ConsentInputModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Host.Models
+namespace IdentityServer4.Quickstart.UI.Models
 {
     public class ConsentInputModel
     {

--- a/src/Host/Models/ConsentInputModel.cs
+++ b/src/Host/Models/ConsentInputModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
 
 namespace IdentityServer4.Quickstart.UI.Models
 {

--- a/src/Host/Models/ConsentViewModel.cs
+++ b/src/Host/Models/ConsentViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
 using System.Linq;
 using IdentityServer4.Models;
 

--- a/src/Host/Models/ConsentViewModel.cs
+++ b/src/Host/Models/ConsentViewModel.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using IdentityServer4.Models;
 
-namespace Host.Models
+namespace IdentityServer4.Quickstart.UI.Models
 {
     public class ConsentViewModel : ConsentInputModel
     {

--- a/src/Host/Models/ErrorViewModel.cs
+++ b/src/Host/Models/ErrorViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using IdentityServer4.Models;
 
-namespace Host.Models
+namespace IdentityServer4.Quickstart.UI.Models
 {
     public class ErrorViewModel
     {

--- a/src/Host/Models/ErrorViewModel.cs
+++ b/src/Host/Models/ErrorViewModel.cs
@@ -1,4 +1,7 @@
-﻿using IdentityServer4.Models;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityServer4.Models;
 
 namespace IdentityServer4.Quickstart.UI.Models
 {

--- a/src/Host/Models/LoggedOutViewModel.cs
+++ b/src/Host/Models/LoggedOutViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Host.Models
+﻿namespace IdentityServer4.Quickstart.UI.Models
 {
     public class LoggedOutViewModel
     {

--- a/src/Host/Models/LoggedOutViewModel.cs
+++ b/src/Host/Models/LoggedOutViewModel.cs
@@ -1,4 +1,7 @@
-﻿namespace IdentityServer4.Quickstart.UI.Models
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace IdentityServer4.Quickstart.UI.Models
 {
     public class LoggedOutViewModel
     {

--- a/src/Host/Models/LoginInputModel.cs
+++ b/src/Host/Models/LoginInputModel.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
 
 namespace IdentityServer4.Quickstart.UI.Models
 {

--- a/src/Host/Models/LoginInputModel.cs
+++ b/src/Host/Models/LoginInputModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Host.Models
+namespace IdentityServer4.Quickstart.UI.Models
 {
     public class LoginInputModel
     {

--- a/src/Host/Models/LoginViewModel.cs
+++ b/src/Host/Models/LoginViewModel.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Linq;
 
-namespace Host.Models
+namespace IdentityServer4.Quickstart.UI.Models
 {
     public class LoginViewModel : LoginInputModel
     {

--- a/src/Host/Models/LoginViewModel.cs
+++ b/src/Host/Models/LoginViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using System.Linq;
 

--- a/src/Host/Models/LogoutViewModel.cs
+++ b/src/Host/Models/LogoutViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Host.Models
+﻿namespace IdentityServer4.Quickstart.UI.Models
 {
     public class LogoutViewModel
     {

--- a/src/Host/Models/LogoutViewModel.cs
+++ b/src/Host/Models/LogoutViewModel.cs
@@ -1,4 +1,7 @@
-﻿namespace IdentityServer4.Quickstart.UI.Models
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace IdentityServer4.Quickstart.UI.Models
 {
     public class LogoutViewModel
     {

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using System;
 

--- a/src/Host/Startup.cs
+++ b/src/Host/Startup.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using System.Linq;
-using IdentityServer4.Quickstart;
-using Host.Services;
 
 namespace Host
 {
@@ -50,15 +48,11 @@ namespace Host
                 options.AuthenticationOptions.FederatedSignOutPaths.Add("/signout-oidc");
             })
             .AddInMemoryClients(Clients.Get())
-            .AddInMemoryScopes(Scopes.Get());
-
-            // UI service for in-memory users
-            services.AddSingleton(new InMemoryUserLoginService(Users.Get()));
-            builder.AddResourceOwnerValidator<InMemoryUserResourceOwnerPasswordValidator>();
-
+            .AddInMemoryScopes(Scopes.Get())
+            .AddInMemoryUsers(Users.Get());
+            
             builder.AddExtensionGrantValidator<Extensions.ExtensionGrantValidator>();
 
-            // for the UI
             services.AddMvc();
         }
 

--- a/src/Host/Startup.cs
+++ b/src/Host/Startup.cs
@@ -1,4 +1,7 @@
-﻿using Host.Configuration;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Host.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Host/Views/Account/LoggedOut.cshtml
+++ b/src/Host/Views/Account/LoggedOut.cshtml
@@ -1,4 +1,4 @@
-﻿@model Host.Models.LoggedOutViewModel
+﻿@model IdentityServer4.Quickstart.UI.Models.LoggedOutViewModel
 
 <div class="page-header">
     <h1>

--- a/src/Host/Views/Account/Login.cshtml
+++ b/src/Host/Views/Account/Login.cshtml
@@ -1,4 +1,4 @@
-﻿@model Host.Models.LoginViewModel
+﻿@model IdentityServer4.Quickstart.UI.Models.LoginViewModel
 
 <div class="login-page">
     <div class="page-header">

--- a/src/Host/Views/Account/Logout.cshtml
+++ b/src/Host/Views/Account/Logout.cshtml
@@ -1,4 +1,4 @@
-﻿@model Host.Models.LogoutViewModel
+﻿@model IdentityServer4.Quickstart.UI.Models.LogoutViewModel
 
 <div class="logout-page">
     <div class="page-header">

--- a/src/Host/Views/Consent/Index.cshtml
+++ b/src/Host/Views/Consent/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model Host.Models.ConsentViewModel
+﻿@model IdentityServer4.Quickstart.UI.Models.ConsentViewModel
 
 <div class="page-consent">
     <div class="row page-header">

--- a/src/Host/Views/Consent/_ScopeListItem.cshtml
+++ b/src/Host/Views/Consent/_ScopeListItem.cshtml
@@ -1,4 +1,4 @@
-﻿@model Host.Models.ScopeViewModel
+﻿@model IdentityServer4.Quickstart.UI.Models.ScopeViewModel
 
 <li class="list-group-item">
     <label>

--- a/src/Host/Views/Home/Index.cshtml
+++ b/src/Host/Views/Home/Index.cshtml
@@ -1,5 +1,4 @@
-﻿
-<div class="welcome-page">
+﻿<div class="welcome-page">
     <div class="row page-header">
         <div class="col-sm-10">
             <h1>

--- a/src/Host/Views/Shared/Error.cshtml
+++ b/src/Host/Views/Shared/Error.cshtml
@@ -1,4 +1,4 @@
-﻿@model Host.Models.ErrorViewModel
+﻿@model IdentityServer4.Quickstart.UI.Models.ErrorViewModel
 
 @{
     var error = Model?.Error?.Error;

--- a/src/IdentityServer4/Events/EventServiceHelper.cs
+++ b/src/IdentityServer4/Events/EventServiceHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
 using System.Diagnostics;
 using IdentityModel;
 using Microsoft.AspNetCore.Http;

--- a/src/IdentityServer4/Quickstart/QuickstartIdentityServerBuilderExtensions.cs
+++ b/src/IdentityServer4/Quickstart/QuickstartIdentityServerBuilderExtensions.cs
@@ -31,12 +31,13 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
-        public static IIdentityServerBuilder AddInMemoryUsers(this IIdentityServerBuilder builder, IEnumerable<InMemoryUser> users)
+        public static IIdentityServerBuilder AddInMemoryUsers(this IIdentityServerBuilder builder, List<InMemoryUser> users)
         {
             builder.Services.AddSingleton(users);
 
             builder.Services.AddTransient<IProfileService, InMemoryUserProfileService>();
             builder.Services.AddTransient<IResourceOwnerPasswordValidator, InMemoryUserResourceOwnerPasswordValidator>();
+            builder.Services.AddTransient<InMemoryUserLoginService>();
 
             return builder;
         }

--- a/src/IdentityServer4/Quickstart/Services/InMemoryLoginService.cs
+++ b/src/IdentityServer4/Quickstart/Services/InMemoryLoginService.cs
@@ -4,9 +4,8 @@ using System;
 using System.Security.Claims;
 using System.IdentityModel.Tokens.Jwt;
 using IdentityModel;
-using IdentityServer4.Quickstart;
 
-namespace Host.Services
+namespace IdentityServer4.Quickstart
 {
     public class InMemoryUserLoginService
     {

--- a/src/IdentityServer4/Quickstart/Services/InMemoryUserProfileService.cs
+++ b/src/IdentityServer4/Quickstart/Services/InMemoryUserProfileService.cs
@@ -24,7 +24,7 @@ namespace IdentityServer4.Quickstart
         /// Initializes a new instance of the <see cref="InMemoryUserService"/> class.
         /// </summary>
         /// <param name="users">The users.</param>
-        public InMemoryUserProfileService(IEnumerable<InMemoryUser> users)
+        public InMemoryUserProfileService(List<InMemoryUser> users)
         {
             _users = users;
         }

--- a/src/IdentityServer4/Quickstart/Services/InMemoryUserResourceOwnerPasswordValidator.cs
+++ b/src/IdentityServer4/Quickstart/Services/InMemoryUserResourceOwnerPasswordValidator.cs
@@ -12,7 +12,7 @@ namespace IdentityServer4.Quickstart
     {
         private readonly IEnumerable<InMemoryUser> _users;
 
-        public InMemoryUserResourceOwnerPasswordValidator(IEnumerable<InMemoryUser> users)
+        public InMemoryUserResourceOwnerPasswordValidator(List<InMemoryUser> users)
         {
             _users = users;
         }


### PR DESCRIPTION
* put the UI into the `IdentityServer4.Quickstart.UI` namespace
* move the `InMemoryUserLoginService` to the `QuickStart.Services` folder
* `AddInMemoryUser` wires up the in-mem user, in-mem resource owner validator and the in-mem login service

This allows adding the QS UI without having to change the DI (if `AddInMemoryUsers` is called).