### PR TITLE
Minor edit to Quickstart docs, code block formatting

### DIFF
--- a/docs/quickstarts/2_resource_owner_passwords.rst
+++ b/docs/quickstarts/2_resource_owner_passwords.rst
@@ -20,8 +20,10 @@ Just like there are in-memory stores for resources (aka scopes) and clients, the
 
 The class ``TestUser`` represents a test user and its claims. Let's create a couple of users
 by adding the following code to our config class:
-First add the following using statement to the config.cs file: 
-using IdentityServer4.Test;
+
+First add the following using statement to the config.cs file::
+
+    using IdentityServer4.Test;
 
     public static List<TestUser> GetUsers()
     {


### PR DESCRIPTION
The markdown for the GetUsers() code block was a little awry with the code not appearing in a code block.

This change rectifies the issue.