### PR TITLE
AuthenticationScheme and SignInScheme is case sensitive

### DIFF
--- a/docs/configuration/mvc.rst
+++ b/docs/configuration/mvc.rst
@@ -18,14 +18,14 @@ In your MVC application startup, you can use the standard Microsoft ASP.NET Open
 
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
-                AuthenticationScheme = "cookies",
+                AuthenticationScheme = "Cookies",
                 AutomaticAuthenticate = true,
             });
 
             var oidcOptions = new OpenIdConnectOptions
             {
                 AuthenticationScheme = "oidc",
-                SignInScheme = "cookies",
+                SignInScheme = "Cookies",
 
                 Authority = "https://demo.identityserver.io",
                 ClientId = "mvc",


### PR DESCRIPTION
I might be "holding it wrong", but I can't get this to work properly unless spelling `Cookies` with a capital `C`.