### PR TITLE
Added link Platform scenario sample

### DIFF
--- a/docs/quickstarts/community.rst
+++ b/docs/quickstarts/community.rst
@@ -13,3 +13,8 @@ Exchanging external tokens from Facebook, Google and Twitter
 * Shows how to exchange an external authentication token to an identity server acesss token using an extension grant
 
 https://github.com/waqaskhan540/IdentityServerExternalAuth
+
+.NET Core and ASP.NET Core "Platform" scenario
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Show an interaction of trusted "internal" applications and "external" applications with .NET Core 2.0 and ASP.NET Core 2.0 applications
+https://github.com/BenjaminAbt/Samples.AspNetCore-IdentityServer4


### PR DESCRIPTION
I created a .NET Core and ASP.NET Core "Platform scenario" sample and have added a link to it in the Community Quickstarts document.

It has "internal" and "external" clients to show what an interaction of consent could/should look alike.