### PR TITLE
removing excess bracket in resource example

### DIFF
--- a/docs/topics/resources.rst
+++ b/docs/topics/resources.rst
@@ -86,8 +86,7 @@ To get access tokens for APIs, you also need to register them as a scope. This t
                 },
 
                 // include the following using claims in access token (in addition to subject id)
-                UserClaims = { JwtClaimTypes.Name, JwtClaimTypes.Email }
-                },
+                UserClaims = { JwtClaimTypes.Name, JwtClaimTypes.Email },
 
                 // this API defines two scopes
                 Scopes =


### PR DESCRIPTION
Hey guys 
Just a minor change - I noticed an excess bracket in this code example while working through the docs. 