### PR TITLE
Create new collection when implying all scopes if none requested

### DIFF
--- a/src/IdentityServer4/Validation/TokenRequestValidator.cs
+++ b/src/IdentityServer4/Validation/TokenRequestValidator.cs
@@ -597,7 +597,7 @@ namespace IdentityServer4.Validation
             {
                 _logger.LogTrace("Client provided no scopes - checking allowed scopes list");
 
-                var clientAllowedScopes = _validatedRequest.Client.AllowedScopes;
+                var clientAllowedScopes = new List<string>(_validatedRequest.Client.AllowedScopes);
                 if (!clientAllowedScopes.IsNullOrEmpty())
                 {
                     if (_validatedRequest.Client.AllowOfflineAccess)

--- a/src/IdentityServer4/Validation/TokenRequestValidator.cs
+++ b/src/IdentityServer4/Validation/TokenRequestValidator.cs
@@ -597,9 +597,10 @@ namespace IdentityServer4.Validation
             {
                 _logger.LogTrace("Client provided no scopes - checking allowed scopes list");
 
-                var clientAllowedScopes = new List<string>(_validatedRequest.Client.AllowedScopes);
+                var clientAllowedScopes = new List<string>();
                 if (!clientAllowedScopes.IsNullOrEmpty())
                 {
+                    clientAllowedScopes.AddRange(_validatedRequest.Client.AllowedScopes));
                     if (_validatedRequest.Client.AllowOfflineAccess)
                     {
                         clientAllowedScopes.Add(IdentityServerConstants.StandardScopes.OfflineAccess);

--- a/src/IdentityServer4/Validation/TokenRequestValidator.cs
+++ b/src/IdentityServer4/Validation/TokenRequestValidator.cs
@@ -596,11 +596,10 @@ namespace IdentityServer4.Validation
             if (scopes.IsMissing())
             {
                 _logger.LogTrace("Client provided no scopes - checking allowed scopes list");
-
-                var clientAllowedScopes = new List<string>();
-                if (!clientAllowedScopes.IsNullOrEmpty())
+                
+                if (!_validatedRequest.Client.AllowedScopes.IsNullOrEmpty())
                 {
-                    clientAllowedScopes.AddRange(_validatedRequest.Client.AllowedScopes));
+                    var clientAllowedScopes = new List<string>(_validatedRequest.Client.AllowedScopes);
                     if (_validatedRequest.Client.AllowOfflineAccess)
                     {
                         clientAllowedScopes.Add(IdentityServerConstants.StandardScopes.OfflineAccess);


### PR DESCRIPTION
Fixes #1026. When using the provided in-memory client store, or enabling
in-memory client store cache, this prevents the offline_access scope
from being continually added to the Client.AllowedScopes collection when
AllowOfflineAccess = true and no scopes were requested for resource
owner, client credentials, and extension grant types.