### PR TITLE
Update 6_aspnet_identity.rst

### DIFF
--- a/docs/quickstarts/6_aspnet_identity.rst
+++ b/docs/quickstarts/6_aspnet_identity.rst
@@ -159,7 +159,7 @@ Creating the user database
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Given that this is a new ASP.NET Identity project, you will need to create the database.
-You can do this by running a command prompt from the project directory and running ``dotnet ef database update``, like this:
+You can do this by running a command prompt from the project directory and running ``dotnet ef database update -c ApplicationDbContext``, like this:
 
 .. image:: images/6_ef_database_update.png
 


### PR DESCRIPTION
Specify DbContext when creating the user database. This resolves the "More than one DbContext was found" when running the command.