### PR TITLE
Fixes #487 - Name of the session cookie is derived from EffeciveAuthenticationScheme

### DIFF
--- a/src/IdentityServer4/Services/Default/DefaultSessionIdService.cs
+++ b/src/IdentityServer4/Services/Default/DefaultSessionIdService.cs
@@ -5,7 +5,9 @@
 using IdentityModel;
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
+using IdentityServer4.Configuration;
 using Microsoft.AspNetCore.Http.Features.Authentication;
+using Microsoft.Extensions.DependencyInjection;
 using IdentityServer4.Extensions;
 
 namespace IdentityServer4.Services.Default
@@ -60,7 +62,8 @@ namespace IdentityServer4.Services.Default
         public string GetCookieName()
         {
             // TODO: fix from config?
-            return "idsvr.session";
+            var options = _context.RequestServices.GetRequiredService<IdentityServerOptions>();
+            return $"{options.AuthenticationOptions.EffectiveAuthenticationScheme}.session";
         }
 
         public string GetCookieValue()

--- a/test/IdentityServer.IntegrationTests/Common/MockIdSvrUiPipeline.cs
+++ b/test/IdentityServer.IntegrationTests/Common/MockIdSvrUiPipeline.cs
@@ -214,11 +214,11 @@ namespace IdentityServer4.IntegrationTests.Common
         }
         public void RemoveSessionCookie()
         {
-            BrowserClient.RemoveCookie("https://server/", "idsvr.session");
+            BrowserClient.RemoveCookie("https://server/", $"{Options.AuthenticationOptions.EffectiveAuthenticationScheme}.session");
         }
         public Cookie GetSessionCookie()
         {
-            return BrowserClient.GetCookie("https://server/", "idsvr.session");
+            return BrowserClient.GetCookie("https://server/", $"{Options.AuthenticationOptions.EffectiveAuthenticationScheme}.session");
         }
 
         public string CreateAuthorizeUrl(


### PR DESCRIPTION
Deriving name of the session cookie from `EffectiveAuthenitcationScheme` makes it configurable. 

I have run all the unit tests locally and they pass. I do not know how to run integration tests locally. Appreciate if someone can help with that.