### PR TITLE
slightly cleaner GetOrigin implementation

### DIFF
--- a/src/IdentityServer4/Extensions/StringsExtensions.cs
+++ b/src/IdentityServer4/Extensions/StringsExtensions.cs
@@ -211,17 +211,12 @@ namespace IdentityServer4.Extensions
 
         public static string GetOrigin(this string url)
         {
-            if (url != null && (url.StartsWith("http://") || url.StartsWith("https://")))
+            if (url != null)
             {
-                var idx = url.IndexOf("//", StringComparison.Ordinal);
-                if (idx > 0)
+                var uri = new Uri(url);
+                if (uri.Scheme == "http" || uri.Scheme = "https")
                 {
-                    idx = url.IndexOf("/", idx + 2, StringComparison.Ordinal);
-                    if (idx >= 0)
-                    {
-                        url = url.Substring(0, idx);
-                    }
-                    return url;
+                    return $"{uri.Scheme}://{uri.Authority}";
                 }
             }
 

--- a/src/IdentityServer4/Extensions/StringsExtensions.cs
+++ b/src/IdentityServer4/Extensions/StringsExtensions.cs
@@ -214,7 +214,7 @@ namespace IdentityServer4.Extensions
             if (url != null)
             {
                 var uri = new Uri(url);
-                if (uri.Scheme == "http" || uri.Scheme = "https")
+                if (uri.Scheme == "http" || uri.Scheme == "https")
                 {
                     return $"{uri.Scheme}://{uri.Authority}";
                 }

--- a/test/IdentityServer.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,91 @@
+﻿using IdentityServer4.Extensions;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Extensions
+{
+    public class StringExtensionsTests
+    {
+        private void CheckOrigin(string inputUrl, string expectedOrigin)
+        {
+            var actualOrigin = inputUrl.GetOrigin();
+            Assert.Equal(expectedOrigin, actualOrigin);
+        }
+
+        [Fact]
+        public void TestGetOrigin()
+        {
+            CheckOrigin("http://idsvr.com", "http://idsvr.com");
+            CheckOrigin("http://idsvr.com/", "http://idsvr.com");
+            CheckOrigin("http://idsvr.com/test", "http://idsvr.com");
+            CheckOrigin("http://idsvr.com/test/resource", "http://idsvr.com");
+            CheckOrigin("http://idsvr.com:8080", "http://idsvr.com:8080");
+            CheckOrigin("http://idsvr.com:8080/", "http://idsvr.com:8080");
+            CheckOrigin("http://idsvr.com:8080/test", "http://idsvr.com:8080");
+            CheckOrigin("http://idsvr.com:8080/test/resource", "http://idsvr.com:8080");
+            CheckOrigin("http://127.0.0.1", "http://127.0.0.1");
+            CheckOrigin("http://127.0.0.1/", "http://127.0.0.1");
+            CheckOrigin("http://127.0.0.1/test", "http://127.0.0.1");
+            CheckOrigin("http://127.0.0.1/test/resource", "http://127.0.0.1");
+            CheckOrigin("http://127.0.0.1:8080", "http://127.0.0.1:8080");
+            CheckOrigin("http://127.0.0.1:8080/", "http://127.0.0.1:8080");
+            CheckOrigin("http://127.0.0.1:8080/test", "http://127.0.0.1:8080");
+            CheckOrigin("http://127.0.0.1:8080/test/resource", "http://127.0.0.1:8080");
+            CheckOrigin("http://localhost", "http://localhost");
+            CheckOrigin("http://localhost/", "http://localhost");
+            CheckOrigin("http://localhost/test", "http://localhost");
+            CheckOrigin("http://localhost/test/resource", "http://localhost");
+            CheckOrigin("http://localhost:8080", "http://localhost:8080");
+            CheckOrigin("http://localhost:8080/", "http://localhost:8080");
+            CheckOrigin("http://localhost:8080/test", "http://localhost:8080");
+            CheckOrigin("http://localhost:8080/test/resource", "http://localhost:8080");
+            CheckOrigin("https://idsvr.com", "https://idsvr.com");
+            CheckOrigin("https://idsvr.com/", "https://idsvr.com");
+            CheckOrigin("https://idsvr.com/test", "https://idsvr.com");
+            CheckOrigin("https://idsvr.com/test/resource", "https://idsvr.com");
+            CheckOrigin("https://idsvr.com:8080", "https://idsvr.com:8080");
+            CheckOrigin("https://idsvr.com:8080/", "https://idsvr.com:8080");
+            CheckOrigin("https://idsvr.com:8080/test", "https://idsvr.com:8080");
+            CheckOrigin("https://idsvr.com:8080/test/resource", "https://idsvr.com:8080");
+            CheckOrigin("https://127.0.0.1", "https://127.0.0.1");
+            CheckOrigin("https://127.0.0.1/", "https://127.0.0.1");
+            CheckOrigin("https://127.0.0.1/test", "https://127.0.0.1");
+            CheckOrigin("https://127.0.0.1/test/resource", "https://127.0.0.1");
+            CheckOrigin("https://127.0.0.1:8080", "https://127.0.0.1:8080");
+            CheckOrigin("https://127.0.0.1:8080/", "https://127.0.0.1:8080");
+            CheckOrigin("https://127.0.0.1:8080/test", "https://127.0.0.1:8080");
+            CheckOrigin("https://127.0.0.1:8080/test/resource", "https://127.0.0.1:8080");
+            CheckOrigin("https://localhost", "https://localhost");
+            CheckOrigin("https://localhost/", "https://localhost");
+            CheckOrigin("https://localhost/test", "https://localhost");
+            CheckOrigin("https://localhost/test/resource", "https://localhost");
+            CheckOrigin("https://localhost:8080", "https://localhost:8080");
+            CheckOrigin("https://localhost:8080/", "https://localhost:8080");
+            CheckOrigin("https://localhost:8080/test", "https://localhost:8080");
+            CheckOrigin("https://localhost:8080/test/resource", "https://localhost:8080");
+            CheckOrigin("test://idsvr.com", null);
+            CheckOrigin("test://idsvr.com/", null);
+            CheckOrigin("test://idsvr.com/test", null);
+            CheckOrigin("test://idsvr.com/test/resource", null);
+            CheckOrigin("test://idsvr.com:8080", null);
+            CheckOrigin("test://idsvr.com:8080/", null);
+            CheckOrigin("test://idsvr.com:8080/test", null);
+            CheckOrigin("test://idsvr.com:8080/test/resource", null);
+            CheckOrigin("test://127.0.0.1", null);
+            CheckOrigin("test://127.0.0.1/", null);
+            CheckOrigin("test://127.0.0.1/test", null);
+            CheckOrigin("test://127.0.0.1/test/resource", null);
+            CheckOrigin("test://127.0.0.1:8080", null);
+            CheckOrigin("test://127.0.0.1:8080/", null);
+            CheckOrigin("test://127.0.0.1:8080/test", null);
+            CheckOrigin("test://127.0.0.1:8080/test/resource", null);
+            CheckOrigin("test://localhost", null);
+            CheckOrigin("test://localhost/", null);
+            CheckOrigin("test://localhost/test", null);
+            CheckOrigin("test://localhost/test/resource", null);
+            CheckOrigin("test://localhost:8080", null);
+            CheckOrigin("test://localhost:8080/", null);
+            CheckOrigin("test://localhost:8080/test", null);
+            CheckOrigin("test://localhost:8080/test/resource", null);
+        }
+    }
+}


### PR DESCRIPTION
I noticed that `StringExtensions.GetOrigin` is a little hard to follow, and uses `String.IndexOf` and substring to approximate URL parsing. While it works alright, I think it's probably better to use the `Uri` class.