### PR TITLE
Remove Microsoft.AspNet.WebApi.Client dependency

### DIFF
--- a/test/IdentityServer.IntegrationTests/Conformance/Basic/RedirectUriTests.cs
+++ b/test/IdentityServer.IntegrationTests/Conformance/Basic/RedirectUriTests.cs
@@ -130,7 +130,7 @@ namespace IdentityServer4.IntegrationTests.Conformance.Basic
             var authorization = _mockPipeline.ParseAuthorizationResponseUrl(response.Headers.Location.ToString());
             authorization.Code.Should().NotBeNull();
             authorization.State.Should().Be(state);
-            var query = response.Headers.Location.ParseQueryString();
+            var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(response.Headers.Location.Query);
             query["foo"].ToString().Should().Be("bar");
             query["baz"].ToString().Should().Be("quux");
         }

--- a/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -14,7 +14,6 @@
 
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
   </ItemGroup>
 
   


### PR DESCRIPTION
This dependency is used in only one place to parse query parameters and can be easily avoided. 

Also this lib works only for net45 and this generates annoying warning.