### PR TITLE
DefaultSessionIdService.GetCookieName is now configurable

### DIFF
--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -27,6 +27,11 @@ namespace IdentityServer4.Configuration
         /// </value>
         public string IssuerUri { get; set; }
 
+        /// <summary>
+        /// The name of the session cookie used by this server instance
+        /// </summary>
+        public string SessionCookieName { get; set; } = Constants.DefaultSessionCookieName;
+
         // todo
         /// <summary>
         /// Gets or sets a value indicating whether SSL is required for IdentityServer. Defaults to `true`.

--- a/src/IdentityServer4/Constants.cs
+++ b/src/IdentityServer4/Constants.cs
@@ -18,6 +18,7 @@ namespace IdentityServer4
         public const string ExternalAuthenticationMethod     = "external";
         public const string AccessTokenAudience              = "{0}resources";
         public const string DefaultHashAlgorithm             = "SHA256";
+        public const string DefaultSessionCookieName         = "idsvr.session";
 
         public static readonly TimeSpan DefaultCookieTimeSpan = TimeSpan.FromHours(10);
         public static readonly TimeSpan DefaultCacheDuration  = TimeSpan.FromMinutes(5);

--- a/src/IdentityServer4/Services/Default/DefaultSessionIdService.cs
+++ b/src/IdentityServer4/Services/Default/DefaultSessionIdService.cs
@@ -5,6 +5,7 @@
 using IdentityModel;
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
+using IdentityServer4.Configuration;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using IdentityServer4.Extensions;
 
@@ -12,10 +13,12 @@ namespace IdentityServer4.Services.Default
 {
     public class DefaultSessionIdService : ISessionIdService
     {
+        private readonly IdentityServerOptions _identityServerOptions;
         private readonly HttpContext _context;
 
-        public DefaultSessionIdService(IHttpContextAccessor context)
+        public DefaultSessionIdService(IHttpContextAccessor context, IdentityServerOptions identityServerOptions)
         {
+            _identityServerOptions = identityServerOptions;
             _context = context.HttpContext;
         }
 
@@ -59,8 +62,7 @@ namespace IdentityServer4.Services.Default
 
         public string GetCookieName()
         {
-            // TODO: fix from config?
-            return "idsvr.session";
+            return _identityServerOptions.SessionCookieName;
         }
 
         public string GetCookieValue()

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultSessionIdServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultSessionIdServiceTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using IdentityServer4.Configuration;
 using Xunit;
 
 namespace IdentityServer4.UnitTests.Services.Default
@@ -29,7 +30,7 @@ namespace IdentityServer4.UnitTests.Services.Default
             _stubAuthHandler = new StubAuthenticationHandler(null, _scheme);
             _mockHttpContext.HttpContext.GetAuthentication().Handler = _stubAuthHandler;
 
-            _subject = new DefaultSessionIdService(_mockHttpContext);
+            _subject = new DefaultSessionIdService(_mockHttpContext, new IdentityServerOptions());
         }
 
         [Fact]


### PR DESCRIPTION
from IdentityServerOptions, the default is "idsvr.session" to not break existing configurations