### PR TITLE
Consent page: Add fallback to ClientId if ClientName is left empty

### DIFF
--- a/src/Host/Quickstart/Consent/ConsentService.cs
+++ b/src/Host/Quickstart/Consent/ConsentService.cs
@@ -132,7 +132,7 @@ namespace IdentityServer4.Quickstart.UI
 
             vm.ReturnUrl = returnUrl;
 
-            vm.ClientName = client.ClientName;
+            vm.ClientName = client.ClientName ?? client.ClientId;
             vm.ClientUrl = client.ClientUri;
             vm.ClientLogoUrl = client.LogoUri;
             vm.AllowRememberConsent = client.AllowRememberConsent;


### PR DESCRIPTION
The consent page was showing '[blank] is requesting your permission'.
The problem was that in my client configuration I didn't fill in the ClientName, I only filled in the ClientId.

I searched for all usages of the ClientName field, apparently the consent page was the only page where this problem existed. The grants page also uses the ClientName, but already falls back to the ClientId if the name is not filled in, so I applied the same fix for the consent page.