### PR TITLE
Update ProcessSignoutCallbackAsync

### DIFF
--- a/src/IdentityServer4/Endpoints/EndSessionEndpoint.cs
+++ b/src/IdentityServer4/Endpoints/EndSessionEndpoint.cs
@@ -84,7 +84,7 @@ namespace IdentityServer4.Endpoints
                 return new StatusCodeResult(HttpStatusCode.MethodNotAllowed);
             }
 
-            _logger.LogDebug("Processing singout callback request");
+            _logger.LogDebug("Processing signout callback request");
 
             var parameters = context.Request.Query.AsNameValueCollection();
             var result = await _endSessionRequestValidator.ValidateCallbackAsync(parameters);


### PR DESCRIPTION
Fix spelling of signout in debug log from EndSessionEndpoint.ProcessSignoutCallbackAsync.