### PR TITLE
Always invoke profile service in DefaultClaimsService

### DIFF
--- a/src/IdentityServer4/Models/Contexts/ProfileDataRequestContext.cs
+++ b/src/IdentityServer4/Models/Contexts/ProfileDataRequestContext.cs
@@ -29,8 +29,6 @@ namespace IdentityServer4.Models
         /// <param name="requestedClaimTypes">The requested claim types.</param>
         public ProfileDataRequestContext(ClaimsPrincipal subject, Client client, string caller, IEnumerable<string> requestedClaimTypes)
         {
-            if (requestedClaimTypes.IsNullOrEmpty()) throw new ArgumentException("No claim types requested", nameof(requestedClaimTypes));
-
             Subject = subject;
             Client = client;
             Caller = caller;

--- a/src/IdentityServer4/Services/DefaultClaimsService.cs
+++ b/src/IdentityServer4/Services/DefaultClaimsService.cs
@@ -71,21 +71,18 @@ namespace IdentityServer4.Services
                     }
                 }
 
-                if (additionalClaims.Count > 0)
-                {
-                    var context = new ProfileDataRequestContext(
+                var context = new ProfileDataRequestContext(
                         subject,
                         client,
                         IdentityServerConstants.ProfileDataCallers.ClaimsProviderIdentityToken,
                         additionalClaims);
 
-                    await Profile.GetProfileDataAsync(context);
+                await Profile.GetProfileDataAsync(context);
 
-                    var claims = FilterProtocolClaims(context.IssuedClaims);
-                    if (claims != null)
-                    {
-                        outputClaims.AddRange(claims);
-                    }
+                var claims = FilterProtocolClaims(context.IssuedClaims);
+                if (claims != null)
+                {
+                    outputClaims.AddRange(claims);
                 }
             }
 
@@ -180,21 +177,18 @@ namespace IdentityServer4.Services
                     }
                 }
 
-                if (additionalClaims.Count > 0)
-                {
-                    var context = new ProfileDataRequestContext(
+                var context = new ProfileDataRequestContext(
                         subject,
                         client,
                         IdentityServerConstants.ProfileDataCallers.ClaimsProviderAccessToken,
                         additionalClaims.Distinct());
 
-                    await Profile.GetProfileDataAsync(context);
+                await Profile.GetProfileDataAsync(context);
 
-                    var claims = FilterProtocolClaims(context.IssuedClaims);
-                    if (claims != null)
-                    {
-                        outputClaims.AddRange(claims);
-                    }
+                var claims = FilterProtocolClaims(context.IssuedClaims);
+                if (claims != null)
+                {
+                    outputClaims.AddRange(claims);
                 }
             }
 


### PR DESCRIPTION
- Users can now control which claims are added to id_token and access_token, regardless of scope claims configured

Closes #683