### PR TITLE
Fix minor typos in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Also read this first: [Being a good open source citizen](https://hackernoon.com/
 Please start a discussion on the [core repo issue tracker](https://github.com/IdentityServer/IdentityServer4/issues).
 
 ## Platform
-IdentityServer is built against ASP.NET Core 1.1 using the RTM tooling that ships with Visual Studio 2017. This is the only configuration we accept.
+IdentityServer is built against ASP.NET Core 2.0 using the RTM tooling that ships with Visual Studio 2017. This is the only configuration we accept.
 
 ## Bugs and feature requests?
 Please log a new issue in the appropriate GitHub repo:

--- a/docs/intro/support.rst
+++ b/docs/intro/support.rst
@@ -28,7 +28,7 @@ https://gitter.im/IdentityServer/IdentityServer4
 **Reporting a bug**
 
 If you think you have found a bug or unexpected behavior, please open an issue on the Github `issue tracker <https://github.com/IdentityServer/IdentityServer4/issues>`_.
-We try to get back to you ASAP. Please understand that we also have day jobs, and might be to busy to reply immediately.
+We try to get back to you ASAP. Please understand that we also have day jobs, and might be too busy to reply immediately.
 
 Also check the `contribution <https://github.com/IdentityServer/IdentityServer4/blob/dev/CONTRIBUTING.md>`_ guidelines before posting.
 


### PR DESCRIPTION
 - Replace `to busy` by `too busy`
 - Update contributing guidelines from `ASP.NET Core 1.1` to `ASP.NET
 Core 2.0`

 #1600 