### PR TITLE
automatically add store implementations to DI when adding cached stores

### DIFF
--- a/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -6,6 +6,7 @@ using IdentityServer4.ResponseHandling;
 using IdentityServer4.Services;
 using IdentityServer4.Stores;
 using IdentityServer4.Validation;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -149,6 +150,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IIdentityServerBuilder AddClientStoreCache<T>(this IIdentityServerBuilder builder)
             where T : IClientStore
         {
+            builder.Services.TryAddTransient(typeof(T));
             builder.Services.AddTransient<IClientStore, CachingClientStore<T>>();
             return builder;
         }
@@ -162,6 +164,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IIdentityServerBuilder AddResourceStoreCache<T>(this IIdentityServerBuilder builder)
             where T : IResourceStore
         {
+            builder.Services.TryAddTransient(typeof(T));
             builder.Services.AddTransient<IResourceStore, CachingResourceStore<T>>();
             return builder;
         }

--- a/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCacheStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCacheStoreTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Configuration;
+using IdentityServer4.Models;
+using IdentityServer4.Stores;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace IdentityServer4.UnitTests.Extensions
+{
+    public class IdentityServerBuilderExtensionsCacheStoreTests
+    {
+        class CustomClientStore: IClientStore
+        {
+            public Task<Client> FindClientByIdAsync(string clientId)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        class CustomResourceStore : IResourceStore
+        {
+            public Task<IEnumerable<IdentityResource>> FindIdentityResourcesByScopeAsync(IEnumerable<string> scopeNames)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task<IEnumerable<ApiResource>> FindApiResourcesByScopeAsync(IEnumerable<string> scopeNames)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task<ApiResource> FindApiResourceAsync(string name)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task<Resources> GetAllResourcesAsync()
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public void AddClientStoreCache_should_add_concrete_iclientstore_implementation()
+        {
+            var services = new ServiceCollection();
+            var identityServerBuilder = new IdentityServerBuilder(services);
+
+            identityServerBuilder.AddClientStoreCache<CustomClientStore>();
+
+            services.Any(x => x.ImplementationType == typeof(CustomClientStore)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void AddResourceStoreCache_should_attempt_to_register_iresourcestore_implementation()
+        {
+            var services = new ServiceCollection();
+            var identityServerBuilder = new IdentityServerBuilder(services);
+
+            identityServerBuilder.AddResourceStoreCache<CustomResourceStore>();
+
+            services.Any(x => x.ImplementationType == typeof(CustomResourceStore)).Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
Currently, in order to add `ClientStoreCache` and `ResourceStoreCache`, we would have to do

```cs
services.AddTransient<CustomStoreCache>();
services.AddTransient<CustomResourceStoreCache>();

services.AddIdentityServer()
    .AddInMemoryCaching()
    .AddClientStoreCache<CustomStoreCache>()
    .AddResourceStoreCache<CustomResourceStoreCache>();
```

this pull request would help simplify the process by attempting to add the custom implementation of the stores within the `AddClientStoreCache<T>` and `AddResourceStoreCache<T>` extension methods, so that the above can be as simple as.

```csharp
services.AddIdentityServer()
    .AddInMemoryCaching()
    .AddClientStoreCache<CustomStoreCache>()
    .AddResourceStoreCache<CustomResourceStoreCache>();
```