### PR TITLE
Update introspection.rst

### DIFF
--- a/docs/endpoints/introspection.rst
+++ b/docs/endpoints/introspection.rst
@@ -43,8 +43,8 @@ You can programmatically access the introspection endpoint using the `IdentityMo
 
     var introspectionClient = new IntrospectionClient(
         doc.IntrospectionEndpoint,
-        "scope_name",
-        "scope_secret");
+        "client_id",
+        "client_secret");
 
     var response = await introspectionClient.SendAsync(
         new IntrospectionRequest { Token = token });


### PR DESCRIPTION
scope_name and scope_secret creates a misleading.
Scope usually represent an Api or an Identity Resource.
Would expect to pass client_id and client_secret instead