### PR TITLE
Add ClientName to LogutMessage and LogoutRequest

### DIFF
--- a/src/Host/Quickstart/Account/AccountService.cs
+++ b/src/Host/Quickstart/Account/AccountService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -127,7 +127,7 @@ namespace IdentityServer4.Quickstart.UI
             {
                 AutomaticRedirectAfterSignOut = AccountOptions.AutomaticRedirectAfterSignOut,
                 PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-                ClientName = logout?.ClientName,
+                ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
                 SignOutIframeUrl = logout?.SignOutIFrameUrl,
                 LogoutId = logoutId
             };

--- a/src/Host/Quickstart/Account/AccountService.cs
+++ b/src/Host/Quickstart/Account/AccountService.cs
@@ -127,7 +127,7 @@ namespace IdentityServer4.Quickstart.UI
             {
                 AutomaticRedirectAfterSignOut = AccountOptions.AutomaticRedirectAfterSignOut,
                 PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-                ClientName = logout?.ClientId,
+                ClientName = logout?.ClientName,
                 SignOutIframeUrl = logout?.SignOutIFrameUrl,
                 LogoutId = logoutId
             };

--- a/src/IdentityServer4/Models/Messages/LogoutRequest.cs
+++ b/src/IdentityServer4/Models/Messages/LogoutRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -42,6 +42,7 @@ namespace IdentityServer4.Models
                 Parameters.Remove(OidcConstants.EndSessionRequest.State);
 
                 ClientId = request.Client?.ClientId;
+                ClientName = request.Client?.ClientName;
                 SubjectId = request.Subject?.GetSubjectId();
                 SessionId = request.SessionId;
                 ClientIds = request.ClientIds;
@@ -61,7 +62,12 @@ namespace IdentityServer4.Models
         /// Gets or sets the client identifier.
         /// </summary>
         public string ClientId { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the client name.
+        /// </summary>
+        public string ClientName { get; set; }
+
         /// <summary>
         /// Gets or sets the post logout redirect URI.
         /// </summary>
@@ -108,6 +114,7 @@ namespace IdentityServer4.Models
             if (message != null)
             {
                 ClientId = message.ClientId;
+                ClientName = message.ClientName;
                 PostLogoutRedirectUri = message.PostLogoutRedirectUri;
                 SubjectId = message.SubjectId;
                 SessionId = message.SessionId;
@@ -122,6 +129,11 @@ namespace IdentityServer4.Models
         /// Gets or sets the client identifier.
         /// </summary>
         public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client name.
+        /// </summary>
+        public string ClientName { get; set; }
 
         /// <summary>
         /// Gets or sets the post logout redirect URI.


### PR DESCRIPTION
Add ClientName to LogutMessage and LogoutRequest so the AccountServices can set it to the LoggedOutViewModel.ClientName and show the client name, instead of client id in the UI.