### PR TITLE
Implemented PairWise Subject

### DIFF
--- a/IdentityServer4.v3.ncrunchsolution
+++ b/IdentityServer4.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddTransient<ITokenService, DefaultTokenService>();
             builder.Services.TryAddTransient<ITokenCreationService, DefaultTokenCreationService>();
             builder.Services.TryAddTransient<IClaimsService, DefaultClaimsService>();
+            builder.Services.TryAddTransient<IClientSubjectService, DefaultClientSubjectService>();
             builder.Services.TryAddTransient<IRefreshTokenService, DefaultRefreshTokenService>();
             builder.Services.TryAddTransient<IConsentService, DefaultConsentService>();
             builder.Services.TryAddTransient<ICorsPolicyService, DefaultCorsPolicyService>();

--- a/src/IdentityServer4/Constants.cs
+++ b/src/IdentityServer4/Constants.cs
@@ -88,7 +88,7 @@ namespace IdentityServer4
             OidcConstants.ResponseModes.Fragment
         };
 
-        public static string[] SupportedSubjectTypes =
+        public static readonly string[] SupportedSubjectTypes =
         {
             "pairwise", "public"
         };

--- a/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
@@ -241,7 +241,7 @@ namespace IdentityServer4.ResponseHandling
                 entries.Add(OidcConstants.Discovery.TokenEndpointAuthenticationMethodsSupported, SecretParsers.GetAvailableAuthenticationMethods().ToArray());
             }
 
-            entries.Add(OidcConstants.Discovery.SubjectTypesSupported, new[] { "public", "pairwise" });
+            entries.Add(OidcConstants.Discovery.SubjectTypesSupported, Constants.SupportedSubjectTypes);
             entries.Add(OidcConstants.Discovery.IdTokenSigningAlgorithmsSupported, new[] { Constants.SigningAlgorithms.RSA_SHA_256 });
             entries.Add(OidcConstants.Discovery.CodeChallengeMethodsSupported, new[] { OidcConstants.CodeChallengeMethods.Plain, OidcConstants.CodeChallengeMethods.Sha256 });
 

--- a/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/DiscoveryResponseGenerator.cs
@@ -241,7 +241,7 @@ namespace IdentityServer4.ResponseHandling
                 entries.Add(OidcConstants.Discovery.TokenEndpointAuthenticationMethodsSupported, SecretParsers.GetAvailableAuthenticationMethods().ToArray());
             }
 
-            entries.Add(OidcConstants.Discovery.SubjectTypesSupported, new[] { "public" });
+            entries.Add(OidcConstants.Discovery.SubjectTypesSupported, new[] { "public", "pairwise" });
             entries.Add(OidcConstants.Discovery.IdTokenSigningAlgorithmsSupported, new[] { Constants.SigningAlgorithms.RSA_SHA_256 });
             entries.Add(OidcConstants.Discovery.CodeChallengeMethodsSupported, new[] { OidcConstants.CodeChallengeMethods.Plain, OidcConstants.CodeChallengeMethods.Sha256 });
 

--- a/src/IdentityServer4/Services/DefaultClientSubjectService.cs
+++ b/src/IdentityServer4/Services/DefaultClientSubjectService.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using IdentityServer4.Models;
+
+namespace IdentityServer4.Services
+{
+    public class DefaultClientSubjectService : IClientSubjectService
+    {
+        public string CreateSubject(string userSubject, Client client)
+        {
+            if (userSubject == null) throw new ArgumentNullException(nameof(userSubject));
+            if (client == null) throw new ArgumentNullException(nameof(client));
+
+            if (string.IsNullOrWhiteSpace(client.PairWiseSubjectSalt))
+            {
+                return userSubject;
+            }
+            return (userSubject + client.PairWiseSubjectSalt).Sha256();
+        }
+
+        public bool ValidateSubject(string userSubject, string tokenSubject, Client client)
+        {
+            if (userSubject == null) throw new ArgumentNullException(nameof(userSubject));
+            if (tokenSubject == null) throw new ArgumentNullException(nameof(tokenSubject));
+            if (client == null) throw new ArgumentNullException(nameof(client));
+
+            userSubject = CreateSubject(userSubject, client);
+            return userSubject == tokenSubject;
+        }
+    }
+}

--- a/src/IdentityServer4/Services/Interfaces/IClientSubjectService.cs
+++ b/src/IdentityServer4/Services/Interfaces/IClientSubjectService.cs
@@ -1,0 +1,10 @@
+﻿using IdentityServer4.Models;
+
+namespace IdentityServer4.Services
+{
+    public interface IClientSubjectService
+    {
+        string CreateSubject(string userSubject, Client client);
+        bool ValidateSubject(string userSubject, string tokenSubject, Client client);
+    }
+}

--- a/src/IdentityServer4/Validation/EndSessionRequestValidator.cs
+++ b/src/IdentityServer4/Validation/EndSessionRequestValidator.cs
@@ -23,6 +23,7 @@ namespace IdentityServer4.Validation
     internal class EndSessionRequestValidator : IEndSessionRequestValidator
     {
         private readonly ILogger _logger;
+        private readonly IClientSubjectService _subjectService;
         private readonly IdentityServerOptions _options;
         private readonly ITokenValidator _tokenValidator;
         private readonly IRedirectUriValidator _uriValidator;
@@ -34,11 +35,12 @@ namespace IdentityServer4.Validation
         public EndSessionRequestValidator(
             IHttpContextAccessor context,
             IdentityServerOptions options,
-            ITokenValidator tokenValidator,
-            IRedirectUriValidator uriValidator,
+            ITokenValidator tokenValidator, 
+            IRedirectUriValidator uriValidator, 
             IUserSession userSession,
-            IClientStore clientStore,
+            IClientStore clientStore, 
             IMessageStore<EndSession> endSessionMessageStore,
+            IClientSubjectService subjectService, 
             ILogger<EndSessionRequestValidator> logger)
         {
             _context = context;
@@ -49,9 +51,11 @@ namespace IdentityServer4.Validation
             _clientStore = clientStore;
             _endSessionMessageStore = endSessionMessageStore;
             _logger = logger;
+            _subjectService = subjectService;
         }
 
-        public async Task<EndSessionValidationResult> ValidateAsync(NameValueCollection parameters, ClaimsPrincipal subject)
+        public async Task<EndSessionValidationResult> ValidateAsync(NameValueCollection parameters,
+            ClaimsPrincipal subject)
         {
             _logger.LogDebug("Start end session request validation");
 
@@ -96,7 +100,8 @@ namespace IdentityServer4.Validation
                 var redirectUri = parameters.Get(OidcConstants.EndSessionRequest.PostLogoutRedirectUri);
                 if (redirectUri.IsPresent())
                 {
-                    if (await _uriValidator.IsPostLogoutRedirectUriValidAsync(redirectUri, validatedRequest.Client) == false)
+                    if (await _uriValidator.IsPostLogoutRedirectUriValidAsync(redirectUri, validatedRequest.Client) ==
+                        false)
                     {
                         return Invalid("Invalid post logout URI", validatedRequest);
                     }
@@ -136,12 +141,7 @@ namespace IdentityServer4.Validation
 
         private bool SubjectIsInvalid(ClaimsPrincipal subject, Claim subjectClaim, Client client)
         {
-            if (string.IsNullOrWhiteSpace(client.PairWiseSubjectSalt))
-            {
-                return subjectClaim.Value != subject.GetSubjectId();
-            }
-            var pairwiseSubject = (subject.GetSubjectId() + client.PairWiseSubjectSalt).Sha256();
-            return subjectClaim.Value != pairwiseSubject;
+            return !_subjectService.ValidateSubject(subject.GetSubjectId(), subjectClaim.Value, client);
         }
 
         private EndSessionValidationResult Invalid(string message, ValidatedEndSessionRequest request = null)
@@ -192,7 +192,8 @@ namespace IdentityServer4.Validation
             return result;
         }
 
-        private async Task<(IEnumerable<string> frontChannel, IEnumerable<BackChannelLogoutModel> backChannel)> GetClientEndSessionUrlsAsync(EndSession endSession)
+        private async Task<(IEnumerable<string> frontChannel, IEnumerable<BackChannelLogoutModel> backChannel)>
+            GetClientEndSessionUrlsAsync(EndSession endSession)
         {
             var frontChannelUrls = new List<string>();
             var backChannelLogouts = new List<BackChannelLogoutModel>();
@@ -209,7 +210,8 @@ namespace IdentityServer4.Validation
                         if (client.FrontChannelLogoutSessionRequired)
                         {
                             url = url.AddQueryString(OidcConstants.EndSessionRequest.Sid, endSession.SessionId);
-                            url = url.AddQueryString(OidcConstants.EndSessionRequest.Issuer, _context.HttpContext.GetIdentityServerIssuerUri());
+                            url = url.AddQueryString(OidcConstants.EndSessionRequest.Issuer,
+                                _context.HttpContext.GetIdentityServerIssuerUri());
                         }
 
                         frontChannelUrls.Add(url);

--- a/src/IdentityServer4/Validation/TokenValidator.cs
+++ b/src/IdentityServer4/Validation/TokenValidator.cs
@@ -100,7 +100,6 @@ namespace IdentityServer4.Validation
             var result = await ValidateJwtAsync(token, clientId, keys, validateLifetime);
 
             result.Client = client;
-
             if (result.IsError)
             {
                 LogError("Error validating JWT");

--- a/test/IdentityServer.IntegrationTests/Clients/DiscoveryClient.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/DiscoveryClient.cs
@@ -46,6 +46,9 @@ namespace IdentityServer.IntegrationTests.Clients
 
             var doc = await client.GetAsync();
 
+            doc.SubjectTypesSupported.Count().Should().Be(2);
+
+            doc.SubjectTypesSupported.Should().Contain("public", "pairwise");
             // endpoints
             doc.TokenEndpoint.Should().Be("https://server/connect/token");
             doc.AuthorizeEndpoint.Should().Be("https://server/connect/authorize");

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -43,7 +43,8 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
                     RequireConsent = true,
                     AllowedScopes = new List<string> { "openid", "profile", "api1", "api2" },
                     RedirectUris = new List<string> { "https://client2/callback" },
-                    AllowAccessTokensViaBrowser = true
+                    AllowAccessTokensViaBrowser = true,
+                    PairWiseSubjectSalt = "saltclient2"
                 },
                 new Client
                 {

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
@@ -49,7 +49,9 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
                     AllowedScopes = new List<string> { "openid", "profile", "api1", "api2" },
                     RedirectUris = new List<string> { "https://client3/callback" },
                     AllowAccessTokensViaBrowser = true,
-                    IdentityProviderRestrictions = new List<string> { "google" }
+                    IdentityProviderRestrictions = new List<string> { "google" },
+                    PairWiseSubjectSalt = "saltclient3"
+
                 }
             });
 

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/RestrictAccessTokenViaBrowserTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/RestrictAccessTokenViaBrowserTests.cs
@@ -32,7 +32,9 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
                     RequireConsent = false,
                     AllowedScopes = new List<string> { "openid" },
                     RedirectUris = new List<string> { "https://client1/callback" },
-                    AllowAccessTokensViaBrowser = true
+                    AllowAccessTokensViaBrowser = true,
+                    PairWiseSubjectSalt = "saltclient1"
+
                 },
                 new Client
                 {

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/SessionIdTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/SessionIdTests.cs
@@ -38,7 +38,9 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
                     RequireConsent = true,
                     AllowedScopes = new List<string> { "openid", "profile", "api1", "api2" },
                     RedirectUris = new List<string> { "https://client2/callback" },
-                    AllowAccessTokensViaBrowser = true
+                    AllowAccessTokensViaBrowser = true,
+                    PairWiseSubjectSalt = "saltclient2"
+
                 }
             });
 

--- a/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
@@ -39,7 +39,8 @@ namespace IdentityServer4.IntegrationTests.Endpoints.EndSession
                 RedirectUris = new List<string> { "https://client1/callback" },
                 FrontChannelLogoutUri = "https://client1/signout",
                 PostLogoutRedirectUris = new List<string> { "https://client1/signout-callback" },
-                AllowAccessTokensViaBrowser = true
+                AllowAccessTokensViaBrowser = true,
+                PairWiseSubjectSalt = "pairWiseSalt"
             });
 
             _mockPipeline.Clients.Add(new Client
@@ -65,9 +66,11 @@ namespace IdentityServer4.IntegrationTests.Endpoints.EndSession
                 AllowedScopes = new List<string> { "openid" },
                 RedirectUris = new List<string> { "https://client3/callback" },
                 BackChannelLogoutUri = "https://client3/signout",
-                AllowAccessTokensViaBrowser = true
+                AllowAccessTokensViaBrowser = true,
+
             });
 
+            
             _mockPipeline.Users.Add(new TestUser
             {
                 SubjectId = "bob",
@@ -134,6 +137,8 @@ namespace IdentityServer4.IntegrationTests.Endpoints.EndSession
             response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             response.Headers.Location.ToString().Should().StartWith("https://server/logout?id=");
         }
+
+
 
         [Fact]
         [Trait("Category", Category)]

--- a/test/IdentityServer.IntegrationTests/Endpoints/Revocation/RevocationTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Revocation/RevocationTests.cs
@@ -42,7 +42,8 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Revocation
                 RedirectUris = new List<string> { redirect_uri },
                 AllowAccessTokensViaBrowser = true,
                 AccessTokenType = AccessTokenType.Reference,
-                RefreshTokenUsage = TokenUsage.ReUse
+                RefreshTokenUsage = TokenUsage.ReUse,
+                PairWiseSubjectSalt = "saltclient1"
             });
             _mockPipeline.Clients.Add(new Client
             {
@@ -52,7 +53,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Revocation
                 AllowedScopes = new List<string> { "api" },
                 RedirectUris = new List<string> { redirect_uri },
                 AllowAccessTokensViaBrowser = true,
-                AccessTokenType = AccessTokenType.Reference
+                AccessTokenType = AccessTokenType.Reference,
             });
             _mockPipeline.Clients.Add(new Client
             {

--- a/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
+++ b/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
+
+    <RootNamespace>IdentityServer.UnitTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
@@ -41,7 +41,7 @@ namespace IdentityServer4.UnitTests.Services.Default
                 new Claim(JwtClaimTypes.AuthenticationContextClassReference, "acr1")
             });
 
-            _subject = new DefaultClaimsService(_mockMockProfileService, TestLogger.Create<DefaultClaimsService>());
+            _subject = new DefaultClaimsService(_mockMockProfileService, new DefaultClientSubjectService(), TestLogger.Create<DefaultClaimsService>());
 
             _validatedRequest = new ValidatedRequest();
             _validatedRequest.SetClient(_client);

--- a/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/EndSessionRequestValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/EndSessionRequestValidatorTests.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using IdentityServer4.Services;
 using Xunit;
 
 namespace IdentityServer4.UnitTests.Validation.EndSessionRequestValidation
@@ -43,8 +44,7 @@ namespace IdentityServer4.UnitTests.Validation.EndSessionRequestValidation
                 _stubRedirectUriValidator,
                 _userSession,
                 _clientStore,
-                _mockEndSessionMessageStore,
-                TestLogger.Create<EndSessionRequestValidator>());
+                _mockEndSessionMessageStore, new DefaultClientSubjectService(), TestLogger.Create<EndSessionRequestValidator>());
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -205,6 +205,7 @@ namespace IdentityServer4.UnitTests.Validation
                 customValidator: new DefaultCustomTokenValidator(
                     profile: profile,
                     clients: clients,
+                    httpContextAccessor:context,
                     logger: TestLogger.Create<DefaultCustomTokenValidator>()),
                     keys: new DefaultKeyMaterialService(new[] { new DefaultValidationKeysStore(new[] { TestCert.LoadSigningCredentials().Key }) }),
                 logger: logger,


### PR DESCRIPTION
I've implemted Pairwise Subject. Not ready for merge yet. I made this PR to get early feedback.


1. Creation of the Pairwise Subject in DefaultClaimService (SubjectId+Salt).Sha256(), to not break backward compatiblity with the virtual method GetStandardSubjectClaimsAsync() i had to transform the Subject Id claim bevor adding them.
2. EndSessionRequestValidator changed to validate the new PairwiseSubject if needed
3. Wrote Unit Tests for all that.
4. Changed DiscoveryResponseGenerator to announce the supported subject types.
5. Adapted Integrationtest for that

ToDo:
1. Write Integrationtests for Pairwise Subject
2. May create IClientSubjectService for creation and valdiation of the client subject, to seperate the concern of creating and validating the subject which is delivered to the client.
```
public interface IClientSubjectService {
     string GeneratedSubject(string userSubject, Client client);
     bool ValidateSubject(string userSubject, string clientSubject, Client client); 
}
```


