### PR TITLE
Move semicolon to fix syntax error

### DIFF
--- a/docs/start/clients.rst
+++ b/docs/start/clients.rst
@@ -37,8 +37,8 @@ In this scenario no interactive user is present - a service (aka client) wants t
                     {
                         "api1", "api2"
                     }
-                };
-            }
+                }
+            };
         }
     }
 


### PR DESCRIPTION
The code in the example for "Defining a client for server to server communication" did not compile.