### PR TITLE
Make certain access token creation parameters dynamic

### DIFF
--- a/src/IdentityServer4/Models/TokenCreationRequest.cs
+++ b/src/IdentityServer4/Models/TokenCreationRequest.cs
@@ -22,14 +22,6 @@ namespace IdentityServer4.Models
         public ClaimsPrincipal Subject { get; set; }
 
         /// <summary>
-        /// Gets or sets the client.
-        /// </summary>
-        /// <value>
-        /// The client.
-        /// </value>
-        public Client Client { get; set; }
-
-        /// <summary>
         /// Gets or sets the resources.
         /// </summary>
         /// <value>
@@ -79,7 +71,7 @@ namespace IdentityServer4.Models
 
         internal void Validate()
         {
-            if (Client == null) LogAndStop("client");
+            //if (Client == null) LogAndStop("client");
             if (Resources == null) LogAndStop("resources");
             if (ValidatedRequest == null) LogAndStop("validatedRequest");
         }

--- a/src/IdentityServer4/ResponseHandling/AuthorizeResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/AuthorizeResponseGenerator.cs
@@ -118,7 +118,6 @@ namespace IdentityServer4.ResponseHandling
                 var tokenRequest = new TokenCreationRequest
                 {
                     Subject = request.Subject,
-                    Client = request.Client,
                     Resources = request.ValidatedScopes.GrantedResources,
 
                     ValidatedRequest = request
@@ -137,7 +136,6 @@ namespace IdentityServer4.ResponseHandling
                 {
                     ValidatedRequest = request,
                     Subject = request.Subject,
-                    Client = request.Client,
                     Resources = request.ValidatedScopes.GrantedResources,
 
                     Nonce = request.Raw.Get(OidcConstants.AuthorizeRequest.Nonce),

--- a/src/IdentityServer4/ResponseHandling/TokenResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/TokenResponseGenerator.cs
@@ -92,7 +92,6 @@ namespace IdentityServer4.ResponseHandling
                 var tokenRequest = new TokenCreationRequest
                 {
                     Subject = request.AuthorizationCode.Subject,
-                    Client = client,
                     Resources = resources,
                     Nonce = request.AuthorizationCode.Nonce,
                     AccessTokenToHash = response.AccessToken,
@@ -140,7 +139,6 @@ namespace IdentityServer4.ResponseHandling
 
                 var creationRequest = new TokenCreationRequest
                 {
-                    Client = request.Client,
                     Subject = subject,
                     ValidatedRequest = request,
                     Resources = await _resources.FindEnabledResourcesByScopeAsync(oldAccessToken.Scopes),
@@ -194,7 +192,6 @@ namespace IdentityServer4.ResponseHandling
                 tokenRequest = new TokenCreationRequest
                 {
                     Subject = request.AuthorizationCode.Subject,
-                    Client = client,
                     Resources = resources,
                     ValidatedRequest = request
                 };
@@ -206,7 +203,6 @@ namespace IdentityServer4.ResponseHandling
                 tokenRequest = new TokenCreationRequest
                 {
                     Subject = request.Subject,
-                    Client = request.Client,
                     Resources = request.ValidatedScopes.GrantedResources,
                     ValidatedRequest = request
                 };
@@ -233,7 +229,6 @@ namespace IdentityServer4.ResponseHandling
                 var tokenRequest = new TokenCreationRequest
                 {
                     Subject = request.RefreshToken.Subject,
-                    Client = request.Client,
                     Resources = await _resources.FindEnabledResourcesByScopeAsync(oldAccessToken.Scopes),
                     ValidatedRequest = request,
                     AccessTokenToHash = newAccessToken

--- a/src/IdentityServer4/ResponseHandling/TokenResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/TokenResponseGenerator.cs
@@ -60,7 +60,7 @@ namespace IdentityServer4.ResponseHandling
             var response = new TokenResponse
             {
                 AccessToken = tokens.AccessTokens,
-                AccessTokenLifetime = request.Client.AccessTokenLifetime
+                AccessTokenLifetime = request.AccessTokenLifetime
             };
 
             //////////////////////////
@@ -150,7 +150,7 @@ namespace IdentityServer4.ResponseHandling
             else
             {
                 oldAccessToken.CreationTime = IdentityServerDateTime.UtcNow;
-                oldAccessToken.Lifetime = request.Client.AccessTokenLifetime;
+                oldAccessToken.Lifetime = request.AccessTokenLifetime;
 
                 accessTokenString = await _tokenService.CreateSecurityTokenAsync(oldAccessToken);
             }
@@ -161,7 +161,7 @@ namespace IdentityServer4.ResponseHandling
             {
                 IdentityToken = await CreateIdTokenFromRefreshTokenRequestAsync(request, accessTokenString),
                 AccessToken = accessTokenString,
-                AccessTokenLifetime = request.Client.AccessTokenLifetime,
+                AccessTokenLifetime = request.AccessTokenLifetime,
                 RefreshToken = handle
             };
         }

--- a/src/IdentityServer4/ResponseHandling/TokenResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/TokenResponseGenerator.cs
@@ -114,7 +114,7 @@ namespace IdentityServer4.ResponseHandling
             var response = new TokenResponse
             {
                 AccessToken = tokens.AccessTokens,
-                AccessTokenLifetime = validationResult.ValidatedRequest.Client.AccessTokenLifetime,
+                AccessTokenLifetime = validationResult.ValidatedRequest.AccessTokenLifetime,
                 Custom = validationResult.CustomResponse
             };
 

--- a/src/IdentityServer4/Services/DefaultClaimsService.cs
+++ b/src/IdentityServer4/Services/DefaultClaimsService.cs
@@ -53,13 +53,15 @@ namespace IdentityServer4.Services
         /// </returns>
         public virtual async Task<IEnumerable<Claim>> GetIdentityTokenClaimsAsync(ClaimsPrincipal subject, Client client, Resources resources, bool includeAllIdentityClaims, ValidatedRequest request)
         {
-            _logger.LogDebug("Getting claims for identity token for subject: {subject} and client: {clientId}", subject.GetSubjectId(), client.ClientId);
+            _logger.LogDebug("Getting claims for identity token for subject: {subject} and client: {clientId}",
+                subject.GetSubjectId(),
+                request.Client.ClientId);
 
             var outputClaims = new List<Claim>(GetStandardSubjectClaims(subject));
             outputClaims.AddRange(GetOptionalClaims(subject));
 
             // fetch all identity claims that need to go into the id token
-            if (includeAllIdentityClaims || client.AlwaysIncludeUserClaimsInIdToken)
+            if (includeAllIdentityClaims || request.Client.AlwaysIncludeUserClaimsInIdToken)
             {
                 var additionalClaimTypes = new List<string>();
 
@@ -76,7 +78,7 @@ namespace IdentityServer4.Services
 
                 var context = new ProfileDataRequestContext(
                     subject,
-                    client,
+                    request.Client,
                     IdentityServerConstants.ProfileDataCallers.ClaimsProviderIdentityToken,
                     additionalClaimTypes);
 
@@ -108,24 +110,24 @@ namespace IdentityServer4.Services
         /// </returns>
         public virtual async Task<IEnumerable<Claim>> GetAccessTokenClaimsAsync(ClaimsPrincipal subject, Client client, Resources resources, ValidatedRequest request)
         {
-            _logger.LogDebug("Getting claims for access token for client: {clientId}", client.ClientId);
+            _logger.LogDebug("Getting claims for access token for client: {clientId}", request.Client.ClientId);
 
             // add client_id
             var outputClaims = new List<Claim>
             {
-                new Claim(JwtClaimTypes.ClientId, client.ClientId),
+                new Claim(JwtClaimTypes.ClientId, request.Client.ClientId),
             };
 
             // check for client claims
-            if (client.Claims != null && client.Claims.Any())
+            if (request.ClientClaims != null && request.ClientClaims.Any())
             {
-                if (subject == null || client.AlwaysSendClientClaims)
+                if (subject == null || request.Client.AlwaysSendClientClaims)
                 {
-                    foreach (var claim in client.Claims)
+                    foreach (var claim in request.ClientClaims)
                     {
                         var claimType = claim.Type;
 
-                        if (client.PrefixClientClaims)
+                        if (request.Client.PrefixClientClaims)
                         {
                             claimType = "client_" + claimType;
                         }
@@ -189,7 +191,7 @@ namespace IdentityServer4.Services
 
                 var context = new ProfileDataRequestContext(
                     subject,
-                    client,
+                    request.Client,
                     IdentityServerConstants.ProfileDataCallers.ClaimsProviderAccessToken,
                     additionalClaimTypes.Distinct());
 

--- a/src/IdentityServer4/Services/DefaultClaimsService.cs
+++ b/src/IdentityServer4/Services/DefaultClaimsService.cs
@@ -53,6 +53,9 @@ namespace IdentityServer4.Services
         /// </returns>
         public virtual async Task<IEnumerable<Claim>> GetIdentityTokenClaimsAsync(ClaimsPrincipal subject, Client client, Resources resources, bool includeAllIdentityClaims, ValidatedRequest request)
         {
+            // client parameter should not be used anymore - will be removed in later version
+            client = null;
+
             _logger.LogDebug("Getting claims for identity token for subject: {subject} and client: {clientId}",
                 subject.GetSubjectId(),
                 request.Client.ClientId);
@@ -110,6 +113,9 @@ namespace IdentityServer4.Services
         /// </returns>
         public virtual async Task<IEnumerable<Claim>> GetAccessTokenClaimsAsync(ClaimsPrincipal subject, Client client, Resources resources, ValidatedRequest request)
         {
+            // client parameter should not be used anymore - will be removed in later version
+            client = null;
+
             _logger.LogDebug("Getting claims for access token for client: {clientId}", request.Client.ClientId);
 
             // add client_id

--- a/src/IdentityServer4/Services/DefaultTokenService.cs
+++ b/src/IdentityServer4/Services/DefaultTokenService.cs
@@ -131,7 +131,7 @@ namespace IdentityServer4.Services
                 Lifetime = request.ValidatedRequest.Client.IdentityTokenLifetime,
                 Claims = claims.Distinct(new ClaimComparer()).ToList(),
                 ClientId = request.ValidatedRequest.Client.ClientId,
-                AccessTokenType = request.ValidatedRequest.Client.AccessTokenType
+                AccessTokenType = request.ValidatedRequest.AccessTokenType
             };
 
             return token;

--- a/src/IdentityServer4/Services/DefaultTokenService.cs
+++ b/src/IdentityServer4/Services/DefaultTokenService.cs
@@ -117,7 +117,7 @@ namespace IdentityServer4.Services
 
             claims.AddRange(await ClaimsProvider.GetIdentityTokenClaimsAsync(
                 request.Subject,
-                request.Client,
+                request.ValidatedRequest.Client,
                 request.Resources,
                 request.IncludeAllIdentityClaims,
                 request.ValidatedRequest));
@@ -126,12 +126,12 @@ namespace IdentityServer4.Services
 
             var token = new Token(OidcConstants.TokenTypes.IdentityToken)
             {
-                Audiences = { request.Client.ClientId },
+                Audiences = { request.ValidatedRequest.Client.ClientId },
                 Issuer = issuer,
-                Lifetime = request.Client.IdentityTokenLifetime,
+                Lifetime = request.ValidatedRequest.Client.IdentityTokenLifetime,
                 Claims = claims.Distinct(new ClaimComparer()).ToList(),
-                ClientId = request.Client.ClientId,
-                AccessTokenType = request.Client.AccessTokenType
+                ClientId = request.ValidatedRequest.Client.ClientId,
+                AccessTokenType = request.ValidatedRequest.Client.AccessTokenType
             };
 
             return token;
@@ -152,11 +152,11 @@ namespace IdentityServer4.Services
             var claims = new List<Claim>();
             claims.AddRange(await ClaimsProvider.GetAccessTokenClaimsAsync(
                 request.Subject,
-                request.Client,
+                request.ValidatedRequest.Client,
                 request.Resources,
                 request.ValidatedRequest));
 
-            if (request.Client.IncludeJwtId)
+            if (request.ValidatedRequest.Client.IncludeJwtId)
             {
                 claims.Add(new Claim(JwtClaimTypes.JwtId, CryptoRandom.CreateUniqueId(16)));
             }
@@ -166,10 +166,10 @@ namespace IdentityServer4.Services
             {
                 Audiences = { string.Format(Constants.AccessTokenAudience, issuer.EnsureTrailingSlash()) },
                 Issuer = issuer,
-                Lifetime = request.Client.AccessTokenLifetime,
-                Claims = claims.Distinct(new ClaimComparer()).ToList(),
-                ClientId = request.Client.ClientId,
-                AccessTokenType = request.Client.AccessTokenType
+                Lifetime = request.ValidatedRequest.AccessTokenLifetime,
+                Claims = request.ValidatedRequest.ClientClaims,
+                ClientId = request.ValidatedRequest.Client.ClientId,
+                AccessTokenType = request.ValidatedRequest.AccessTokenType
             };
 
             foreach(var api in request.Resources.ApiResources)

--- a/src/IdentityServer4/Services/DefaultTokenService.cs
+++ b/src/IdentityServer4/Services/DefaultTokenService.cs
@@ -167,7 +167,7 @@ namespace IdentityServer4.Services
                 Audiences = { string.Format(Constants.AccessTokenAudience, issuer.EnsureTrailingSlash()) },
                 Issuer = issuer,
                 Lifetime = request.ValidatedRequest.AccessTokenLifetime,
-                Claims = request.ValidatedRequest.ClientClaims,
+                Claims = claims,
                 ClientId = request.ValidatedRequest.Client.ClientId,
                 AccessTokenType = request.ValidatedRequest.AccessTokenType
             };

--- a/src/IdentityServer4/Validation/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer4/Validation/AuthorizeRequestValidator.cs
@@ -157,6 +157,9 @@ namespace IdentityServer4.Validation
             }
 
             request.Client = client;
+            request.AccessTokenLifetime = client.AccessTokenLifetime;
+            request.AccessTokenType = client.AccessTokenType;
+            request.ClientClaims = client.Claims.Select(c => new Claim(c.Type, c.Value)).ToList();
 
             //////////////////////////////////////////////////////////
             // check if client protocol type is oidc

--- a/src/IdentityServer4/Validation/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer4/Validation/AuthorizeRequestValidator.cs
@@ -156,10 +156,7 @@ namespace IdentityServer4.Validation
                 return Invalid(request, OidcConstants.AuthorizeErrors.UnauthorizedClient);
             }
 
-            request.Client = client;
-            request.AccessTokenLifetime = client.AccessTokenLifetime;
-            request.AccessTokenType = client.AccessTokenType;
-            request.ClientClaims = client.Claims.Select(c => new Claim(c.Type, c.Value)).ToList();
+            request.SetClient(client);
 
             //////////////////////////////////////////////////////////
             // check if client protocol type is oidc

--- a/src/IdentityServer4/Validation/Models/ValidatedAuthorizeRequest.cs
+++ b/src/IdentityServer4/Validation/Models/ValidatedAuthorizeRequest.cs
@@ -38,14 +38,6 @@ namespace IdentityServer4.Validation
         public string GrantType { get; set; }
 
         /// <summary>
-        /// Gets or sets the client.
-        /// </summary>
-        /// <value>
-        /// The client.
-        /// </value>
-        public Client Client { get; set; }
-
-        /// <summary>
         /// Gets or sets the redirect URI.
         /// </summary>
         /// <value>

--- a/src/IdentityServer4/Validation/Models/ValidatedEndSessionRequest.cs
+++ b/src/IdentityServer4/Validation/Models/ValidatedEndSessionRequest.cs
@@ -20,14 +20,6 @@ namespace IdentityServer4.Validation
         public bool IsAuthenticated => Client != null;
 
         /// <summary>
-        /// Gets or sets the client.
-        /// </summary>
-        /// <value>
-        /// The client.
-        /// </value>
-        public Client Client { get; set; }
-
-        /// <summary>
         /// Gets or sets the post-logout URI.
         /// </summary>
         /// <value>

--- a/src/IdentityServer4/Validation/Models/ValidatedRequest.cs
+++ b/src/IdentityServer4/Validation/Models/ValidatedRequest.cs
@@ -8,6 +8,7 @@ using IdentityServer4.Models;
 using System.Collections.Specialized;
 using System.Security.Claims;
 using IdentityModel;
+using System.Linq;
 
 namespace IdentityServer4.Validation
 {
@@ -81,5 +82,13 @@ namespace IdentityServer4.Validation
         /// The validated scopes.
         /// </value>
         public ScopeValidator ValidatedScopes { get; set; }
+
+        public void SetClient(Client client)
+        {
+            Client = client;
+            AccessTokenLifetime = client.AccessTokenLifetime;
+            AccessTokenType = client.AccessTokenType;
+            ClientClaims = client.Claims.Select(c => new Claim(c.Type, c.Value)).ToList();
+        }
     }
 }

--- a/src/IdentityServer4/Validation/Models/ValidatedRequest.cs
+++ b/src/IdentityServer4/Validation/Models/ValidatedRequest.cs
@@ -3,6 +3,7 @@
 
 
 using IdentityServer4.Configuration;
+using IdentityServer4.Models;
 using System.Collections.Specialized;
 using System.Security.Claims;
 
@@ -20,6 +21,14 @@ namespace IdentityServer4.Validation
         /// The raw.
         /// </value>
         public NameValueCollection Raw { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client.
+        /// </summary>
+        /// <value>
+        /// The client.
+        /// </value>
+        public Client Client { get; set; }
 
         /// <summary>
         /// Gets or sets the subject.

--- a/src/IdentityServer4/Validation/Models/ValidatedRequest.cs
+++ b/src/IdentityServer4/Validation/Models/ValidatedRequest.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System.Collections.Generic;
 using IdentityServer4.Configuration;
 using IdentityServer4.Models;
 using System.Collections.Specialized;
 using System.Security.Claims;
+using IdentityModel;
 
 namespace IdentityServer4.Validation
 {
@@ -29,6 +31,24 @@ namespace IdentityServer4.Validation
         /// The client.
         /// </value>
         public Client Client { get; set; }
+
+        /// <summary>
+        /// Gets or sets the effective access token lifetime for the current request.
+        /// This value is initally read from the client configuration but can be modified in the request pipeline
+        /// </summary>
+        public int AccessTokenLifetime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client claims for the current request.
+        /// This value is initally read from the client configuration but can be modified in the request pipeline
+        /// </summary>
+        public ICollection<Claim> ClientClaims { get; set; } = new HashSet<Claim>(new ClaimComparer());
+
+        /// <summary>
+        /// Gets or sets the effective access token type for the current request.
+        /// This value is initally read from the client configuration but can be modified in the request pipeline
+        /// </summary>
+        public AccessTokenType AccessTokenType { get; set; }
 
         /// <summary>
         /// Gets or sets the subject.

--- a/src/IdentityServer4/Validation/Models/ValidatedTokenRequest.cs
+++ b/src/IdentityServer4/Validation/Models/ValidatedTokenRequest.cs
@@ -13,14 +13,6 @@ namespace IdentityServer4.Validation
     public class ValidatedTokenRequest : ValidatedRequest
     {
         /// <summary>
-        /// Gets or sets the client.
-        /// </summary>
-        /// <value>
-        /// The client.
-        /// </value>
-        public Client Client { get; set; }
-        
-        /// <summary>
         /// Gets or sets the type of the grant.
         /// </summary>
         /// <value>

--- a/src/IdentityServer4/Validation/TokenRequestValidator.cs
+++ b/src/IdentityServer4/Validation/TokenRequestValidator.cs
@@ -60,12 +60,10 @@ namespace IdentityServer4.Validation
             _validatedRequest = new ValidatedTokenRequest
             {
                 Raw = parameters,
-                Client = client,
-                AccessTokenLifetime = client.AccessTokenLifetime,
-                AccessTokenType =  client.AccessTokenType,
-                ClientClaims = client.Claims.Select(c => new Claim(c.Type, c.Value)).ToList(),
                 Options = _options
             };
+
+            _validatedRequest.SetClient(client);
 
             /////////////////////////////////////////////
             // check client protocol type

--- a/src/IdentityServer4/Validation/TokenRequestValidator.cs
+++ b/src/IdentityServer4/Validation/TokenRequestValidator.cs
@@ -63,7 +63,7 @@ namespace IdentityServer4.Validation
                 Client = client,
                 AccessTokenLifetime = client.AccessTokenLifetime,
                 AccessTokenType =  client.AccessTokenType,
-                ClientClaims = client.Claims.Select(c => new Claim(c.Type, c.Value)).ToList()
+                ClientClaims = client.Claims.Select(c => new Claim(c.Type, c.Value)).ToList(),
                 Options = _options
             };
 

--- a/src/IdentityServer4/Validation/TokenRequestValidator.cs
+++ b/src/IdentityServer4/Validation/TokenRequestValidator.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -60,6 +61,9 @@ namespace IdentityServer4.Validation
             {
                 Raw = parameters,
                 Client = client,
+                AccessTokenLifetime = client.AccessTokenLifetime,
+                AccessTokenType =  client.AccessTokenType,
+                ClientClaims = client.Claims.Select(c => new Claim(c.Type, c.Value)).ToList()
                 Options = _options
             };
 

--- a/test/IdentityServer.IntegrationTests/Clients/ExtensionGrantClient.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/ExtensionGrantClient.cs
@@ -225,6 +225,191 @@ namespace IdentityServer4.IntegrationTests.Clients
             response.Error.Should().Be("unsupported_grant_type");
         }
 
+        [Fact]
+        public async Task Dynamic_Client_Lifetime()
+        {
+            var client = new TokenClient(
+                TokenEndpoint,
+                "client.dynamic",
+                "secret",
+                innerHttpMessageHandler: _handler);
+
+            var customParameters = new Dictionary<string, string>
+                {
+                    { "lifetime", "5000"},
+                    { "sub",  "818727"}
+                };
+
+            var response = await client.RequestCustomGrantAsync("dynamic", "api1", customParameters);
+
+            response.IsError.Should().BeFalse();
+            response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+            response.ExpiresIn.Should().Be(5000);
+            response.TokenType.Should().Be("Bearer");
+            response.IdentityToken.Should().BeNull();
+            response.RefreshToken.Should().BeNull();
+
+            var payload = GetPayload(response);
+
+            payload.Count().Should().Be(10);
+            payload.Should().Contain("iss", "https://idsvr4");
+            payload.Should().Contain("client_id", "client.dynamic");
+            payload.Should().Contain("sub", "818727");
+            payload.Should().Contain("idp", "local");
+
+            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
+            audiences.Count().Should().Be(2);
+            audiences.Should().Contain("https://idsvr4/resources");
+            audiences.Should().Contain("api");
+
+            var scopes = payload["scope"] as JArray;
+            scopes.First().ToString().Should().Be("api1");
+
+            var amr = payload["amr"] as JArray;
+            amr.Count().Should().Be(1);
+            amr.First().ToString().Should().Be("delegation");
+        }
+
+        [Fact]
+        public async Task Dynamic_Client_Jwt()
+        {
+            var client = new TokenClient(
+                TokenEndpoint,
+                "client.dynamic",
+                "secret",
+                innerHttpMessageHandler: _handler);
+
+            var customParameters = new Dictionary<string, string>
+                {
+                    { "sub",  "818727"},
+                    { "type", "jwt" }
+                };
+
+            var response = await client.RequestCustomGrantAsync("dynamic", "api1", customParameters);
+
+            response.IsError.Should().BeFalse();
+            response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+            response.ExpiresIn.Should().Be(3600);
+            response.TokenType.Should().Be("Bearer");
+            response.IdentityToken.Should().BeNull();
+            response.RefreshToken.Should().BeNull();
+
+            response.AccessToken.Should().Contain(".");
+        }
+
+        [Fact]
+        public async Task Dynamic_Client_Reference()
+        {
+            var client = new TokenClient(
+                TokenEndpoint,
+                "client.dynamic",
+                "secret",
+                innerHttpMessageHandler: _handler);
+
+            var customParameters = new Dictionary<string, string>
+                {
+                    { "sub",  "818727"},
+                    { "type", "reference" }
+                };
+
+            var response = await client.RequestCustomGrantAsync("dynamic", "api1", customParameters);
+
+            response.IsError.Should().BeFalse();
+            response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+            response.ExpiresIn.Should().Be(3600);
+            response.TokenType.Should().Be("Bearer");
+            response.IdentityToken.Should().BeNull();
+            response.RefreshToken.Should().BeNull();
+
+            response.AccessToken.Should().NotContain(".");
+        }
+
+        [Fact]
+        public async Task Dynamic_Client_Client_Claims()
+        {
+            var client = new TokenClient(
+                TokenEndpoint,
+                "client.dynamic",
+                "secret",
+                innerHttpMessageHandler: _handler);
+
+            var customParameters = new Dictionary<string, string>
+                {
+                    { "claim", "extra_claim"},
+                    { "sub",  "818727"}
+                };
+
+            var response = await client.RequestCustomGrantAsync("dynamic", "api1", customParameters);
+
+            response.IsError.Should().BeFalse();
+            response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+            response.ExpiresIn.Should().Be(3600);
+            response.TokenType.Should().Be("Bearer");
+            response.IdentityToken.Should().BeNull();
+            response.RefreshToken.Should().BeNull();
+
+            var payload = GetPayload(response);
+
+            payload.Count().Should().Be(11);
+            payload.Should().Contain("iss", "https://idsvr4");
+            payload.Should().Contain("client_id", "client.dynamic");
+            payload.Should().Contain("sub", "818727");
+            payload.Should().Contain("idp", "local");
+
+            payload.Should().Contain("client_extra", "extra_claim");
+
+            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
+            audiences.Count().Should().Be(2);
+            audiences.Should().Contain("https://idsvr4/resources");
+            audiences.Should().Contain("api");
+
+            var scopes = payload["scope"] as JArray;
+            scopes.First().ToString().Should().Be("api1");
+
+            var amr = payload["amr"] as JArray;
+            amr.Count().Should().Be(1);
+            amr.First().ToString().Should().Be("delegation");
+        }
+
+        [Fact]
+        public async Task Dynamic_Client_Client_Claims_no_Sub()
+        {
+            var client = new TokenClient(
+                TokenEndpoint,
+                "client.dynamic",
+                "secret",
+                innerHttpMessageHandler: _handler);
+
+            var customParameters = new Dictionary<string, string>
+                {
+                    { "claim", "extra_claim"}
+                };
+
+            var response = await client.RequestCustomGrantAsync("dynamic", "api1", customParameters);
+
+            response.IsError.Should().BeFalse();
+            response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+            response.ExpiresIn.Should().Be(3600);
+            response.TokenType.Should().Be("Bearer");
+            response.IdentityToken.Should().BeNull();
+            response.RefreshToken.Should().BeNull();
+
+            var payload = GetPayload(response);
+
+            payload.Count().Should().Be(7);
+            payload.Should().Contain("iss", "https://idsvr4");
+            payload.Should().Contain("client_id", "client.dynamic");
+            payload.Should().Contain("client_extra", "extra_claim");
+
+            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
+            audiences.Count().Should().Be(2);
+            audiences.Should().Contain("https://idsvr4/resources");
+            audiences.Should().Contain("api");
+
+            var scopes = payload["scope"] as JArray;
+            scopes.First().ToString().Should().Be("api1");
+        }
+
         private Dictionary<string, object> GetPayload(TokenResponse response)
         {
             var token = response.AccessToken.Split('.').Skip(1).Take(1).First();

--- a/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
@@ -132,7 +132,9 @@ namespace IdentityServer4.IntegrationTests.Clients
                     AllowedScopes =
                     {
                         "api1", "api2"
-                    }
+                    },
+
+                    AlwaysSendClientClaims = true
                 },
 
                 ///////////////////////////////////////////

--- a/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
@@ -119,6 +119,21 @@ namespace IdentityServer4.IntegrationTests.Clients
                         "api1", "api2"
                     }
                 },
+                new Client
+                {
+                    ClientId = "client.dynamic",
+                    ClientSecrets =
+                    {
+                        new Secret("secret".Sha256())
+                    },
+
+                    AllowedGrantTypes = GrantTypes.List("dynamic"),
+
+                    AllowedScopes =
+                    {
+                        "api1", "api2"
+                    }
+                },
 
                 ///////////////////////////////////////////
                 // Introspection Client Sample

--- a/test/IdentityServer.IntegrationTests/Clients/Setup/DynamicParameterExtensionGrantValidator.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/Setup/DynamicParameterExtensionGrantValidator.cs
@@ -16,6 +16,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             var lifetime = context.Request.Raw.Get("lifetime");
             var extraClaim = context.Request.Raw.Get("claim");
             var tokenType = context.Request.Raw.Get("type");
+            var sub = context.Request.Raw.Get("sub");
 
             if (!string.IsNullOrEmpty(lifetime))
             {
@@ -39,7 +40,15 @@ namespace IdentityServer4.IntegrationTests.Clients
                 context.Request.ClientClaims.Add(new Claim("extra", extraClaim));
             }
 
-            context.Result = new GrantValidationResult();
+            if (!string.IsNullOrEmpty(sub))
+            {
+                context.Result = new GrantValidationResult(sub, "delegation");
+            }
+            else
+            {
+                context.Result = new GrantValidationResult();
+            }
+
             return Task.FromResult(0);
         }
 

--- a/test/IdentityServer.IntegrationTests/Clients/Setup/DynamicParameterExtensionGrantValidator.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/Setup/DynamicParameterExtensionGrantValidator.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using IdentityServer4.Models;
+using IdentityServer4.Validation;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.IntegrationTests.Clients
+{
+    public class DynamicParameterExtensionGrantValidator : IExtensionGrantValidator
+    {
+        public Task ValidateAsync(ExtensionGrantValidationContext context)
+        {
+            var lifetime = context.Request.Raw.Get("lifetime");
+            var extraClaim = context.Request.Raw.Get("claim");
+            var tokenType = context.Request.Raw.Get("type");
+
+            if (!string.IsNullOrEmpty(lifetime))
+            {
+                context.Request.AccessTokenLifetime = int.Parse(lifetime);
+            }
+
+            if (!string.IsNullOrEmpty(tokenType))
+            {
+                if (tokenType == "jwt")
+                {
+                    context.Request.AccessTokenType = AccessTokenType.Jwt;
+                }
+                else if (tokenType == "reference")
+                {
+                    context.Request.AccessTokenType = AccessTokenType.Reference;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(extraClaim))
+            {
+                context.Request.ClientClaims.Add(new Claim("extra", extraClaim));
+            }
+
+            context.Result = new GrantValidationResult();
+            return Task.FromResult(0);
+        }
+
+        public string GrantType => "dynamic";
+    }
+}

--- a/test/IdentityServer.IntegrationTests/Clients/Setup/Startup.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/Setup/Startup.cs
@@ -38,6 +38,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             builder.AddExtensionGrantValidator<ExtensionGrantValidator>();
             builder.AddExtensionGrantValidator<ExtensionGrantValidator2>();
             builder.AddExtensionGrantValidator<NoSubjectExtensionGrantValidator>();
+            builder.AddExtensionGrantValidator<DynamicParameterExtensionGrantValidator>();
 
             builder.AddSecretParser<ClientAssertionSecretParser>();
             builder.AddSecretValidator<PrivateKeyJwtSecretValidator>();

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
@@ -27,10 +27,6 @@ namespace IdentityServer4.UnitTests.Services.Default
 
         public DefaultClaimsServiceTests()
         {
-            _validatedRequest = new ValidatedRequest
-            {
-            };
-
             _client = new Client
             {
                 ClientId = "client",
@@ -46,6 +42,9 @@ namespace IdentityServer4.UnitTests.Services.Default
             });
 
             _subject = new DefaultClaimsService(_mockMockProfileService, TestLogger.Create<DefaultClaimsService>());
+
+            _validatedRequest = new ValidatedRequest();
+            _validatedRequest.SetClient(_client);
         }
 
         [Fact]
@@ -119,7 +118,7 @@ namespace IdentityServer4.UnitTests.Services.Default
         [Fact]
         public async Task GetAccessTokenClaimsAsync_client_claims_should_be_prefixed()
         {
-            _client.PrefixClientClaims = true;
+            _validatedRequest.Client.PrefixClientClaims = true;
             var claims = await _subject.GetAccessTokenClaimsAsync(null, _client, _resources, _validatedRequest);
 
             claims.Where(x => x.Type == "client_some_claim" && x.Value == "some_claim_value").Count().Should().Be(1);
@@ -128,7 +127,7 @@ namespace IdentityServer4.UnitTests.Services.Default
         [Fact]
         public async Task GetAccessTokenClaimsAsync_should_contain_client_claims_when_no_subject()
         {
-            _client.PrefixClientClaims = false;
+            _validatedRequest.Client.PrefixClientClaims = false;
             var claims = await _subject.GetAccessTokenClaimsAsync(null, _client, _resources, _validatedRequest);
 
             claims.Where(x => x.Type == "some_claim" && x.Value == "some_claim_value").Count().Should().Be(1);
@@ -137,8 +136,8 @@ namespace IdentityServer4.UnitTests.Services.Default
         [Fact]
         public async Task GetAccessTokenClaimsAsync_should_contain_client_claims_when_configured_to_send_client_claims()
         {
-            _client.PrefixClientClaims = false;
-            _client.AlwaysSendClientClaims = true;
+            _validatedRequest.Client.PrefixClientClaims = false;
+            _validatedRequest.Client.AlwaysSendClientClaims = true;
 
             var claims = await _subject.GetAccessTokenClaimsAsync(_user, _client, _resources, _validatedRequest);
 


### PR DESCRIPTION
Will allow setting certain access token parameters on a per-request basis, e.g.

* token type (JWT vs reference)
* token lifetime
* client claims