### PR TITLE
Fixed the Configure method contents

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -130,6 +130,7 @@ It must be added **before** MVC, e.g.::
         loggerFactory.AddConsole(Configuration.GetSection("Logging"));
         loggerFactory.AddDebug();
 
+        app.UseIdentityServer();
         app.UseIdentityServerAuthentication(new IdentityServerAuthenticationOptions
         {
             Authority = "http://localhost:5000",


### PR DESCRIPTION
Fixed the documentation quick start example - previously there was no call to `app.UseIdentityServer` which is necessary to make the example actually work (`.well-known` discovery endpoint)