### PR TITLE
use client config on login page (enable local; allowed providers)

### DIFF
--- a/src/Host/Models/LoginViewModel.cs
+++ b/src/Host/Models/LoginViewModel.cs
@@ -3,32 +3,12 @@
 
 
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Http;
-using System.Linq;
 
 namespace IdentityServer4.Quickstart.UI.Models
 {
     public class LoginViewModel : LoginInputModel
     {
-        public LoginViewModel(HttpContext httpContext)
-        {
-            ExternalProviders = httpContext.Authentication.GetAuthenticationSchemes()
-                .Where(x => x.DisplayName != null)
-                .Select(x => new ExternalProvider {
-                    DisplayName = x.DisplayName,
-                    AuthenticationScheme = x.AuthenticationScheme
-                });
-        }
-
-        public LoginViewModel(HttpContext httpContext, LoginInputModel other)
-            : this(httpContext)
-        {
-            Username = other.Username;
-            Password = other.Password;
-            ReturnUrl = other.ReturnUrl;
-        }
-
-        public string ErrorMessage { get; set; }
+        public bool EnableLocalLogin { get; set; }
         public IEnumerable<ExternalProvider> ExternalProviders { get; set; }
     }
 

--- a/src/Host/Views/Account/Login.cshtml
+++ b/src/Host/Views/Account/Login.cshtml
@@ -8,35 +8,39 @@
     @Html.Partial("_ValidationSummary")
 
     <div class="row">
-        <div class="col-sm-6">
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h3 class="panel-title">Local Login</h3>
-                </div>
-                <div class="panel-body">
 
-                    <form asp-route="Login">
-                        <input type="hidden" asp-for="ReturnUrl" />
+        @if (Model.EnableLocalLogin)
+        {
+            <div class="col-sm-6">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Local Login</h3>
+                    </div>
+                    <div class="panel-body">
 
-                        <fieldset>
-                            <div class="form-group">
-                                <label asp-for="Username"></label>
-                                <input class="form-control" placeholder="Username" asp-for="Username" autofocus>
-                            </div>
-                            <div class="form-group">
-                                <label asp-for="Password"></label>
-                                <input type="password" class="form-control" placeholder="Password" asp-for="Password" autocomplete="off">
-                            </div>
-                            <div class="form-group">
-                                <button class="btn btn-primary">Login</button>
-                            </div>
-                        </fieldset>
-                    </form>
+                        <form asp-route="Login">
+                            <input type="hidden" asp-for="ReturnUrl" />
+
+                            <fieldset>
+                                <div class="form-group">
+                                    <label asp-for="Username"></label>
+                                    <input class="form-control" placeholder="Username" asp-for="Username" autofocus>
+                                </div>
+                                <div class="form-group">
+                                    <label asp-for="Password"></label>
+                                    <input type="password" class="form-control" placeholder="Password" asp-for="Password" autocomplete="off">
+                                </div>
+                                <div class="form-group">
+                                    <button class="btn btn-primary">Login</button>
+                                </div>
+                            </fieldset>
+                        </form>
+                    </div>
                 </div>
             </div>
-        </div>
+        }
 
-        @if (Model.ExternalProviders != null && Model.ExternalProviders.Any())
+        @if (Model.ExternalProviders.Any())
         {
             <div class="col-md-6 col-sm-6 external-providers">
                 <div class="panel panel-default">
@@ -59,6 +63,14 @@
                         </ul>
                     </div>
                 </div>
+            </div>
+        }
+
+        @if (!Model.EnableLocalLogin && !Model.ExternalProviders.Any())
+        {
+            <div class="alert alert-warning">
+                <strong>Invalid login request</strong>
+                There are no login schemes configured for this client.
             </div>
         }
     </div>


### PR DESCRIPTION
Incorporate client settings on login page for enable local logins, and external provider restriction list. This required re-working how the login view model is constructed.

Fixes #318

// @leastprivilege 