### PR TITLE
Fixed Claims property on InMemoryUser initializer

### DIFF
--- a/docs/quickstarts/3_interactive_login.rst
+++ b/docs/quickstarts/3_interactive_login.rst
@@ -202,7 +202,7 @@ Let's add these claims to the user, so IdentityServer can put them into the iden
                 Username = "alice",
                 Password = "password",
 
-                Claims = 
+                Claims = new []
                 {
                     new Claim("name", "Alice"),
                     new Claim("website", "https://alice.com")
@@ -214,7 +214,7 @@ Let's add these claims to the user, so IdentityServer can put them into the iden
                 Username = "bob",
                 Password = "password",
 
-                Claims = 
+                Claims = new []
                 {
                     new Claim("name", "Bob"),
                     new Claim("website", "https://bob.com")


### PR DESCRIPTION
At least in an ASP.NET Core app, the code as presented doesn't compile.  Added `new []` to ensure that the `InMemoryUser.Claims` property is a valid `IEnumerable<Claim>`.