### PR TITLE
lost a day on this

### DIFF
--- a/docs/quickstarts/8_entity_framework.rst
+++ b/docs/quickstarts/8_entity_framework.rst
@@ -69,7 +69,7 @@ We will replace them with this code::
     // configure identity server with in-memory stores, keys, clients and scopes
     services.AddIdentityServer()
         .AddDeveloperSigningCredential()
-        .AddTestUsers(Config.GetUsers())
+        .AddAspNetIdentity<ApplicationUser>()
         // this adds the config data from DB (clients, resources)
         .AddConfigurationStore(options =>
         {
@@ -183,7 +183,7 @@ And then we can invoke this from the ``Configure`` method::
     }
 
 Now if you run the IdentityServer project, the database should be created and seeded with the quickstart configuration data.
-You should be able to use SqlServer Management Studio or Visual Studio to connect and inspect the data.
+You should be able to use SQL Server Management Studio or Visual Studio to connect and inspect the data.
 
 .. image:: images/8_database.png
 


### PR DESCRIPTION
The quickstart code and the tone of the dialog agree that at this point we are using data-driven logins, but this implementation in the documentation assumes hard-wired users. As a side-bar note, the failure to call .AddAspNetIdentity<ApplicationUser>() is one of the reasons users (yours truly being one) run into the "sub claim is missing" problem. All these assertions subject to verification, but this is what I'm seeing. :)