### PR TITLE
Make secret validation more pluggable

### DIFF
--- a/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -118,7 +118,6 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             builder.Services.AddTransient<ApiSecretValidator>();
             builder.Services.AddTransient<SecretParser>();
-            builder.Services.AddTransient<ClientSecretValidator>();
             builder.Services.AddTransient<SecretValidator>();
             builder.Services.AddTransient<ScopeValidator>();
             builder.Services.AddTransient<ExtensionGrantValidator>();
@@ -168,6 +167,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddTransient<IPersistentGrantSerializer, PersistentGrantSerializer>();
             builder.Services.TryAddTransient<IEventService, DefaultEventService>();
             builder.Services.TryAddTransient<IEventSink, DefaultEventSink>();
+            builder.Services.AddTransient<IClientSecretValidator, ClientSecretValidator>();
 
             return builder;
         }

--- a/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -116,7 +116,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IIdentityServerBuilder AddCoreServices(this IIdentityServerBuilder builder)
         {
-            builder.Services.AddTransient<ApiSecretValidator>();
             builder.Services.AddTransient<SecretParser>();
             builder.Services.AddTransient<SecretValidator>();
             builder.Services.AddTransient<ScopeValidator>();
@@ -168,6 +167,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddTransient<IEventService, DefaultEventService>();
             builder.Services.TryAddTransient<IEventSink, DefaultEventSink>();
             builder.Services.AddTransient<IClientSecretValidator, ClientSecretValidator>();
+            builder.Services.AddTransient<IApiSecretValidator, ApiSecretValidator>();
 
             return builder;
         }

--- a/src/IdentityServer4/Endpoints/IntrospectionEndpoint.cs
+++ b/src/IdentityServer4/Endpoints/IntrospectionEndpoint.cs
@@ -22,7 +22,7 @@ namespace IdentityServer4.Endpoints
         private readonly IIntrospectionResponseGenerator _responseGenerator;
         private readonly ILogger _logger;
         private readonly IIntrospectionRequestValidator _requestValidator;
-        private readonly ApiSecretValidator _apiSecretValidator;
+        private readonly IApiSecretValidator _apiSecretValidator;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IntrospectionEndpoint"/> class.
@@ -32,7 +32,7 @@ namespace IdentityServer4.Endpoints
         /// <param name="responseGenerator">The generator.</param>
         /// <param name="logger">The logger.</param>
         public IntrospectionEndpoint(
-            ApiSecretValidator apiSecretValidator, 
+            IApiSecretValidator apiSecretValidator, 
             IIntrospectionRequestValidator requestValidator, 
             IIntrospectionResponseGenerator responseGenerator,  
             ILogger<IntrospectionEndpoint> logger)

--- a/src/IdentityServer4/Endpoints/TokenEndpoint.cs
+++ b/src/IdentityServer4/Endpoints/TokenEndpoint.cs
@@ -23,7 +23,7 @@ namespace IdentityServer4.Endpoints
     /// <seealso cref="IdentityServer4.Hosting.IEndpointHandler" />
     internal class TokenEndpoint : IEndpointHandler
     {
-        private readonly ClientSecretValidator _clientValidator;
+        private readonly IClientSecretValidator _clientValidator;
         private readonly ITokenRequestValidator _requestValidator;
         private readonly ITokenResponseGenerator _responseGenerator;
         private readonly IEventService _events;
@@ -37,7 +37,12 @@ namespace IdentityServer4.Endpoints
         /// <param name="responseGenerator">The response generator.</param>
         /// <param name="events">The events.</param>
         /// <param name="logger">The logger.</param>
-        public TokenEndpoint(ClientSecretValidator clientValidator, ITokenRequestValidator requestValidator, ITokenResponseGenerator responseGenerator, IEventService events, ILogger<TokenEndpoint> logger)
+        public TokenEndpoint(
+            IClientSecretValidator clientValidator, 
+            ITokenRequestValidator requestValidator, 
+            ITokenResponseGenerator responseGenerator, 
+            IEventService events, 
+            ILogger<TokenEndpoint> logger)
         {
             _clientValidator = clientValidator;
             _requestValidator = requestValidator;

--- a/src/IdentityServer4/Endpoints/TokenRevocationEndpoint.cs
+++ b/src/IdentityServer4/Endpoints/TokenRevocationEndpoint.cs
@@ -24,7 +24,7 @@ namespace IdentityServer4.Endpoints
     internal class TokenRevocationEndpoint : IEndpointHandler
     {
         private readonly ILogger _logger;
-        private readonly ClientSecretValidator _clientValidator;
+        private readonly IClientSecretValidator _clientValidator;
         private readonly ITokenRevocationRequestValidator _requestValidator;
         private readonly ITokenRevocationResponseGenerator _responseGenerator;
         private readonly IEventService _events;
@@ -38,7 +38,7 @@ namespace IdentityServer4.Endpoints
         /// <param name="responseGenerator">The response generator.</param>
         /// <param name="events">The events.</param>
         public TokenRevocationEndpoint(ILogger<TokenRevocationEndpoint> logger,
-            ClientSecretValidator clientValidator,
+            IClientSecretValidator clientValidator,
             ITokenRevocationRequestValidator requestValidator,
             ITokenRevocationResponseGenerator responseGenerator,
             IEventService events)

--- a/src/IdentityServer4/Validation/ApiSecretValidator.cs
+++ b/src/IdentityServer4/Validation/ApiSecretValidator.cs
@@ -14,7 +14,7 @@ namespace IdentityServer4.Validation
     /// <summary>
     /// Validates API secrets using the registered secret validators and parsers
     /// </summary>
-    public class ApiSecretValidator
+    public class ApiSecretValidator : IApiSecretValidator
     {
         private readonly ILogger _logger;
         private readonly IResourceStore _resources;

--- a/src/IdentityServer4/Validation/ClientSecretValidator.cs
+++ b/src/IdentityServer4/Validation/ClientSecretValidator.cs
@@ -15,7 +15,7 @@ namespace IdentityServer4.Validation
     /// <summary>
     /// Validates a client secret using the registered secret validators and parsers
     /// </summary>
-    public class ClientSecretValidator
+    public class ClientSecretValidator : IClientSecretValidator
     {
         private readonly ILogger _logger;
         private readonly IClientStore _clients;

--- a/src/IdentityServer4/Validation/Interfaces/IApiSecretValidator.cs
+++ b/src/IdentityServer4/Validation/Interfaces/IApiSecretValidator.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace IdentityServer4.Validation
+{
+    /// <summary>
+    /// Validator for handling API client authentication.
+    /// </summary>
+    public interface IApiSecretValidator
+    {
+        /// <summary>
+        /// Tries to authenticate an API client based on the incoming request
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns></returns>
+        Task<ApiSecretValidationResult> ValidateAsync(HttpContext context);
+    }
+}

--- a/src/IdentityServer4/Validation/Interfaces/IClientSecretValidator.cs
+++ b/src/IdentityServer4/Validation/Interfaces/IClientSecretValidator.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace IdentityServer4.Validation
+{
+    /// <summary>
+    /// Validator for handling client authentication
+    /// </summary>
+    public interface IClientSecretValidator
+    {
+        /// <summary>
+        /// Tries to authenticate a client based on the incoming request
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns></returns>
+        Task<ClientSecretValidationResult> ValidateAsync(HttpContext context);
+    }
+}

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -214,7 +214,7 @@ namespace IdentityServer4.UnitTests.Validation
             return validator;
         }
 
-        public static ClientSecretValidator CreateClientSecretValidator(IClientStore clients = null, SecretParser parser = null, SecretValidator validator = null, IdentityServerOptions options = null)
+        public static IClientSecretValidator CreateClientSecretValidator(IClientStore clients = null, SecretParser parser = null, SecretValidator validator = null, IdentityServerOptions options = null)
         {
             options = options ?? TestIdentityServerOptions.Create();
 


### PR DESCRIPTION
for both client and api secrets

* extract interface from `ClientSecretValidator` and `ApiSecretValidator`
* use interfaces in code
* allow replacement of implementation via DI