### PR TITLE
Update 2_resource_owner_passwords.rst

### DIFF
--- a/docs/quickstarts/2_resource_owner_passwords.rst
+++ b/docs/quickstarts/2_resource_owner_passwords.rst
@@ -111,7 +111,7 @@ Again IdentityModel's ``TokenClient`` can help out here::
 
 When you send the token to the identity API endpoint, you will notice one small
 but important difference compared to the client credentials grant. The access token will
-now contain a ``sub`` claim which uniquely identifies the user. "How will I notice this and what should I see"
+now contain a ``sub`` claim which uniquely identifies the user. This "sub" claim can be seen by examining the content variable after the call to the API and also will be displayed on the screen by the console application. 
 
 The presence (or absence) of the ``sub`` claim let's the API distinguish between calls on behalf
 of clients and calls on behalf of users.

--- a/docs/quickstarts/2_resource_owner_passwords.rst
+++ b/docs/quickstarts/2_resource_owner_passwords.rst
@@ -111,7 +111,7 @@ Again IdentityModel's ``TokenClient`` can help out here::
 
 When you send the token to the identity API endpoint, you will notice one small
 but important difference compared to the client credentials grant. The access token will
-now contain a ``sub`` claim which uniquely identifies the user.
+now contain a ``sub`` claim which uniquely identifies the user. "How will I notice this and what should I see"
 
 The presence (or absence) of the ``sub`` claim let's the API distinguish between calls on behalf
 of clients and calls on behalf of users.


### PR DESCRIPTION
In the following text from this documentation:
"When you send the token to the identity API endpoint, you will notice one small
but important difference compared to the client credentials grant. The access token will
now contain a ``sub`` claim which uniquely identifies the user.

The presence (or absence) of the ``sub`` claim let's the API distinguish between calls on behalf
of clients and calls on behalf of users."
The statements are unclear as to how to identify the "sub" claim. It would help to tell the reader how the "sub" claim can be seen and verified. I see that the access token returned for the ResourceOwnerPassword request now has more characters in the returned access token for the ClientCredential request. Are the extra characters in the access token the "sub" claim described. I am not sure about where the "sub" claim is.