### PR TITLE
Add VSCode workspace to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,6 @@ docs/_build/
 tools/Cake/
 tools/packages.config.md5sum
 .idea
+
+# Visual Studio Code workspace options
+.vscode


### PR DESCRIPTION
This is a trivial commit that just makes sure VSCode
workspace options files are not included into repo

Thanks!