### PR TITLE
Moving IdentityServerMiddleware IEventService parameter from constructor to Invoke

### DIFF
--- a/src/IdentityServer4/Hosting/IdentityServerMiddleware.cs
+++ b/src/IdentityServer4/Hosting/IdentityServerMiddleware.cs
@@ -16,7 +16,6 @@ namespace IdentityServer4.Hosting
     /// </summary>
     public class IdentityServerMiddleware
     {
-        private readonly IEventService _events;
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
 
@@ -24,12 +23,10 @@ namespace IdentityServer4.Hosting
         /// Initializes a new instance of the <see cref="IdentityServerMiddleware"/> class.
         /// </summary>
         /// <param name="next">The next.</param>
-        /// <param name="events">The events.</param>
         /// <param name="logger">The logger.</param>
-        public IdentityServerMiddleware(RequestDelegate next, IEventService events, ILogger<IdentityServerMiddleware> logger)
+        public IdentityServerMiddleware(RequestDelegate next, ILogger<IdentityServerMiddleware> logger)
         {
             _next = next;
-            _events = events;
             _logger = logger;
         }
 
@@ -39,8 +36,9 @@ namespace IdentityServer4.Hosting
         /// <param name="context">The context.</param>
         /// <param name="router">The router.</param>
         /// <param name="session">The user session.</param>
+        /// <param name="events">The event service.</param>
         /// <returns></returns>
-        public async Task Invoke(HttpContext context, IEndpointRouter router, IUserSession session)
+        public async Task Invoke(HttpContext context, IEndpointRouter router, IUserSession session, IEventService events)
         {
             // this will check the authentication session and from it emit the check session
             // cookie needed from JS-based signout clients.
@@ -66,7 +64,7 @@ namespace IdentityServer4.Hosting
             }
             catch (Exception ex)
             {
-                await _events.RaiseAsync(new UnhandledExceptionEvent(ex));
+                await events.RaiseAsync(new UnhandledExceptionEvent(ex));
                 _logger.LogCritical("Unhandled exception: {exception}", ex.ToString());
                 throw;
             }


### PR DESCRIPTION
 - The goal is to allow per-request instances of IEventSink.
 - Attempting to use per-request (scoped) instances of IEventService/IEventSink results in a runtime exception due to the fact that IdentityServerMiddleware injects an IEventService during construction, rather than per-request.