### PR TITLE
Correct use of IHttpContextAccessor

### DIFF
--- a/src/IdentityServer4/Hosting/AuthenticationHandler.cs
+++ b/src/IdentityServer4/Hosting/AuthenticationHandler.cs
@@ -17,7 +17,7 @@ namespace IdentityServer4.Hosting
     public class AuthenticationHandler : IAuthenticationHandler
     {
         private readonly IdentityServerOptions _options;
-        private readonly HttpContext _context;
+        private readonly IHttpContextAccessor _context;
         private IAuthenticationHandler _handler;
         private readonly ISessionIdService _sessionId;
         private readonly ILogger<AuthenticationHandler> _logger;
@@ -30,7 +30,7 @@ namespace IdentityServer4.Hosting
             IEventService events,
             ILogger<AuthenticationHandler> logger)
         {
-            _context = context.HttpContext;
+            _context = context;
             _options = options;
             _sessionId = sessionId;
             _events = events;
@@ -99,11 +99,11 @@ namespace IdentityServer4.Hosting
 
         IHttpAuthenticationFeature GetAuthentication()
         {
-            var auth = _context.Features.Get<IHttpAuthenticationFeature>();
+            var auth = _context.HttpContext.Features.Get<IHttpAuthenticationFeature>();
             if (auth == null)
             {
                 auth = new HttpAuthenticationFeature();
-                _context.Features.Set(auth);
+                _context.HttpContext.Features.Set(auth);
             }
             return auth;
         }
@@ -115,7 +115,7 @@ namespace IdentityServer4.Hosting
 
         private async Task RaiseSignOutEventAsync()
         {
-            var principal = await _context.GetIdentityServerUserAsync();
+            var principal = await _context.HttpContext.GetIdentityServerUserAsync();
             if (principal.IsAuthenticated())
             {
                 await _events.RaiseLogoutEventAsync(principal);


### PR DESCRIPTION
Hello,

We faced an issue with signing out with AzureAd. Causing the following exception in the `HttpContextExtensions.cs` in the `GetIdentityServerUserInfoAsync` method.
We also changed the `AuthenticationHandler` to match the rest of the code base. And we believe this is the correct way to use the `IHttpContextAccessor`  

```
An unhandled exception has occurred: Value cannot be null. 
Parameter name: provider System.ArgumentNullException: Value cannot be null.
```

For debugging purposes we added this and noticed that the following objects were not equal. 

```cs  
private readonly HttpContext _context;
private readonly IdentityServerOptions _options;
private readonly IHttpContextAccessor _accessor;

public DefaultSessionIdService(IHttpContextAccessor context, IdentityServerOptions options)
{
    _accessor = context;
    _context = context.HttpContext;
    _options = options;
}

public async Task<string> GetCurrentSessionIdAsync()
{
    var c1 = _accessor.HttpContext;
    var c2 = _context;
    var equal = Equals(c1, c2);

    var info = await _context.GetIdentityServerUserInfoAsync();
    if (info.Properties.Items.ContainsKey(OidcConstants.EndSessionRequest.Sid))
    {
        var sid = info.Properties.Items[OidcConstants.EndSessionRequest.Sid];
        return sid;
    }
    return null;
}
```

Most of the credits go to @henkmollema