### PR TITLE
add clarity on AddInMemoryUsers method

### DIFF
--- a/docs/quickstarts/8_entity_framework.rst
+++ b/docs/quickstarts/8_entity_framework.rst
@@ -61,6 +61,8 @@ We will replace them with this code::
                   options.MigrationsAssembly(migrationsAssembly)));
   }
 
+If you followed the other quickstarts, you will notice the ``AddInMemoryUsers`` method. If you have not created this in the `Config.cs` Class, have a look at the quickstart [EntityFrameworkStorage Quickstarts](https://github.com/IdentityServer/IdentityServer4.Samples/blob/dev/Quickstarts/8_EntityFrameworkStorage/src/QuickstartIdentityServer/Config.cs)  after line 100.
+
 The above code is hard-coding a connection string, which you should feel free to change if you wish.
 Also, the calls to ``AddConfigurationStore`` and ``AddOperationalStore`` are registering the EF-backed store implementations.
 


### PR DESCRIPTION
the flow of the tutorials and quickstarts, do not explain the in memory usage of inmemoryuser. however the method is clearly defined in the actual quickstart for EF.
referecing the method and location in the quickstart.
open to complete rewrite, but the method was not discussed earlier or in the aspnetcore identity quickstart.

<!---
@huboard:{"milestone_order":63.01575126003149}
-->
