### PR TITLE
Removed duplicate scopes

### DIFF
--- a/src/IdentityServer4/Stores/InMemory/InMemoryResourcesStore.cs
+++ b/src/IdentityServer4/Stores/InMemory/InMemoryResourcesStore.cs
@@ -89,10 +89,10 @@ namespace IdentityServer4.Stores
         {
             if (names == null) throw new ArgumentNullException(nameof(names));
 
-            var api = from a in _apiResources
+            var api = (from a in _apiResources
                       from s in a.Scopes
                       where names.Contains(s.Name)
-                      select a;
+                      select a).Distinct();
 
             return Task.FromResult(api);
         }


### PR DESCRIPTION
When using InMemoryResourcesStore you may get duplicate scopes in several  ui screens and inside jwt scopes section also.

This is a fix for an [issue i opened](https://github.com/IdentityServer/IdentityServer4/issues/1216)

This fix may also apply to [this issue](https://github.com/IdentityServer/IdentityServer4/issues/1099) if InMemory store is used. It solved the issue in my case.



