### PR TITLE
Separate callback route endpoints from base route endpoints

### DIFF
--- a/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             builder.Services.AddTransient<IEndpointRouter, EndpointRouter>();
 
+            builder.AddEndpoint<AuthorizeCallbackEndpoint>(EndpointNames.Authorize, ProtocolRoutePaths.AuthorizeCallback.EnsureLeadingSlash());
             builder.AddEndpoint<AuthorizeEndpoint>(EndpointNames.Authorize, ProtocolRoutePaths.Authorize.EnsureLeadingSlash());
             builder.AddEndpoint<CheckSessionEndpoint>(EndpointNames.CheckSession, ProtocolRoutePaths.CheckSession.EnsureLeadingSlash());
             builder.AddEndpoint<DiscoveryEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());

--- a/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.AddEndpoint<AuthorizeCallbackEndpoint>(EndpointNames.Authorize, ProtocolRoutePaths.AuthorizeCallback.EnsureLeadingSlash());
             builder.AddEndpoint<AuthorizeEndpoint>(EndpointNames.Authorize, ProtocolRoutePaths.Authorize.EnsureLeadingSlash());
             builder.AddEndpoint<CheckSessionEndpoint>(EndpointNames.CheckSession, ProtocolRoutePaths.CheckSession.EnsureLeadingSlash());
+            builder.AddEndpoint<DiscoveryKeyEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryWebKeys.EnsureLeadingSlash());
             builder.AddEndpoint<DiscoveryEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());
             builder.AddEndpoint<EndSessionCallbackEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSessionCallback.EnsureLeadingSlash());
             builder.AddEndpoint<EndSessionEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSession.EnsureLeadingSlash());

--- a/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.AddEndpoint<AuthorizeEndpoint>(EndpointNames.Authorize, ProtocolRoutePaths.Authorize.EnsureLeadingSlash());
             builder.AddEndpoint<CheckSessionEndpoint>(EndpointNames.CheckSession, ProtocolRoutePaths.CheckSession.EnsureLeadingSlash());
             builder.AddEndpoint<DiscoveryEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());
+            builder.AddEndpoint<EndSessionCallbackEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSessionCallback.EnsureLeadingSlash());
             builder.AddEndpoint<EndSessionEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSession.EnsureLeadingSlash());
             builder.AddEndpoint<IntrospectionEndpoint>(EndpointNames.Introspection, ProtocolRoutePaths.Introspection.EnsureLeadingSlash());
             builder.AddEndpoint<TokenRevocationEndpoint>(EndpointNames.Revocation, ProtocolRoutePaths.Revocation.EnsureLeadingSlash());

--- a/src/IdentityServer4/Endpoints/AuthorizeCallbackEndpoint.cs
+++ b/src/IdentityServer4/Endpoints/AuthorizeCallbackEndpoint.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using IdentityServer4.Endpoints.Results;
+using IdentityServer4.Extensions;
+using IdentityServer4.Hosting;
+using IdentityServer4.Models;
+using IdentityServer4.ResponseHandling;
+using IdentityServer4.Services;
+using IdentityServer4.Stores;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace IdentityServer4.Endpoints
+{
+    internal class AuthorizeCallbackEndpoint : AuthorizeEndpointBase
+    {
+        private readonly IConsentMessageStore _consentResponseStore;
+
+        public AuthorizeCallbackEndpoint(
+            IEventService events,
+            ILogger<AuthorizeCallbackEndpoint> logger,
+            IAuthorizeRequestValidator validator,
+            IAuthorizeInteractionResponseGenerator interactionGenerator,
+            IAuthorizeResponseGenerator authorizeResponseGenerator,
+            IUserSession userSession,
+            IConsentMessageStore consentResponseStore)
+            : base(events, logger, validator, interactionGenerator, authorizeResponseGenerator, userSession)
+        {
+            this._consentResponseStore = consentResponseStore;
+        }
+
+        public override async Task<IEndpointResult> ProcessAsync(HttpContext context)
+        {
+            if (context.Request.Method != "GET")
+            {
+                Logger.LogWarning("Invalid HTTP method for authorize endpoint.");
+                return new StatusCodeResult(HttpStatusCode.MethodNotAllowed);
+            }
+
+            Logger.LogDebug("Start authorize callback request");
+
+            var parameters = context.Request.Query.AsNameValueCollection();
+
+            var user = await UserSession.GetUserAsync();
+            var consentRequest = new ConsentRequest(parameters, user?.GetSubjectId());
+            var consent = await this._consentResponseStore.ReadAsync(consentRequest.Id);
+
+            if (consent != null && consent.Data == null)
+            {
+                return await CreateErrorResultAsync("consent message is missing data");
+            }
+
+            try
+            {
+                var result = await ProcessAuthorizeRequestAsync(parameters, user, consent?.Data);
+
+                Logger.LogTrace("End Authorize Request. Result type: {0}", result?.GetType().ToString() ?? "-none-");
+
+                return result;
+            }
+            finally
+            {
+                if (consent != null)
+                {
+                    await this._consentResponseStore.DeleteAsync(consentRequest.Id);
+                }
+            }
+        }
+    }
+}

--- a/src/IdentityServer4/Endpoints/AuthorizeEndpoint.cs
+++ b/src/IdentityServer4/Endpoints/AuthorizeEndpoint.cs
@@ -1,80 +1,36 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
-using System.Threading.Tasks;
-using IdentityServer4.Extensions;
-using IdentityServer4.Validation;
-using IdentityServer4.ResponseHandling;
-using IdentityServer4.Services;
-using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Specialized;
 using System.Net;
-using System.Security.Claims;
-using IdentityServer4.Hosting;
-using IdentityServer4.Events;
-using IdentityServer4.Models;
+using System.Threading.Tasks;
 using IdentityServer4.Endpoints.Results;
-using IdentityServer4.Stores;
-using IdentityModel;
+using IdentityServer4.Hosting;
+using IdentityServer4.ResponseHandling;
+using IdentityServer4.Services;
+using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Http;
-using IdentityServer4.Logging;
-using System;
+using Microsoft.Extensions.Logging;
 
 namespace IdentityServer4.Endpoints
 {
-    internal class AuthorizeEndpoint : IEndpointHandler
+    internal class AuthorizeEndpoint : AuthorizeEndpointBase
     {
-        private readonly IEventService _events;
-        private readonly ILogger _logger;
-        private readonly IAuthorizeRequestValidator _validator;
-        private readonly IAuthorizeInteractionResponseGenerator _interactionGenerator;
-        private readonly IConsentMessageStore _consentResponseStore;
-        private readonly IAuthorizeResponseGenerator _authorizeResponseGenerator;
-        private readonly IUserSession _userSession;
-
         public AuthorizeEndpoint(
-            IEventService events, 
-            ILogger<AuthorizeEndpoint> logger,
-            IAuthorizeRequestValidator validator,
-            IAuthorizeInteractionResponseGenerator interactionGenerator,
-            IConsentMessageStore consentResponseStore,
-            IAuthorizeResponseGenerator authorizeResponseGenerator,
-            IUserSession userSession)
+           IEventService events,
+           ILogger<AuthorizeEndpoint> logger,
+           IAuthorizeRequestValidator validator,
+           IAuthorizeInteractionResponseGenerator interactionGenerator,
+           IAuthorizeResponseGenerator authorizeResponseGenerator,
+           IUserSession userSession)
+            : base(events, logger, validator, interactionGenerator, authorizeResponseGenerator, userSession)
         {
-            _events = events;
-            _logger = logger;
-            _validator = validator;
-            _interactionGenerator = interactionGenerator;
-            _consentResponseStore = consentResponseStore;
-            _authorizeResponseGenerator = authorizeResponseGenerator;
-            _userSession = userSession;
         }
 
-        public async Task<IEndpointResult> ProcessAsync(HttpContext context)
+        public override async Task<IEndpointResult> ProcessAsync(HttpContext context)
         {
-            if (context.Request.Path == Constants.ProtocolRoutePaths.Authorize.EnsureLeadingSlash())
-            {
-                return await ProcessAuthorizeAsync(context);
-            }
-
-            if (context.Request.Method != "GET")
-            {
-                _logger.LogWarning("Invalid HTTP method for authorize endpoint.");
-                return new StatusCodeResult(HttpStatusCode.MethodNotAllowed);
-            }
-
-            if (context.Request.Path == Constants.ProtocolRoutePaths.AuthorizeCallback.EnsureLeadingSlash())
-            {
-                return await ProcessAuthorizeCallbackAsync(context);
-            }
-
-            return new StatusCodeResult(HttpStatusCode.NotFound);
-        }
-
-        private async Task<IEndpointResult> ProcessAuthorizeAsync(HttpContext context)
-        {
-            _logger.LogDebug("Start authorize request");
+            Logger.LogDebug("Start authorize request");
 
             NameValueCollection values;
 
@@ -96,174 +52,12 @@ namespace IdentityServer4.Endpoints
                 return new StatusCodeResult(HttpStatusCode.MethodNotAllowed);
             }
 
-            var user = await _userSession.GetUserAsync();
+            var user = await UserSession.GetUserAsync();
             var result = await ProcessAuthorizeRequestAsync(values, user, null);
 
-            _logger.LogTrace("End authorize request. result type: {0}", result?.GetType().ToString() ?? "-none-");
+            Logger.LogTrace("End authorize request. result type: {0}", result?.GetType().ToString() ?? "-none-");
 
             return result;
-        }
-
-        internal async Task<IEndpointResult> ProcessAuthorizeCallbackAsync(HttpContext context)
-        {
-            _logger.LogDebug("Start authorize callback request");
-
-            var parameters = context.Request.Query.AsNameValueCollection();
-
-            var user = await _userSession.GetUserAsync();
-            var consentRequest = new ConsentRequest(parameters, user?.GetSubjectId());
-            var consent = await _consentResponseStore.ReadAsync(consentRequest.Id);
-
-            if (consent != null && consent.Data == null)
-            {
-                return await CreateErrorResultAsync("consent message is missing data");
-            }
-
-            try
-            {
-                var result = await ProcessAuthorizeRequestAsync(parameters, user, consent?.Data);
-
-                _logger.LogTrace("End Authorize Request. Result type: {0}", result?.GetType().ToString() ?? "-none-");
-
-                return result;
-            }
-            finally
-            {
-                if (consent != null)
-                {
-                    await _consentResponseStore.DeleteAsync(consentRequest.Id);
-                }
-            }
-        }
-        
-        internal async Task<IEndpointResult> ProcessAuthorizeRequestAsync(NameValueCollection parameters, ClaimsPrincipal user, ConsentResponse consent)
-        {
-            if (user != null)
-            {
-                _logger.LogDebug("User in authorize request: {subjectId}", user.GetSubjectId());
-            }
-            else
-            {
-                _logger.LogDebug("No user present in authorize request");
-            }
-
-            // validate request
-            var result = await _validator.ValidateAsync(parameters, user);
-            if (result.IsError)
-            {
-                return await CreateErrorResultAsync(
-                    "Request validation failed",
-                    result.ValidatedRequest,
-                    result.Error,
-                    result.ErrorDescription);
-            }
-
-            var request = result.ValidatedRequest;
-            LogRequest(request);
-
-            // determine user interaction
-            var interactionResult = await _interactionGenerator.ProcessInteractionAsync(request, consent);
-            if (interactionResult.IsError)
-            {
-                return await CreateErrorResultAsync("Interaction generator error", request, interactionResult.Error, logError: false);
-            }
-            if (interactionResult.IsLogin)
-            {
-                return new LoginPageResult(request);
-            }
-            if (interactionResult.IsConsent)
-            {
-                return new ConsentPageResult(request);
-            }
-            if (interactionResult.IsRedirect)
-            {
-                return new CustomRedirectResult(request, interactionResult.RedirectUrl);
-            }
-
-            var response = await _authorizeResponseGenerator.CreateResponseAsync(request);
-
-            await RaiseResponseEventAsync(response);
-
-            LogResponse(response);
-            
-            return new AuthorizeResult(response);
-        }
-
-        private void LogRequest(ValidatedAuthorizeRequest request)
-        {
-            var details = new AuthorizeRequestValidationLog(request);
-            _logger.LogInformation("ValidatedAuthorizeRequest" + Environment.NewLine + "{validationDetails}", details);
-        }
-
-        private void LogResponse(AuthorizeResponse response)
-        {
-            var details = new AuthorizeResponseLog(response);
-            _logger.LogInformation("Authorize endpoint response" + Environment.NewLine + "{response}", details);
-        }
-
-        private async Task<IEndpointResult> CreateErrorResultAsync(
-            string logMessage,
-            ValidatedAuthorizeRequest request = null, 
-            string error = OidcConstants.AuthorizeErrors.ServerError, 
-            string errorDescription = null, 
-            bool logError = true)
-        {
-            if (logError)
-            {
-                _logger.LogError(logMessage);
-            }
-
-            if (request != null)
-            {
-                var details = new AuthorizeRequestValidationLog(request);
-                _logger.LogInformation("{validationDetails}", details);
-            }
-
-            // TODO: should we raise a token failure event for all errors to the authorize endpoint?
-            await RaiseFailureEventAsync(request, error, errorDescription);
-
-            return new AuthorizeResult(new AuthorizeResponse {
-                Request = request,
-                Error = error,
-                ErrorDescription = errorDescription
-            });
-        }
-
-        private Task RaiseResponseEventAsync(AuthorizeResponse response)
-        {
-            if (!response.IsError)
-            {
-                LogTokens(response);
-                return _events.RaiseAsync(new TokenIssuedSuccessEvent(response));
-            }
-            else
-            {
-                return RaiseFailureEventAsync(response.Request, response.Error, response.ErrorDescription);
-            }
-        }
-
-        private Task RaiseFailureEventAsync(ValidatedAuthorizeRequest request, string error, string errorDescription)
-        {
-            return _events.RaiseAsync(new TokenIssuedFailureEvent(request, error, errorDescription));
-        }
-
-        private void LogTokens(AuthorizeResponse response)
-        {
-            var clientId = $"{response.Request.ClientId} ({response.Request.Client.ClientName ?? "no name set"})";
-            var subjectId = response.Request.Subject.GetSubjectId();
-
-            if (response.IdentityToken != null)
-            {
-                _logger.LogTrace("Identity token issued for {clientId} / {subjectId}: {token}", clientId, subjectId, response.IdentityToken);
-            }
-            if (response.Code != null)
-            {
-                _logger.LogTrace("Code issued for {clientId} / {subjectId}: {token}", clientId, subjectId, response.Code);
-            }
-            if (response.AccessToken != null)
-            {
-                _logger.LogTrace("Access token issued for {clientId} / {subjectId}: {token}", clientId, subjectId, response.AccessToken);
-            }
         }
     }
 }

--- a/src/IdentityServer4/Endpoints/AuthorizeEndpointBase.cs
+++ b/src/IdentityServer4/Endpoints/AuthorizeEndpointBase.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Specialized;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using IdentityModel;
+using IdentityServer4.Endpoints.Results;
+using IdentityServer4.Events;
+using IdentityServer4.Extensions;
+using IdentityServer4.Hosting;
+using IdentityServer4.Logging;
+using IdentityServer4.Models;
+using IdentityServer4.ResponseHandling;
+using IdentityServer4.Services;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace IdentityServer4.Endpoints
+{
+    internal abstract class AuthorizeEndpointBase : IEndpointHandler
+    {
+        private readonly IAuthorizeResponseGenerator _authorizeResponseGenerator;
+
+        private readonly IEventService _events;
+
+        private readonly IAuthorizeInteractionResponseGenerator _interactionGenerator;
+
+        private readonly IAuthorizeRequestValidator _validator;
+
+        protected AuthorizeEndpointBase(
+            IEventService events,
+            ILogger<AuthorizeEndpointBase> logger,
+            IAuthorizeRequestValidator validator,
+            IAuthorizeInteractionResponseGenerator interactionGenerator,
+            IAuthorizeResponseGenerator authorizeResponseGenerator,
+            IUserSession userSession)
+        {
+            this._events = events;
+            this.Logger = logger;
+            this._validator = validator;
+            this._interactionGenerator = interactionGenerator;
+            this._authorizeResponseGenerator = authorizeResponseGenerator;
+            this.UserSession = userSession;
+        }
+
+        protected ILogger Logger { get; private set; }
+
+        protected IUserSession UserSession { get; private set; }
+
+        public abstract Task<IEndpointResult> ProcessAsync(HttpContext context);
+
+        internal async Task<IEndpointResult> ProcessAuthorizeRequestAsync(NameValueCollection parameters, ClaimsPrincipal user, ConsentResponse consent)
+        {
+            if (user != null)
+            {
+                this.Logger.LogDebug("User in authorize request: {subjectId}", user.GetSubjectId());
+            }
+            else
+            {
+                this.Logger.LogDebug("No user present in authorize request");
+            }
+
+            // validate request
+            var result = await this._validator.ValidateAsync(parameters, user);
+            if (result.IsError)
+            {
+                return await this.CreateErrorResultAsync(
+                    "Request validation failed",
+                    result.ValidatedRequest,
+                    result.Error,
+                    result.ErrorDescription);
+            }
+
+            var request = result.ValidatedRequest;
+            this.LogRequest(request);
+
+            // determine user interaction
+            var interactionResult = await this._interactionGenerator.ProcessInteractionAsync(request, consent);
+            if (interactionResult.IsError)
+            {
+                return await this.CreateErrorResultAsync("Interaction generator error", request, interactionResult.Error, logError: false);
+            }
+            if (interactionResult.IsLogin)
+            {
+                return new LoginPageResult(request);
+            }
+            if (interactionResult.IsConsent)
+            {
+                return new ConsentPageResult(request);
+            }
+            if (interactionResult.IsRedirect)
+            {
+                return new CustomRedirectResult(request, interactionResult.RedirectUrl);
+            }
+
+            var response = await this._authorizeResponseGenerator.CreateResponseAsync(request);
+
+            await this.RaiseResponseEventAsync(response);
+
+            this.LogResponse(response);
+
+            return new AuthorizeResult(response);
+        }
+
+        protected async Task<IEndpointResult> CreateErrorResultAsync(
+            string logMessage,
+            ValidatedAuthorizeRequest request = null,
+            string error = OidcConstants.AuthorizeErrors.ServerError,
+            string errorDescription = null,
+            bool logError = true)
+        {
+            if (logError)
+            {
+                this.Logger.LogError(logMessage);
+            }
+
+            if (request != null)
+            {
+                var details = new AuthorizeRequestValidationLog(request);
+                this.Logger.LogInformation("{validationDetails}", details);
+            }
+
+            // TODO: should we raise a token failure event for all errors to the authorize endpoint?
+            await this.RaiseFailureEventAsync(request, error, errorDescription);
+
+            return new AuthorizeResult(new AuthorizeResponse
+            {
+                Request = request,
+                Error = error,
+                ErrorDescription = errorDescription
+            });
+        }
+
+        private void LogRequest(ValidatedAuthorizeRequest request)
+        {
+            var details = new AuthorizeRequestValidationLog(request);
+            this.Logger.LogInformation(nameof(ValidatedAuthorizeRequest) + Environment.NewLine + "{validationDetails}", details);
+        }
+
+        private void LogResponse(AuthorizeResponse response)
+        {
+            var details = new AuthorizeResponseLog(response);
+            this.Logger.LogInformation("Authorize endpoint response" + Environment.NewLine + "{response}", details);
+        }
+
+        private void LogTokens(AuthorizeResponse response)
+        {
+            var clientId = $"{response.Request.ClientId} ({response.Request.Client.ClientName ?? "no name set"})";
+            var subjectId = response.Request.Subject.GetSubjectId();
+
+            if (response.IdentityToken != null)
+            {
+                this.Logger.LogTrace("Identity token issued for {clientId} / {subjectId}: {token}", clientId, subjectId, response.IdentityToken);
+            }
+            if (response.Code != null)
+            {
+                this.Logger.LogTrace("Code issued for {clientId} / {subjectId}: {token}", clientId, subjectId, response.Code);
+            }
+            if (response.AccessToken != null)
+            {
+                this.Logger.LogTrace("Access token issued for {clientId} / {subjectId}: {token}", clientId, subjectId, response.AccessToken);
+            }
+        }
+
+        private Task RaiseFailureEventAsync(ValidatedAuthorizeRequest request, string error, string errorDescription)
+        {
+            return this._events.RaiseAsync(new TokenIssuedFailureEvent(request, error, errorDescription));
+        }
+
+        private Task RaiseResponseEventAsync(AuthorizeResponse response)
+        {
+            if (!response.IsError)
+            {
+                this.LogTokens(response);
+                return this._events.RaiseAsync(new TokenIssuedSuccessEvent(response));
+            }
+            else
+            {
+                return this.RaiseFailureEventAsync(response.Request, response.Error, response.ErrorDescription);
+            }
+        }
+    }
+}

--- a/src/IdentityServer4/Endpoints/EndSessionCallbackEndpoint.cs
+++ b/src/IdentityServer4/Endpoints/EndSessionCallbackEndpoint.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Net;
+using System.Threading.Tasks;
+using IdentityServer4.Endpoints.Results;
+using IdentityServer4.Hosting;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace IdentityServer4.Endpoints
+{
+    internal class EndSessionCallbackEndpoint : IEndpointHandler
+    {
+        private readonly IEndSessionRequestValidator _endSessionRequestValidator;
+
+        private readonly ILogger _logger;
+
+        public EndSessionCallbackEndpoint(
+            IEndSessionRequestValidator endSessionRequestValidator,
+            ILogger<EndSessionCallbackEndpoint> logger)
+        {
+            this._endSessionRequestValidator = endSessionRequestValidator;
+            this._logger = logger;
+        }
+
+        public async Task<IEndpointResult> ProcessAsync(HttpContext context)
+        {
+            if (context.Request.Method != "GET")
+            {
+                this._logger.LogWarning("Invalid HTTP method for end session callback endpoint.");
+                return new StatusCodeResult(HttpStatusCode.MethodNotAllowed);
+            }
+
+            this._logger.LogDebug("Processing signout callback request");
+
+            var parameters = context.Request.Query.AsNameValueCollection();
+            var result = await this._endSessionRequestValidator.ValidateCallbackAsync(parameters);
+
+            if (result.IsError == false)
+            {
+                this._logger.LogInformation("Successful signout callback. Client logout iframe urls: {urls}", result.FrontChannelLogoutUrls);
+            }
+
+            return new EndSessionCallbackResult(result);
+        }
+    }
+}

--- a/src/IdentityServer4/Endpoints/EndSessionEndpoint.cs
+++ b/src/IdentityServer4/Endpoints/EndSessionEndpoint.cs
@@ -1,24 +1,25 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
+using System.Collections.Specialized;
+using System.Net;
+using System.Threading.Tasks;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
-using Microsoft.Extensions.Logging;
-using System.Net;
-using System.Threading.Tasks;
-using System.Collections.Specialized;
+using IdentityServer4.Services;
 using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Http;
-using IdentityServer4.Services;
+using Microsoft.Extensions.Logging;
 
 namespace IdentityServer4.Endpoints
 {
     internal class EndSessionEndpoint : IEndpointHandler
     {
         private readonly IEndSessionRequestValidator _endSessionRequestValidator;
+
         private readonly ILogger _logger;
+
         private readonly IUserSession _userSession;
 
         public EndSessionEndpoint(
@@ -26,28 +27,12 @@ namespace IdentityServer4.Endpoints
             IUserSession userSession,
             ILogger<EndSessionEndpoint> logger)
         {
-            _endSessionRequestValidator = endSessionRequestValidator;
-            _userSession = userSession;
-            _logger = logger;
+            this._endSessionRequestValidator = endSessionRequestValidator;
+            this._userSession = userSession;
+            this._logger = logger;
         }
 
         public async Task<IEndpointResult> ProcessAsync(HttpContext context)
-        {
-            if (context.Request.Path == Constants.ProtocolRoutePaths.EndSession.EnsureLeadingSlash())
-            {
-                return await ProcessSignoutAsync(context);
-            }
-
-            if (context.Request.Path == Constants.ProtocolRoutePaths.EndSessionCallback.EnsureLeadingSlash())
-            {
-                return await ProcessSignoutCallbackAsync(context);
-            }
-
-            _logger.LogWarning("Invalid request path to end session endpoint");
-            return new StatusCodeResult(HttpStatusCode.NotFound);
-        }
-
-        private async Task<IEndpointResult> ProcessSignoutAsync(HttpContext context)
         {
             NameValueCollection parameters;
             if (context.Request.Method == "GET")
@@ -60,47 +45,26 @@ namespace IdentityServer4.Endpoints
             }
             else
             {
-                _logger.LogWarning("Invalid HTTP method for end session endpoint.");
+                this._logger.LogWarning("Invalid HTTP method for end session endpoint.");
                 return new StatusCodeResult(HttpStatusCode.MethodNotAllowed);
             }
 
-            var user = await _userSession.GetUserAsync();
+            var user = await this._userSession.GetUserAsync();
 
-            _logger.LogDebug("Processing signout request for {subjectId}", user?.GetSubjectId() ?? "anonymous");
+            this._logger.LogDebug("Processing signout request for {subjectId}", user?.GetSubjectId() ?? "anonymous");
 
-            var result = await _endSessionRequestValidator.ValidateAsync(parameters, user);
-            
+            var result = await this._endSessionRequestValidator.ValidateAsync(parameters, user);
+
             if (result.IsError)
             {
-                _logger.LogError("Error processing end session request {error}", result.Error);
+                this._logger.LogError("Error processing end session request {error}", result.Error);
             }
             else
             {
-                _logger.LogDebug("Success validating end session request from {clientId}", result.ValidatedRequest?.Client?.ClientId);
+                this._logger.LogDebug("Success validating end session request from {clientId}", result.ValidatedRequest?.Client?.ClientId);
             }
 
             return new EndSessionResult(result);
-        }
-
-        private async Task<IEndpointResult> ProcessSignoutCallbackAsync(HttpContext context)
-        {
-            if (context.Request.Method != "GET")
-            {
-                _logger.LogWarning("Invalid HTTP method for end session callback endpoint.");
-                return new StatusCodeResult(HttpStatusCode.MethodNotAllowed);
-            }
-
-            _logger.LogDebug("Processing signout callback request");
-
-            var parameters = context.Request.Query.AsNameValueCollection();
-            var result = await _endSessionRequestValidator.ValidateCallbackAsync(parameters);
-
-            if (result.IsError == false)
-            {
-                _logger.LogInformation("Successful signout callback. Client logout iframe urls: {urls}", result.FrontChannelLogoutUrls);
-            }
-
-            return new EndSessionCallbackResult(result);
         }
     }
 }

--- a/src/IdentityServer4/Hosting/EndpointRouter.cs
+++ b/src/IdentityServer4/Hosting/EndpointRouter.cs
@@ -31,7 +31,7 @@ namespace IdentityServer4.Hosting
             foreach(var endpoint in _endpoints)
             {
                 var path = endpoint.Path;
-                if (context.Request.Path.StartsWithSegments(path))
+                if (context.Request.Path.Equals(path, StringComparison.OrdinalIgnoreCase))
                 {
                     var endpointName = endpoint.Name;
                     _logger.LogDebug("Request path {path} matched to endpoint type {endpoint}", context.Request.Path, endpointName);

--- a/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeCallbackEndpointTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeCallbackEndpointTests.cs
@@ -1,0 +1,234 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Specialized;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Endpoints;
+using IdentityServer4.Endpoints.Results;
+using IdentityServer4.Extensions;
+using IdentityServer4.Models;
+using IdentityServer4.UnitTests.Common;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace IdentityServer4.UnitTests.Endpoints.Authorize
+{
+    public class AuthorizeCallbackEndpointTests
+    {
+        private const string Category = "Authorize Endpoint";
+
+        private HttpContext _context;
+
+        private TestEventService _fakeEventService = new TestEventService();
+
+        private ILogger<AuthorizeCallbackEndpoint> _fakeLogger = TestLogger.Create<AuthorizeCallbackEndpoint>();
+
+        private MockConsentMessageStore _mockUserConsentResponseMessageStore = new MockConsentMessageStore();
+
+        private MockUserSession _mockUserSession = new MockUserSession();
+
+        private NameValueCollection _params = new NameValueCollection();
+
+        private StubAuthorizeRequestValidator _stubAuthorizeRequestValidator = new StubAuthorizeRequestValidator();
+
+        private StubAuthorizeResponseGenerator _stubAuthorizeResponseGenerator = new StubAuthorizeResponseGenerator();
+
+        private StubAuthorizeInteractionResponseGenerator _stubInteractionGenerator = new StubAuthorizeInteractionResponseGenerator();
+
+        private AuthorizeCallbackEndpoint _subject;
+
+        private ClaimsPrincipal _user = IdentityServerPrincipal.Create("bob", "Bob Loblaw");
+
+        private ValidatedAuthorizeRequest _validatedAuthorizeRequest;
+
+        public AuthorizeCallbackEndpointTests()
+        {
+            this.Init();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_authorize_after_consent_path_should_return_authorization_result()
+        {
+            var parameters = new NameValueCollection()
+            {
+                { "client_id", "client" },
+                { "nonce", "some_nonce" },
+                { "scope", "api1 api2" }
+            };
+            var request = new ConsentRequest(parameters, this._user.GetSubjectId());
+            this._mockUserConsentResponseMessageStore.Messages.Add(request.Id, new Message<ConsentResponse>(new ConsentResponse()));
+
+            this._mockUserSession.User = this._user;
+
+            this._context.Request.Method = "GET";
+            this._context.Request.Path = new PathString("/connect/authorize/callback");
+            this._context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            result.Should().BeOfType<AuthorizeResult>();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_authorize_after_login_path_should_return_authorization_result()
+        {
+            this._context.Request.Method = "GET";
+            this._context.Request.Path = new PathString("/connect/authorize/callback");
+            this._mockUserSession.User = this._user;
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            result.Should().BeOfType<AuthorizeResult>();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_consent_missing_consent_data_should_return_error_page()
+        {
+            var parameters = new NameValueCollection()
+            {
+                { "client_id", "client" },
+                { "nonce", "some_nonce" },
+                { "scope", "api1 api2" }
+            };
+            var request = new ConsentRequest(parameters, this._user.GetSubjectId());
+            this._mockUserConsentResponseMessageStore.Messages.Add(request.Id, new Message<ConsentResponse>(null));
+
+            this._mockUserSession.User = this._user;
+
+            this._context.Request.Method = "GET";
+            this._context.Request.Path = new PathString("/connect/authorize/callback");
+            this._context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            result.Should().BeOfType<AuthorizeResult>();
+            ((AuthorizeResult)result).Response.IsError.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_no_consent_message_should_return_redirect_for_consent()
+        {
+            this._stubInteractionGenerator.Response.IsConsent = true;
+
+            var parameters = new NameValueCollection()
+            {
+                { "client_id", "client" },
+                { "nonce", "some_nonce" },
+                { "scope", "api1 api2" }
+            };
+            var request = new ConsentRequest(parameters, this._user.GetSubjectId());
+            this._mockUserConsentResponseMessageStore.Messages.Add(request.Id, null);
+
+            this._mockUserSession.User = this._user;
+
+            this._context.Request.Method = "GET";
+            this._context.Request.Path = new PathString("/connect/authorize/callback");
+            this._context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            result.Should().BeOfType<ConsentPageResult>();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_post_to_entry_point_should_return_405()
+        {
+            this._context.Request.Method = "POST";
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            var statusCode = result as StatusCodeResult;
+            statusCode.Should().NotBeNull();
+            statusCode.StatusCode.Should().Be(405);
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_valid_consent_message_should_cleanup_consent_cookie()
+        {
+            var parameters = new NameValueCollection()
+            {
+                { "client_id", "client" },
+                { "nonce", "some_nonce" },
+                { "scope", "api1 api2" }
+            };
+            var request = new ConsentRequest(parameters, this._user.GetSubjectId());
+            this._mockUserConsentResponseMessageStore.Messages.Add(request.Id, new Message<ConsentResponse>(new ConsentResponse() { ScopesConsented = new string[] { "api1", "api2" } }));
+
+            this._mockUserSession.User = this._user;
+
+            this._context.Request.Method = "GET";
+            this._context.Request.Path = new PathString("/connect/authorize/callback");
+            this._context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            this._mockUserConsentResponseMessageStore.Messages.Count.Should().Be(0);
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_valid_consent_message_should_return_authorize_result()
+        {
+            var parameters = new NameValueCollection()
+            {
+                { "client_id", "client" },
+                { "nonce", "some_nonce" },
+                { "scope", "api1 api2" }
+            };
+            var request = new ConsentRequest(parameters, this._user.GetSubjectId());
+            this._mockUserConsentResponseMessageStore.Messages.Add(request.Id, new Message<ConsentResponse>(new ConsentResponse() { ScopesConsented = new string[] { "api1", "api2" } }));
+
+            this._mockUserSession.User = this._user;
+
+            this._context.Request.Method = "GET";
+            this._context.Request.Path = new PathString("/connect/authorize/callback");
+            this._context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            result.Should().BeOfType<AuthorizeResult>();
+        }
+
+        internal void Init()
+        {
+            this._context = new MockHttpContextAccessor().HttpContext;
+
+            this._validatedAuthorizeRequest = new ValidatedAuthorizeRequest()
+            {
+                RedirectUri = "http://client/callback",
+                State = "123",
+                ResponseMode = "fragment",
+                ClientId = "client",
+                Client = new Client
+                {
+                    ClientId = "client",
+                    ClientName = "Test Client"
+                },
+                Raw = this._params,
+                Subject = this._user
+            };
+            this._stubAuthorizeResponseGenerator.Response.Request = this._validatedAuthorizeRequest;
+
+            this._stubAuthorizeRequestValidator.Result = new AuthorizeRequestValidationResult(this._validatedAuthorizeRequest);
+
+            this._subject = new AuthorizeCallbackEndpoint(
+                this._fakeEventService,
+                this._fakeLogger,
+                this._stubAuthorizeRequestValidator,
+                this._stubInteractionGenerator,
+                this._stubAuthorizeResponseGenerator,
+                this._mockUserSession,
+                this._mockUserConsentResponseMessageStore);
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Specialized;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Endpoints;
+using IdentityServer4.Endpoints.Results;
+using IdentityServer4.Hosting;
+using IdentityServer4.Models;
+using IdentityServer4.ResponseHandling;
+using IdentityServer4.Services;
+using IdentityServer4.UnitTests.Common;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace IdentityServer4.UnitTests.Endpoints.Authorize
+{
+    public class AuthorizeEndpointBaseTests
+    {
+        private const string Category = "Authorize Endpoint";
+
+        private HttpContext _context;
+
+        private TestEventService _fakeEventService = new TestEventService();
+
+        private ILogger<TestAuthorizeEndpoint> _fakeLogger = TestLogger.Create<TestAuthorizeEndpoint>();
+
+        private MockUserSession _mockUserSession = new MockUserSession();
+
+        private NameValueCollection _params = new NameValueCollection();
+
+        private StubAuthorizeRequestValidator _stubAuthorizeRequestValidator = new StubAuthorizeRequestValidator();
+
+        private StubAuthorizeResponseGenerator _stubAuthorizeResponseGenerator = new StubAuthorizeResponseGenerator();
+
+        private StubAuthorizeInteractionResponseGenerator _stubInteractionGenerator = new StubAuthorizeInteractionResponseGenerator();
+
+        private TestAuthorizeEndpoint _subject;
+
+        private ClaimsPrincipal _user = IdentityServerPrincipal.Create("bob", "Bob Loblaw");
+
+        private ValidatedAuthorizeRequest _validatedAuthorizeRequest;
+
+        public AuthorizeEndpointBaseTests()
+        {
+            this.Init();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task authorize_request_validation_produces_error_should_display_error_page()
+        {
+            this._stubAuthorizeRequestValidator.Result.IsError = true;
+            this._stubAuthorizeRequestValidator.Result.Error = "some_error";
+
+            var result = await this._subject.ProcessAuthorizeRequestAsync(this._params, this._user, null);
+
+            result.Should().BeOfType<AuthorizeResult>();
+            ((AuthorizeResult)result).Response.IsError.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task interaction_generator_consent_produces_consent_should_show_consent_page()
+        {
+            this._stubInteractionGenerator.Response.IsConsent = true;
+
+            var result = await this._subject.ProcessAuthorizeRequestAsync(this._params, this._user, null);
+
+            result.Should().BeOfType<ConsentPageResult>();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task interaction_produces_error_should_show_error_page()
+        {
+            this._stubInteractionGenerator.Response.Error = "error";
+
+            var result = await this._subject.ProcessAuthorizeRequestAsync(this._params, this._user, null);
+
+            result.Should().BeOfType<AuthorizeResult>();
+            ((AuthorizeResult)result).Response.IsError.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task interaction_produces_login_result_should_trigger_login()
+        {
+            this._stubInteractionGenerator.Response.IsLogin = true;
+
+            var result = await this._subject.ProcessAuthorizeRequestAsync(this._params, this._user, null);
+
+            result.Should().BeOfType<LoginPageResult>();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAuthorizeRequestAsync_custom_interaction_redirect_result_should_issue_redirect()
+        {
+            this._mockUserSession.User = this._user;
+            this._stubInteractionGenerator.Response.RedirectUrl = "http://foo.com";
+
+            var result = await this._subject.ProcessAuthorizeRequestAsync(this._params, this._user, null);
+
+            result.Should().BeOfType<CustomRedirectResult>();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task successful_authorization_request_should_generate_authorize_result()
+        {
+            var result = await this._subject.ProcessAuthorizeRequestAsync(this._params, this._user, null);
+
+            result.Should().BeOfType<AuthorizeResult>();
+        }
+
+        internal void Init()
+        {
+            this._context = new MockHttpContextAccessor().HttpContext;
+
+            this._validatedAuthorizeRequest = new ValidatedAuthorizeRequest()
+            {
+                RedirectUri = "http://client/callback",
+                State = "123",
+                ResponseMode = "fragment",
+                ClientId = "client",
+                Client = new Client
+                {
+                    ClientId = "client",
+                    ClientName = "Test Client"
+                },
+                Raw = this._params,
+                Subject = this._user
+            };
+            this._stubAuthorizeResponseGenerator.Response.Request = this._validatedAuthorizeRequest;
+
+            this._stubAuthorizeRequestValidator.Result = new AuthorizeRequestValidationResult(this._validatedAuthorizeRequest);
+
+            this._subject = new TestAuthorizeEndpoint(
+                this._fakeEventService,
+                this._fakeLogger,
+                this._stubAuthorizeRequestValidator,
+                this._stubInteractionGenerator,
+                this._stubAuthorizeResponseGenerator,
+                this._mockUserSession);
+        }
+
+        internal class TestAuthorizeEndpoint : AuthorizeEndpointBase
+        {
+            public TestAuthorizeEndpoint(
+              IEventService events,
+              ILogger<TestAuthorizeEndpoint> logger,
+              IAuthorizeRequestValidator validator,
+              IAuthorizeInteractionResponseGenerator interactionGenerator,
+              IAuthorizeResponseGenerator authorizeResponseGenerator,
+              IUserSession userSession)
+            : base(events, logger, validator, interactionGenerator, authorizeResponseGenerator, userSession)
+            {
+            }
+
+            public override Task<IEndpointResult> ProcessAsync(HttpContext context)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointTests.cs
@@ -2,19 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using FluentAssertions;
-using IdentityServer4.Endpoints;
-using System.Threading.Tasks;
-using Xunit;
 using System.Collections.Specialized;
 using System.Security.Claims;
-using IdentityServer4.Validation;
-using Microsoft.Extensions.Logging;
-using IdentityServer4.Models;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Endpoints;
 using IdentityServer4.Endpoints.Results;
-using Microsoft.AspNetCore.Http;
-using IdentityServer4.Extensions;
+using IdentityServer4.Models;
 using IdentityServer4.UnitTests.Common;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
 
 namespace IdentityServer4.UnitTests.Endpoints.Authorize
 {
@@ -22,32 +21,64 @@ namespace IdentityServer4.UnitTests.Endpoints.Authorize
     {
         private const string Category = "Authorize Endpoint";
 
-        private AuthorizeEndpoint _subject;
-
-        private NameValueCollection _params = new NameValueCollection();
-        private ClaimsPrincipal _user = IdentityServerPrincipal.Create("bob", "Bob Loblaw");
-
         private HttpContext _context;
-        private ValidatedAuthorizeRequest _validatedAuthorizeRequest;
 
         private TestEventService _fakeEventService = new TestEventService();
+
         private ILogger<AuthorizeEndpoint> _fakeLogger = TestLogger.Create<AuthorizeEndpoint>();
-        private StubAuthorizeRequestValidator _stubAuthorizeRequestValidator = new StubAuthorizeRequestValidator();
-        private StubAuthorizeInteractionResponseGenerator _stubInteractionGenerator = new StubAuthorizeInteractionResponseGenerator();
-        private MockConsentMessageStore _mockUserConsentResponseMessageStore = new MockConsentMessageStore();
-        private StubAuthorizeResponseGenerator _stubAuthorizeResponseGenerator = new StubAuthorizeResponseGenerator();
+
         private MockUserSession _mockUserSession = new MockUserSession();
+
+        private NameValueCollection _params = new NameValueCollection();
+
+        private StubAuthorizeRequestValidator _stubAuthorizeRequestValidator = new StubAuthorizeRequestValidator();
+
+        private StubAuthorizeResponseGenerator _stubAuthorizeResponseGenerator = new StubAuthorizeResponseGenerator();
+
+        private StubAuthorizeInteractionResponseGenerator _stubInteractionGenerator = new StubAuthorizeInteractionResponseGenerator();
+
+        private AuthorizeEndpoint _subject;
+
+        private ClaimsPrincipal _user = IdentityServerPrincipal.Create("bob", "Bob Loblaw");
+
+        private ValidatedAuthorizeRequest _validatedAuthorizeRequest;
 
         public AuthorizeEndpointTests()
         {
-            Init();
+            this.Init();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_authorize_path_should_return_authorization_result()
+        {
+            this._context.Request.Method = "GET";
+            this._context.Request.Path = new PathString("/connect/authorize");
+            this._mockUserSession.User = this._user;
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            result.Should().BeOfType<AuthorizeResult>();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task ProcessAsync_post_without_form_content_type_should_return_415()
+        {
+            this._context.Request.Method = "POST";
+
+            var result = await this._subject.ProcessAsync(this._context);
+
+            var statusCode = result as StatusCodeResult;
+            statusCode.Should().NotBeNull();
+            statusCode.StatusCode.Should().Be(415);
         }
 
         internal void Init()
         {
-            _context = new MockHttpContextAccessor().HttpContext;
+            this._context = new MockHttpContextAccessor().HttpContext;
 
-            _validatedAuthorizeRequest = new ValidatedAuthorizeRequest()
+            this._validatedAuthorizeRequest = new ValidatedAuthorizeRequest()
             {
                 RedirectUri = "http://client/callback",
                 State = "123",
@@ -58,279 +89,20 @@ namespace IdentityServer4.UnitTests.Endpoints.Authorize
                     ClientId = "client",
                     ClientName = "Test Client"
                 },
-                Raw = _params,
-                Subject = _user
+                Raw = this._params,
+                Subject = this._user
             };
-            _stubAuthorizeResponseGenerator.Response.Request = _validatedAuthorizeRequest;
+            this._stubAuthorizeResponseGenerator.Response.Request = this._validatedAuthorizeRequest;
 
-            _stubAuthorizeRequestValidator.Result = new AuthorizeRequestValidationResult(_validatedAuthorizeRequest);
+            this._stubAuthorizeRequestValidator.Result = new AuthorizeRequestValidationResult(this._validatedAuthorizeRequest);
 
-            _subject = new AuthorizeEndpoint(
-                _fakeEventService,
-                _fakeLogger,
-                _stubAuthorizeRequestValidator,
-                _stubInteractionGenerator,
-                _mockUserConsentResponseMessageStore,
-                _stubAuthorizeResponseGenerator, 
-                _mockUserSession);
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAsync_post_to_entry_point_should_return_405()
-        {
-            _context.Request.Method = "POST";
-
-            var result = await _subject.ProcessAsync(_context);
-
-            var statusCode = result as StatusCodeResult;
-            statusCode.Should().NotBeNull();
-            statusCode.StatusCode.Should().Be(405);
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAsync_invalid_path_should_return_404()
-        {
-            _context.Request.Method = "GET";
-            _context.Request.Path = new PathString("/foo");
-
-            var result = await _subject.ProcessAsync(_context);
-
-            var statusCode = result as StatusCodeResult;
-            statusCode.Should().NotBeNull();
-            statusCode.StatusCode.Should().Be(404);
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAsync_authorize_path_should_return_authorization_result()
-        {
-            _context.Request.Method = "GET";
-            _context.Request.Path = new PathString("/connect/authorize");
-            _mockUserSession.User = _user;
-
-            var result = await _subject.ProcessAsync(_context);
-
-            result.Should().BeOfType<AuthorizeResult>();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAsync_authorize_after_login_path_should_return_authorization_result()
-        {
-            _context.Request.Method = "GET";
-            _context.Request.Path = new PathString("/connect/authorize/callback");
-            _mockUserSession.User = _user;
-
-            var result = await _subject.ProcessAsync(_context);
-
-            result.Should().BeOfType<AuthorizeResult>();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAsync_authorize_after_consent_path_should_return_authorization_result()
-        {
-            var parameters = new NameValueCollection()
-            {
-                { "client_id", "client" },
-                { "nonce", "some_nonce" },
-                { "scope", "api1 api2" }
-            };
-            var request = new ConsentRequest(parameters, _user.GetSubjectId());
-            _mockUserConsentResponseMessageStore.Messages.Add(request.Id, new Message<ConsentResponse>(new ConsentResponse()));
-
-            _mockUserSession.User = _user;
-
-            _context.Request.Method = "GET";
-            _context.Request.Path = new PathString("/connect/authorize/callback");
-            _context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
-
-            var result = await _subject.ProcessAsync(_context);
-
-            result.Should().BeOfType<AuthorizeResult>();
-        }
-
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task authorize_request_validation_produces_error_should_display_error_page()
-        {
-            _stubAuthorizeRequestValidator.Result.IsError = true;
-            _stubAuthorizeRequestValidator.Result.Error = "some_error";
-
-            var result = await _subject.ProcessAuthorizeRequestAsync(_params, _user, null);
-
-            result.Should().BeOfType<AuthorizeResult>();
-            ((AuthorizeResult)result).Response.IsError.Should().BeTrue();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task interaction_produces_error_should_show_error_page()
-        {
-            _stubInteractionGenerator.Response.Error = "error";
-
-            var result = await _subject.ProcessAuthorizeRequestAsync(_params, _user, null);
-
-            result.Should().BeOfType<AuthorizeResult>();
-            ((AuthorizeResult)result).Response.IsError.Should().BeTrue();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task interaction_produces_login_result_should_trigger_login()
-        {
-            _stubInteractionGenerator.Response.IsLogin = true;
-
-            var result = await _subject.ProcessAuthorizeRequestAsync(_params, _user, null);
-
-            result.Should().BeOfType<LoginPageResult>();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task interaction_generator_consent_produces_consent_should_show_consent_page()
-        {
-            _stubInteractionGenerator.Response.IsConsent = true;
-
-            var result = await _subject.ProcessAuthorizeRequestAsync(_params, _user, null);
-
-            result.Should().BeOfType<ConsentPageResult>();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task successful_authorization_request_should_generate_authorize_result()
-        {
-            var result = await _subject.ProcessAuthorizeRequestAsync(_params, _user, null);
-
-            result.Should().BeOfType<AuthorizeResult>();
-        }
-
-        // after login
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAuthorizeAfterLoginAsync_no_user_should_trigger_login()
-        {
-            _stubInteractionGenerator.Response.IsLogin = true;
-            _mockUserSession.User = null;
-
-            var result = await _subject.ProcessAuthorizeCallbackAsync(_context);
-
-            result.Should().BeOfType<LoginPageResult>();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAuthorizeWithConsentAsync_no_consent_message_should_return_redirect_for_consent()
-        {
-            _stubInteractionGenerator.Response.IsConsent = true;
-
-            var parameters = new NameValueCollection()
-            {
-                { "client_id", "client" },
-                { "nonce", "some_nonce" },
-                { "scope", "api1 api2" }
-            };
-            var request = new ConsentRequest(parameters, _user.GetSubjectId());
-            _mockUserConsentResponseMessageStore.Messages.Add(request.Id, null);
-
-            _mockUserSession.User = _user;
-
-            _context.Request.Method = "GET";
-            _context.Request.Path = new PathString("/connect/authorize/callback");
-            _context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
-
-            var result = await _subject.ProcessAuthorizeCallbackAsync(_context);
-
-            result.Should().BeOfType<ConsentPageResult>();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAuthorizeWithConsentAsync_consent_missing_consent_data_should_return_error_page()
-        {
-            var parameters = new NameValueCollection()
-            {
-                { "client_id", "client" },
-                { "nonce", "some_nonce" },
-                { "scope", "api1 api2" }
-            };
-            var request = new ConsentRequest(parameters, _user.GetSubjectId());
-            _mockUserConsentResponseMessageStore.Messages.Add(request.Id, new Message<ConsentResponse>(null));
-
-            _mockUserSession.User = _user;
-
-            _context.Request.Method = "GET";
-            _context.Request.Path = new PathString("/connect/authorize/callback");
-            _context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
-
-            var result = await _subject.ProcessAuthorizeCallbackAsync(_context);
-
-            result.Should().BeOfType<AuthorizeResult>();
-            ((AuthorizeResult)result).Response.IsError.Should().BeTrue();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAuthorizeWithConsentAsync_valid_consent_message_should_return_authorize_result()
-        {
-            var parameters = new NameValueCollection()
-            {
-                { "client_id", "client" },
-                { "nonce", "some_nonce" },
-                { "scope", "api1 api2" }
-            };
-            var request = new ConsentRequest(parameters, _user.GetSubjectId());
-            _mockUserConsentResponseMessageStore.Messages.Add(request.Id, new Message<ConsentResponse>(new ConsentResponse() {ScopesConsented = new string[] { "api1", "api2" } }));
-
-            _mockUserSession.User = _user;
-
-            _context.Request.Method = "GET";
-            _context.Request.Path = new PathString("/connect/authorize/callback");
-            _context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
-
-            var result = await _subject.ProcessAuthorizeCallbackAsync(_context);
-
-            result.Should().BeOfType<AuthorizeResult>();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAuthorizeWithConsentAsync_valid_consent_message_should_cleanup_consent_cookie()
-        {
-            var parameters = new NameValueCollection()
-            {
-                { "client_id", "client" },
-                { "nonce", "some_nonce" },
-                { "scope", "api1 api2" }
-            };
-            var request = new ConsentRequest(parameters, _user.GetSubjectId());
-            _mockUserConsentResponseMessageStore.Messages.Add(request.Id, new Message<ConsentResponse>(new ConsentResponse() { ScopesConsented = new string[] { "api1", "api2" } }));
-
-            _mockUserSession.User = _user;
-
-            _context.Request.Method = "GET";
-            _context.Request.Path = new PathString("/connect/authorize/callback");
-            _context.Request.QueryString = new QueryString("?" + parameters.ToQueryString());
-
-            var result = await _subject.ProcessAuthorizeCallbackAsync(_context);
-
-            _mockUserConsentResponseMessageStore.Messages.Count.Should().Be(0);
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task ProcessAuthorizeRequestAsync_custom_interaction_redirect_result_should_issue_redirect()
-        {
-            _mockUserSession.User = _user;
-            _stubInteractionGenerator.Response.RedirectUrl = "http://foo.com";
-
-            var result = await _subject.ProcessAuthorizeRequestAsync(_params, _user, null);
-
-            result.Should().BeOfType<CustomRedirectResult>();
+            this._subject = new AuthorizeEndpoint(
+                this._fakeEventService,
+                this._fakeLogger,
+                this._stubAuthorizeRequestValidator,
+                this._stubInteractionGenerator,
+                this._stubAuthorizeResponseGenerator,
+                this._mockUserSession);
         }
     }
 }

--- a/test/IdentityServer.UnitTests/Hosting/EndpointRouterTests.cs
+++ b/test/IdentityServer.UnitTests/Hosting/EndpointRouterTests.cs
@@ -66,7 +66,7 @@ namespace IdentityServer4.UnitTests.Hosting
         }
 
         [Fact]
-        public void Find_should_find_nested_paths()
+        public void Find_should_not_find_nested_paths()
         {
             _endpoints.Add(new Endpoint("ep1", "/ep1", typeof(MyEndpointHandler)));
             _endpoints.Add(new Endpoint("ep2", "/ep2", typeof(MyOtherEndpointHandler)));
@@ -76,7 +76,7 @@ namespace IdentityServer4.UnitTests.Hosting
             ctx.RequestServices = new StubServiceProvider();
 
             var result = _subject.Find(ctx);
-            result.Should().BeOfType<MyEndpointHandler>();
+            result.Should().BeNull();
         }
 
         [Fact]


### PR DESCRIPTION
Addresses #1572:

- Split `/connect/authorize` endpoint from `/connect/authorize/callback`. Retains common code in abstract base class.
- Split `/connect/endsession` endpoint from `/connect/endsession/callback`. No common code was shared.

All tests were retained and still pass, though the `authorize` endpoint tests got split so they only run against the appropriate endpoint class.