### PR TITLE
remove duplicate entries from scopes_supported element in discovery doc

### DIFF
--- a/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
@@ -182,7 +182,7 @@ namespace IdentityServer4.ResponseHandling
 
                 if (scopes.Any())
                 {
-                    entries.Add(OidcConstants.Discovery.ScopesSupported, scopes.ToArray());
+                    entries.Add(OidcConstants.Discovery.ScopesSupported, scopes.Distinct().ToArray());
                 }
 
                 // claims


### PR DESCRIPTION
a small and simple PR to remove all duplicate entries from the `scopes_supported` element in the discovery endpoint document.

from
```json
"scopes_supported":[
    "openid",
    "profile",
    "digital-api",
    "digital-api",
    "offline_access"
]
```

to
```json
"scopes_supported":[
    "openid",
    "profile",
    "digital-api",
    "offline_access"
]
```