### PR TITLE
Removed exception from XML doc

### DIFF
--- a/src/IdentityServer4/Stores/InMemory/InMemoryScopeStore.cs
+++ b/src/IdentityServer4/Stores/InMemory/InMemoryScopeStore.cs
@@ -49,7 +49,6 @@ namespace IdentityServer4.Stores.InMemory
         /// </summary>
         /// <param name="publicOnly">if set to <c>true</c> only public scopes are returned.</param>
         /// <returns></returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         public Task<IEnumerable<Scope>> GetScopesAsync(bool publicOnly = true)
         {
             if (publicOnly)


### PR DESCRIPTION
The method doesn't actually throw System.NotImplementedException.  I think this might be something either GhostDoc or Exceptional (ReSharper plug-in) added when the method was originally stubbed out.