### PR TITLE
Improve grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is the main repo for IdentityServer4 - but there's more:
 
 ### Platform
 
-IdentityServer is built against ASP.NET Core 1.1.0 using the 1.0.0-preview2-003131 SDK. This is the only configuration we gonna support on the issue tracker.
+IdentityServer is built against ASP.NET Core 1.1.0 using the 1.0.0-preview2-003131 SDK. This is the only configuration we are going to support on the issue tracker.
 
 ### How to build
 


### PR DESCRIPTION
This colloquial abbreviation is folksy and should not appear in serious writing. Additionally, without the word "are" before "gonna" the grammar is also incorrect.