### PR TITLE
Fixes issue where SessionIdKey is not present in the properties dictionary

### DIFF
--- a/src/IdentityServer4/Services/DefaultUserSession.cs
+++ b/src/IdentityServer4/Services/DefaultUserSession.cs
@@ -93,7 +93,7 @@ namespace IdentityServer4.Services
             var currentSubjectId = (await GetUserAsync())?.GetSubjectId();
             var newSubjectId = principal.GetSubjectId();
 
-            if (currentSubjectId == null || currentSubjectId != newSubjectId)
+            if (!properties.Items.ContainsKey(SessionIdKey) || currentSubjectId == null || currentSubjectId != newSubjectId)
             {
                 properties.Items[SessionIdKey] = CryptoRandom.CreateUniqueId(16);
             }


### PR DESCRIPTION
I've got this exception after upgrading to one of the 2.0.0 previews. The KeyNotFoundException was thrown after successful login.