### PR TITLE
Pass LoginUrl/LogoutUrl from IdentityServerOptions to auth cookie

### DIFF
--- a/src/IdentityServer4/Hosting/CookieMiddleware.cs
+++ b/src/IdentityServer4/Hosting/CookieMiddleware.cs
@@ -30,6 +30,9 @@ namespace IdentityServer4.Hosting
                         SlidingExpiration = options.Authentication.CookieSlidingExpiration,
                         ExpireTimeSpan = options.Authentication.CookieLifetime,
                         CookieName = IdentityServerConstants.DefaultCookieAuthenticationScheme,
+                        LoginPath = options.UserInteraction.LoginUrl,
+                        LogoutPath = options.UserInteraction.LogoutUrl,
+                        ReturnUrlParameter = options.UserInteraction.LoginReturnUrlParameter
                     });
 
                     logger.LogDebug("Adding CookieAuthentication middleware for external authentication with scheme: {authenticationScheme}", IdentityServerConstants.ExternalCookieAuthenticationScheme);

--- a/src/IdentityServer4/Hosting/CookieMiddleware.cs
+++ b/src/IdentityServer4/Hosting/CookieMiddleware.cs
@@ -30,8 +30,8 @@ namespace IdentityServer4.Hosting
                         SlidingExpiration = options.Authentication.CookieSlidingExpiration,
                         ExpireTimeSpan = options.Authentication.CookieLifetime,
                         CookieName = IdentityServerConstants.DefaultCookieAuthenticationScheme,
-                        LoginPath = options.UserInteraction.LoginUrl,
-                        LogoutPath = options.UserInteraction.LogoutUrl,
+                        LoginPath = ExtractLocalUrl(options.UserInteraction.LoginUrl),
+                        LogoutPath = ExtractLocalUrl(options.UserInteraction.LogoutUrl),
                         ReturnUrlParameter = options.UserInteraction.LoginReturnUrlParameter
                     });
 
@@ -51,6 +51,21 @@ namespace IdentityServer4.Hosting
                 app.UseMiddleware<AuthenticationMiddleware>();
                 app.UseMiddleware<FederatedSignOutMiddleware>();
             }
+        }
+
+        private static string ExtractLocalUrl(string url)
+        {
+            if (url.IsLocalUrl())
+            {
+                if (url.StartsWith("~/"))
+                {
+                    url = url.Substring(1);
+                }
+
+                return url;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
When an unauthenticated user tries to access an authenticated page from an IdentityServer app (e.g. for changing a password) the user gets redirected to "/Account/Login?ReturnUrl=...". This is the default value in the ASP.NET Core cookie authentication middleware and in IdentityServer (although it's lowercase "/account/login" there) so everything works with the default settings. 

Unfortunately, changes to `identityServerOptions.Authentication.LoginUrl`, `identityServerOptions.Authentication.LogoutUrl` and `identityServerOptions.Authentication.LoginReturnUrlParameter` are currently not passed to the cookie authentication middleware. This results in the user still being redirected to "/Account/Login". My workaround for now is to use my own cookies in Startup.cs.

This PR would change that by passing the option values to the cookie middleware.