### PR TITLE
Add more flexibility to token request pipeline [WIP]

### DIFF
--- a/src/IdentityServer4/Validation/Models/TokenRequestOverrides.cs
+++ b/src/IdentityServer4/Validation/Models/TokenRequestOverrides.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using IdentityModel;
+using IdentityServer4.Models;
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace IdentityServer4.Validation
+{
+    /// <summary>
+    /// Allows setting per-request configuration overrides for token requests 
+    /// (e.g. from a custom token request validator or an extension/password grant validator
+    /// </summary>
+    public class TokenRequestOverrides
+    {
+        public AccessTokenType? TokenType { get; set; } = null;
+        public int? TokenLifetime { get; set; } = null;
+
+        public ICollection<Claim> ClientClaims { get; set; } = new HashSet<Claim>(new ClaimComparer());
+        public ICollection<string> Scopes { get; set; } = new HashSet<string>();
+    }
+}

--- a/src/IdentityServer4/Validation/Models/ValidatedTokenRequest.cs
+++ b/src/IdentityServer4/Validation/Models/ValidatedTokenRequest.cs
@@ -83,5 +83,13 @@ namespace IdentityServer4.Validation
         /// The code verifier.
         /// </value>
         public string CodeVerifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets the per-request configuration overrides.
+        /// </summary>
+        /// <value>
+        /// The overrides.
+        /// </value>
+        public TokenRequestOverrides Overrides { get; set; } = new TokenRequestOverrides();
     }
 }


### PR DESCRIPTION
see #629

Sometimes it would be useful to be able to change certain parameters on the fly during a token request (e.g. from a custom validator or an extension grant), e.g.

* scopes
* token lifetime
* token type
* client claims