### PR TITLE
Included ui_locales as query parameter to ErrorUrl and LogoutUrl

### DIFF
--- a/src/IdentityServer4/Endpoints/Results/EndSessionResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/EndSessionResult.cs
@@ -2,16 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using System.Threading.Tasks;
-using IdentityServer4.Validation;
-using IdentityServer4.Hosting;
-using Microsoft.AspNetCore.Http;
+using IdentityModel;
 using IdentityServer4.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+using IdentityServer4.Extensions;
+using IdentityServer4.Hosting;
 using IdentityServer4.Models;
 using IdentityServer4.Stores;
-using IdentityServer4.Extensions;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Threading.Tasks;
 
 namespace IdentityServer4.Endpoints.Results
 {
@@ -64,6 +65,7 @@ namespace IdentityServer4.Endpoints.Results
             var validatedRequest = _result.IsError ? null : _result.ValidatedRequest;
 
             string id = null;
+            string uilocales = null;
 
             if (validatedRequest != null)
             {
@@ -73,6 +75,8 @@ namespace IdentityServer4.Endpoints.Results
                     var msg = new Message<LogoutMessage>(logoutMessage);
                     id = await _logoutMessageStore.WriteAsync(msg);
                 }
+
+                uilocales = validatedRequest.Raw?.Get(OidcConstants.EndSessionRequest.UiLocales);
             }
 
             var redirect = _options.UserInteraction.LogoutUrl;
@@ -85,6 +89,12 @@ namespace IdentityServer4.Endpoints.Results
             if (id != null)
             {
                 redirect = redirect.AddQueryString(_options.UserInteraction.LogoutIdParameter, id);
+            }
+
+            // add uilocales to the query string if it is available
+            if (uilocales.IsPresent() && uilocales.Length < _options.InputLengthRestrictions.UiLocale)
+            {
+                redirect = redirect.AddQueryString(OidcConstants.EndSessionRequest.UiLocales, uilocales);
             }
 
             context.Response.Redirect(redirect);

--- a/src/IdentityServer4/IdentityServer4.csproj
+++ b/src/IdentityServer4/IdentityServer4.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
-    <PackageReference Include="IdentityModel" Version="2.10.0" />
+    <PackageReference Include="IdentityModel" Version="2.10.0-build00138" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Included ui_locales as query parameter to ErrorUrl and LogoutUrl 
Fix for Issue https://github.com/IdentityServer/IdentityServer4/issues/1305

Note: 
1.Dependency on IdentityModel changes. Please refer PR : https://github.com/IdentityModel/IdentityModel2/pull/51

2. I have not added the relevant tests yet. All existing tests do pass. Please let me know if the changes look fine fine. 
