### PR TITLE
include username in ExtensionGrantValidationContext

### DIFF
--- a/src/IdentityServer4/Validation/ExtensionGrantValidator.cs
+++ b/src/IdentityServer4/Validation/ExtensionGrantValidator.cs
@@ -8,6 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using IdentityModel;
+using IdentityServer4.Extensions;
 
 namespace IdentityServer4.Validation
 {
@@ -70,7 +72,10 @@ namespace IdentityServer4.Validation
                 {
                     Request = request
                 };
-            
+
+                // attempt to populate the username property if it is present in the raw request
+                context.Request.UserName = request.Raw.Get(OidcConstants.TokenRequest.UserName);
+
                 await validator.ValidateAsync(context);
                 return context.Result;
             }

--- a/test/IdentityServer.UnitTests/ExtensionGrantValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/ExtensionGrantValidatorTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Specialized;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.UnitTests.Common;
+using IdentityServer4.Validation;
+using Xunit;
+
+namespace IdentityServer4.UnitTests.Validation
+{
+    public class ExtensionGrantValidatorTests
+    {
+        private readonly ExtensionGrantValidator _sut;
+
+        public ExtensionGrantValidatorTests()
+        {
+            _sut = new ExtensionGrantValidator(new[] {new TestGrantValidator(true)}, TestLogger.Create<ExtensionGrantValidator>());
+        }
+
+        [Fact]
+        public async Task should_populate_username_property_in_extension_grant_validation_context()
+        {
+            var request = new ValidatedTokenRequest
+            {
+                Raw = new NameValueCollection
+                {
+                    { "username", "12345678" }
+                },
+                GrantType = "custom_grant"
+            };
+
+            var result = await _sut.ValidateAsync(request);
+
+            result.Should().NotBeNull();
+            request.UserName.Should().Be("12345678");
+        }
+    }
+}


### PR DESCRIPTION
a small pull request to simplify extension grant validation, specifically with grants that validates custom credentials and require access to the `ExtensionGrantValidationContext.Request.Username` property

currently we would have to read the username from `ExtensionGrantValidationContext.Request.Raw.Get("username")`, this pull request would make it possible to simply do `ExtensionGrantValidationContext.Request.Username`