### PR TITLE
Validate scoped services

### DIFF
--- a/src/IdentityServer4/Configuration/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/IdentityServer4/Configuration/IdentityServerApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@
 using IdentityServer4.Hosting;
 using IdentityServer4.Stores;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 
 namespace Microsoft.AspNetCore.Builder
@@ -27,25 +28,28 @@ namespace Microsoft.AspNetCore.Builder
 
         internal static void Validate(this IApplicationBuilder app)
         {
+            var scopeFactory = app.ApplicationServices.GetService<IServiceScopeFactory>();
+            var serviceProvider = scopeFactory.CreateScope().ServiceProvider;
+
             var loggerFactory = app.ApplicationServices.GetService(typeof(ILoggerFactory)) as ILoggerFactory;
             if (loggerFactory == null) throw new ArgumentNullException(nameof(loggerFactory));
 
             var logger = loggerFactory.CreateLogger("IdentityServer4.Startup");
 
-            app.TestService(typeof(IPersistedGrantStore), logger, "No storage mechanism for grants specified. Use the 'AddInMemoryPersistedGrants' extension method to register a development version.");
-            app.TestService(typeof(IClientStore), logger, "No storage mechanism for clients specified. Use the 'AddInMemoryClients' extension method to register a development version.");
-            app.TestService(typeof(IResourceStore), logger, "No storage mechanism for resources specified. Use the 'AddInMemoryResources' extension method to register a development version.");
+            TestService(serviceProvider, typeof(IPersistedGrantStore), logger, "No storage mechanism for grants specified. Use the 'AddInMemoryPersistedGrants' extension method to register a development version.");
+            TestService(serviceProvider, typeof(IClientStore), logger, "No storage mechanism for clients specified. Use the 'AddInMemoryClients' extension method to register a development version.");
+            TestService(serviceProvider, typeof(IResourceStore), logger, "No storage mechanism for resources specified. Use the 'AddInMemoryResources' extension method to register a development version.");
 
-            var persistedGrants = app.ApplicationServices.GetService(typeof(IPersistedGrantStore));
+            var persistedGrants = serviceProvider.GetService(typeof(IPersistedGrantStore));
             if (persistedGrants.GetType().FullName == typeof(InMemoryPersistedGrantStore).FullName)
             {
                 logger.LogInformation("You are using the in-memory version of the persisted grant store. This will store consent decisions, authorization codes, refresh and reference tokens in memory only. If you are using any of those features in production, you want to switch to a different store implementation.");
             }
         }
 
-        internal static object TestService(this IApplicationBuilder app, Type service, ILogger logger, string message = null, bool doThrow = true)
+        internal static object TestService(IServiceProvider serviceProvider, Type service, ILogger logger, string message = null, bool doThrow = true)
         {
-            var appService = app.ApplicationServices.GetService(service);
+            var appService = serviceProvider.GetService(service);
 
             if (appService == null)
             {

--- a/src/IdentityServer4/Configuration/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/IdentityServer4/Configuration/IdentityServerApplicationBuilderExtensions.cs
@@ -28,22 +28,26 @@ namespace Microsoft.AspNetCore.Builder
 
         internal static void Validate(this IApplicationBuilder app)
         {
-            var scopeFactory = app.ApplicationServices.GetService<IServiceScopeFactory>();
-            var serviceProvider = scopeFactory.CreateScope().ServiceProvider;
-
             var loggerFactory = app.ApplicationServices.GetService(typeof(ILoggerFactory)) as ILoggerFactory;
             if (loggerFactory == null) throw new ArgumentNullException(nameof(loggerFactory));
 
             var logger = loggerFactory.CreateLogger("IdentityServer4.Startup");
 
-            TestService(serviceProvider, typeof(IPersistedGrantStore), logger, "No storage mechanism for grants specified. Use the 'AddInMemoryPersistedGrants' extension method to register a development version.");
-            TestService(serviceProvider, typeof(IClientStore), logger, "No storage mechanism for clients specified. Use the 'AddInMemoryClients' extension method to register a development version.");
-            TestService(serviceProvider, typeof(IResourceStore), logger, "No storage mechanism for resources specified. Use the 'AddInMemoryResources' extension method to register a development version.");
+            var scopeFactory = app.ApplicationServices.GetService<IServiceScopeFactory>();
 
-            var persistedGrants = serviceProvider.GetService(typeof(IPersistedGrantStore));
-            if (persistedGrants.GetType().FullName == typeof(InMemoryPersistedGrantStore).FullName)
+            using (var scope = scopeFactory.CreateScope())
             {
-                logger.LogInformation("You are using the in-memory version of the persisted grant store. This will store consent decisions, authorization codes, refresh and reference tokens in memory only. If you are using any of those features in production, you want to switch to a different store implementation.");
+                var serviceProvider = scope.ServiceProvider;
+
+                TestService(serviceProvider, typeof(IPersistedGrantStore), logger, "No storage mechanism for grants specified. Use the 'AddInMemoryPersistedGrants' extension method to register a development version.");
+                TestService(serviceProvider, typeof(IClientStore), logger, "No storage mechanism for clients specified. Use the 'AddInMemoryClients' extension method to register a development version.");
+                TestService(serviceProvider, typeof(IResourceStore), logger, "No storage mechanism for resources specified. Use the 'AddInMemoryResources' extension method to register a development version.");
+
+                var persistedGrants = serviceProvider.GetService(typeof(IPersistedGrantStore));
+                if (persistedGrants.GetType().FullName == typeof(InMemoryPersistedGrantStore).FullName)
+                {
+                    logger.LogInformation("You are using the in-memory version of the persisted grant store. This will store consent decisions, authorization codes, refresh and reference tokens in memory only. If you are using any of those features in production, you want to switch to a different store implementation.");
+                }
             }
         }
 


### PR DESCRIPTION
Hi,

So in ASP.NET Core 1.1 it is possible to do the following:
```
public IServiceProvider ConfigureServices(IServiceCollection services)
{
    return services.BuildServiceProvider(validateScopes: true);
}
```
Setting this parameter to true will validate the correct lifetime of the dependencies.
This gave a few errors in `TestService()` in combination with the IdentityServer4.EF package. 
The services are being resolved from the root ServiceProvider which means they will be Singleton.

Kinda related: 
https://github.com/IdentityServer/IdentityServer4.EntityFramework/pull/57 
