### PR TITLE
Fix typo in the X-Frame-Options directive.

### DIFF
--- a/src/IdentityServer4/Endpoints/Results/EndSessionCallbackResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/EndSessionCallbackResult.cs
@@ -116,7 +116,7 @@ namespace IdentityServer4.Endpoints.Results
                 }
                 else
                 {
-                    context.Response.Headers.Add("X-Frame-Options", $"ALLOWFROM {logoutPageUrl.GetOrigin()}");
+                    context.Response.Headers.Add("X-Frame-Options", $"ALLOW-FROM {logoutPageUrl.GetOrigin()}");
                 }
             }
         }


### PR DESCRIPTION
It should be ALLOW-FROM instead of ALLOWFROM. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

This fixes https://github.com/IdentityServer/IdentityServer4/issues/931