### PR TITLE
Fixed authorization endpoint typo in docs

### DIFF
--- a/docs/endpoints/authorize.rst
+++ b/docs/endpoints/authorize.rst
@@ -75,7 +75,7 @@ IdentityModel
 ^^^^^^^^^^^^^
 You can programmatically create URLs for the authorize endpoint using the `IdentityModel <https://github.com/IdentityModel/IdentityModel2>`_ library::
 
-    var request = new AuthorizeRequest(doc.AuthorizationEndpoint);
+    var request = new AuthorizeRequest(doc.AuthorizeEndpoint);
     var url = request.CreateAuthorizeUrl(
         clientId:     "client",
         responseType: OidcConstants.ResponseTypes.CodeIdToken,


### PR DESCRIPTION
Currently using IdentityModel v2.1.1 and noticed the documentation didn't match the current code. Updated the docs to reflect the change.

http://docs.identityserver.io/en/release/endpoints/authorize.html#identitymodel

