### PR TITLE
Updating Dependencies to 2.0.0 release

### DIFF
--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.0.1" />
@@ -18,6 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0-preview2-final" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Host/Quickstart/Account/AccountController.cs
+++ b/src/Host/Quickstart/Account/AccountController.cs
@@ -300,7 +300,7 @@ namespace IdentityServer4.Quickstart.UI
             }
 
             // delete local authentication cookie
-            await HttpContext.SignOutAsync();
+            await HttpContext.SignOut2Async();
 
             var user = await HttpContext.GetIdentityServerUserAsync();
             if (user != null)

--- a/src/Host/Startup.cs
+++ b/src/Host/Startup.cs
@@ -61,14 +61,15 @@ namespace Host
     {
         public static IServiceCollection AddExternalIdentityProviders(this IServiceCollection services)
         {
-            services.AddGoogleAuthentication("Google", options =>
+            services.AddAuthentication().
+                AddGoogle("Google", options =>
             {
                 options.SignInScheme = IdentityServerConstants.ExternalCookieAuthenticationScheme;
                 options.ClientId = "708996912208-9m4dkjb5hscn7cjrn5u0r4tbgkbj1fko.apps.googleusercontent.com";
                 options.ClientSecret = "wdfPY6t8H8cecgjlxud__4Gh";
-            });
-
-            services.AddOpenIdConnectAuthentication("demoidsrv", options =>
+            })
+            
+            .AddOpenIdConnect("demoidsrv", options =>
             {
                 options.SignInScheme = IdentityServerConstants.ExternalCookieAuthenticationScheme;
                 options.SignOutScheme = IdentityServerConstants.SignoutScheme;
@@ -88,9 +89,9 @@ namespace Host
                     NameClaimType = "name",
                     RoleClaimType = "role"
                 };
-            });
-
-            services.AddOpenIdConnectAuthentication("aad", options =>
+            })
+            
+            .AddOpenIdConnect("aad", options =>
             {
                 options.SignInScheme = IdentityServerConstants.ExternalCookieAuthenticationScheme;
                 options.SignOutScheme = IdentityServerConstants.SignoutScheme;
@@ -108,9 +109,9 @@ namespace Host
                     NameClaimType = "name",
                     RoleClaimType = "role"
                 };
-            });
-
-            services.AddOpenIdConnectAuthentication("adfs", options =>
+            })
+            
+            .AddOpenIdConnect("adfs", options =>
             {
                 options.SignInScheme = IdentityServerConstants.ExternalCookieAuthenticationScheme;
                 options.SignOutScheme = IdentityServerConstants.SignoutScheme;

--- a/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -52,23 +52,20 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IIdentityServerBuilder AddCookieAuthentication(this IIdentityServerBuilder builder)
         {
-            builder.Services.AddCookieAuthentication(IdentityServerConstants.DefaultCookieAuthenticationScheme, options =>
-            {
-                options.CookieName = IdentityServerConstants.DefaultCookieAuthenticationScheme;
-            });
-
-            builder.Services.AddCookieAuthentication(IdentityServerConstants.ExternalCookieAuthenticationScheme, options =>
-            {
-                options.CookieName = IdentityServerConstants.ExternalCookieAuthenticationScheme;
-            });
-
             // todo: is not really needed for IS...?!
             builder.Services.AddAuthentication(options =>
             {
                 options.DefaultAuthenticateScheme = IdentityServerConstants.DefaultCookieAuthenticationScheme;
                 options.DefaultChallengeScheme = IdentityServerConstants.DefaultCookieAuthenticationScheme;
                 options.DefaultSignInScheme = IdentityServerConstants.DefaultCookieAuthenticationScheme;
-            });
+            }).AddCookie(IdentityServerConstants.DefaultCookieAuthenticationScheme, options =>
+             {
+                 options.Cookie.Name = IdentityServerConstants.DefaultCookieAuthenticationScheme;
+
+             }).AddCookie(IdentityServerConstants.ExternalCookieAuthenticationScheme, options =>
+             {
+                 options.Cookie.Name = IdentityServerConstants.ExternalCookieAuthenticationScheme;
+             });
 
             builder.Services.AddSingleton<IConfigureOptions<CookieAuthenticationOptions>, ConfigureInternalCookieOptions>();
             

--- a/src/IdentityServer4/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
@@ -22,8 +22,8 @@ namespace IdentityServer4.Configuration
             {
                 options.SlidingExpiration = _idsrv.Authentication.CookieSlidingExpiration;
                 options.ExpireTimeSpan = _idsrv.Authentication.CookieLifetime;
-                options.CookieName = IdentityServerConstants.DefaultCookieAuthenticationScheme;
-                options.CookieSameSite = SameSiteMode.None;
+                options.Cookie.Name = IdentityServerConstants.DefaultCookieAuthenticationScheme;
+                options.Cookie.SameSite = SameSiteMode.None;
                 options.LoginPath = ExtractLocalUrl(_idsrv.UserInteraction.LoginUrl);
                 options.LogoutPath = ExtractLocalUrl(_idsrv.UserInteraction.LogoutUrl);
                 options.ReturnUrlParameter = _idsrv.UserInteraction.LoginReturnUrlParameter;

--- a/src/IdentityServer4/Extensions/HttpContextAuthenticationExtensions.cs
+++ b/src/IdentityServer4/Extensions/HttpContextAuthenticationExtensions.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         /// <param name="context">The manager.</param>
         /// <returns></returns>
-        public static async Task SignOutAsync(this HttpContext context)
+        public static async Task SignOut2Async(this HttpContext context)
         {
             var scheme = context.GetIdentityServerAuthenticationScheme();
             await context.SignOutAsync(scheme);

--- a/src/IdentityServer4/Hosting/CookieConfiguration.cs
+++ b/src/IdentityServer4/Hosting/CookieConfiguration.cs
@@ -30,6 +30,7 @@ namespace IdentityServer4.Hosting
 
                 // todo: right place for this config code?
                 var authOptions = app.ApplicationServices.GetRequiredService<IOptions<Microsoft.AspNetCore.Authentication.AuthenticationOptions>>();
+
                 authOptions.Value.DefaultAuthenticateScheme = options.Authentication.EffectiveAuthenticationScheme;
                 authOptions.Value.DefaultChallengeScheme = options.Authentication.EffectiveAuthenticationScheme;
                 authOptions.Value.DefaultSignInScheme = options.Authentication.EffectiveAuthenticationScheme;

--- a/src/IdentityServer4/Hosting/FederatedSignoutMiddleware.cs
+++ b/src/IdentityServer4/Hosting/FederatedSignoutMiddleware.cs
@@ -64,7 +64,7 @@ namespace IdentityServer4.Hosting
                     {
                         _logger.LogDebug("sid parameter matches external idp sid claim for current user");
 
-                        await context.SignOutAsync();
+                        await context.SignOut2Async();
 
                         var iframeUrl = await context.GetIdentityServerSignoutFrameCallbackUrlAsync();
                         if (iframeUrl != null)

--- a/src/IdentityServer4/IdentityServer4.csproj
+++ b/src/IdentityServer4/IdentityServer4.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
     <PackageReference Include="IdentityModel" Version="2.10.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />

--- a/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
 

--- a/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
 
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
   </ItemGroup>

--- a/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
+++ b/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
 
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
+    <PackageReference Include="FluentAssertions" Version="4.19.3" />
   </ItemGroup>
 
   <!--<PropertyGroup>

--- a/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
+++ b/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
 
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
   </ItemGroup>
 


### PR DESCRIPTION
.netcore 2.0 is released and it has some breaking changes from 2.0.0-preview2.

IServiceCollection.AddCookieAuthentication() no longer works and it has been replaced with AuthenticationBuilder.AddCookie()

This pr updates dependencies to 2.0.0 and changes the code to conform to the api change above