### PR TITLE
Update standard IDistributedCache implementation.

### DIFF
--- a/docs/topics/apis.rst
+++ b/docs/topics/apis.rst
@@ -105,7 +105,7 @@ Typically, you don't want to do a roundtrip to the introspection endpoint for ea
         options.CacheDuration = TimeSpan.FromMinutes(10); // that's the default
     })
 
-The handler will use whatever `IDistributedCache` implementation is registered in the DI container (e.g. the standad `IDistributedInMemoryCache`).
+The handler will use whatever `IDistributedCache` implementation is registered in the DI container (e.g. the standad `MemoryDistributedCache`).
 
 Validating scopes
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I was unable to find anything about `IDistributedInMemoryCache` anywhere, but MS provides `MemoryDistributedCache` as part of the `Microsoft.Extensions.Caching.Memory` package.