### PR TITLE
AuthenticateAsync do not return null anymore

### DIFF
--- a/src/IdentityServer4/Services/DefaultUserSession.cs
+++ b/src/IdentityServer4/Services/DefaultUserSession.cs
@@ -128,7 +128,7 @@ namespace IdentityServer4.Services
         async Task<string> GetClientListPropertyValueAsync()
         {
             var info = await HttpContext.AuthenticateAsync(AuthenticationScheme);
-            if (info == null)
+            if (info == null || !info.Succeeded)
             {
                 _logger.LogWarning("No authenticated user");
                 return null;


### PR DESCRIPTION
AuthenticateAsync do not return null anymore (did not remove the null check as I dont know if it is a guarantied that it dont return null)