### PR TITLE
added "alg" to JsonWebKey and DiscoveryResponseGenerator

### DIFF
--- a/src/IdentityServer4/Models/JsonWebKey.cs
+++ b/src/IdentityServer4/Models/JsonWebKey.cs
@@ -14,5 +14,6 @@ namespace IdentityServer4.Models
         public string e { get; set; }
         public string n { get; set; }
         public string[] x5c { get; set; }
+        public string alg { get; set; }
     }
 }

--- a/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
@@ -280,6 +280,7 @@ namespace IdentityServer4.ResponseHandling
         {
             var webKeys = new List<Models.JsonWebKey>();
             var signingCredentials = await Keys.GetSigningCredentialsAsync();
+            var algorithm = signingCredentials?.Algorithm ?? Constants.SigningAlgorithms.RSA_SHA_256;
 
             foreach (var key in await Keys.GetValidationKeysAsync())
             {
@@ -302,7 +303,7 @@ namespace IdentityServer4.ResponseHandling
                         e = exponent,
                         n = modulus,
                         x5c = new[] { cert64 },
-                        alg = signingCredentials?.Algorithm ?? Constants.SigningAlgorithms.RSA_SHA_256
+                        alg = algorithm
                     };
 
                     webKeys.Add(webKey);
@@ -322,7 +323,7 @@ namespace IdentityServer4.ResponseHandling
                         kid = rsaKey.KeyId,
                         e = exponent,
                         n = modulus,
-                        alg = signingCredentials?.Algorithm ?? Constants.SigningAlgorithms.RSA_SHA_256
+                        alg = algorithm
                     };
 
                     webKeys.Add(webKey);

--- a/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
@@ -279,6 +279,7 @@ namespace IdentityServer4.ResponseHandling
         public virtual async Task<IEnumerable<Models.JsonWebKey>> CreateJwkDocumentAsync()
         {
             var webKeys = new List<Models.JsonWebKey>();
+            var signingCredentials = await Keys.GetSigningCredentialsAsync();
 
             foreach (var key in await Keys.GetValidationKeysAsync())
             {
@@ -300,7 +301,8 @@ namespace IdentityServer4.ResponseHandling
                         x5t = thumbprint,
                         e = exponent,
                         n = modulus,
-                        x5c = new[] { cert64 }
+                        x5c = new[] { cert64 },
+                        alg = signingCredentials?.Algorithm ?? Constants.SigningAlgorithms.RSA_SHA_256
                     };
 
                     webKeys.Add(webKey);
@@ -319,7 +321,8 @@ namespace IdentityServer4.ResponseHandling
                         use = "sig",
                         kid = rsaKey.KeyId,
                         e = exponent,
-                        n = modulus
+                        n = modulus,
+                        alg = signingCredentials?.Algorithm ?? Constants.SigningAlgorithms.RSA_SHA_256
                     };
 
                     webKeys.Add(webKey);

--- a/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -29,5 +29,29 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Discovery
 
             issuer.Should().Be("https://server/root");
         }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task jwks_entries_should_contain_alg()
+        {
+            MockIdSvrUiPipeline pipeline = new MockIdSvrUiPipeline();
+            pipeline.Initialize("/ROOT");
+
+            var result = await pipeline.Client.GetAsync("https://server/root/.well-known/openid-configuration/jwks");
+
+            var json = await result.Content.ReadAsStringAsync();
+            var data = JObject.Parse(json);
+
+            var keys = data["keys"];
+            keys.Should().NotBeNull();
+
+            var key = keys[0];
+            key.Should().NotBeNull();
+
+            var alg = key["alg"];
+            alg.Should().NotBeNull();
+
+            alg.Value<string>().Should().Be(Constants.SigningAlgorithms.RSA_SHA_256);
+        }
     }
 }


### PR DESCRIPTION
Even though it's optional, I though perhaps it can be added out of the box (see https://tools.ietf.org/html/rfc7517#section-4.4)
If this doesn't belong to the core server, my apologies - please just ignore the PR.