### PR TITLE
Wrong link in documentation

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -28,3 +28,4 @@ William Grow
 Espen Medbø ([@emedbo](https://twitter.com/emedbo))  
 John Korsnes ([@johnkors](https://twitter.com/johnkors))  
 James Roberts  
+Chris Simmons  

--- a/docs/quickstarts/6_aspnet_identity.rst
+++ b/docs/quickstarts/6_aspnet_identity.rst
@@ -53,7 +53,7 @@ Scopes and Clients Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Despite this being a new project for IdentityServer, we still need the same scope and client configuration as the prior quickstarts.
-Copy the configuration class (in `Config.cs <https://github.com/IdentityServer/IdentityServer4.Samples/blob/dev/Quickstarts/1_ClientCredentials/src/QuickstartIdentityServer/Config.cs>`_) you used for the previous quickstarts into this new project.
+Copy the configuration class (in `Config.cs <https://github.com/IdentityServer/IdentityServer4.Samples/blob/dev/Quickstarts/6_AspNetIdentity/src/IdentityServerWithAspNetIdentity/Config.cs>`_) you used for the previous quickstarts into this new project.
 
 One change to the configuration that is necessary (for now) is to disable consent for the MVC client.
 We've not yet copied over the consent code from the prior IdentityServer project, so for now make this one modification to the MVC client and set ``RequireConsent=false``::


### PR DESCRIPTION
**What issue does this PR address?**
The link in the documentation was redirecting to a config file that did not contain the needed `Config.GetIdentityResources()`.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)
