### PR TITLE
Log full exceptions when available to aid in debugging

### DIFF
--- a/src/IdentityServer4/Infrastructure/BackChannelLogoutClient.cs
+++ b/src/IdentityServer4/Infrastructure/BackChannelLogoutClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -64,7 +64,7 @@ namespace IdentityServer4.Infrastructure
             }
             catch(Exception ex)
             {
-                _logger.LogError("Exception invoking back channel logout for client id: {0} to URI: {1}, message: {2}", client.ClientId, client.LogoutUri, ex.Message);
+                _logger.LogError(ex, "Exception invoking back channel logout for client id: {0} to URI: {1}", client.ClientId, client.LogoutUri);
             }
         }
 

--- a/src/IdentityServer4/Infrastructure/MessageCookie.cs
+++ b/src/IdentityServer4/Infrastructure/MessageCookie.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -113,7 +113,7 @@ namespace IdentityServer4
                 }
                 catch(Exception ex)
                 {
-                    _logger.LogError("Error unprotecting message cookie: {exception}", ex.Message);
+                    _logger.LogError(ex, "Error unprotecting message cookie");
                     ClearByCookieName(name);
                 }
             }
@@ -157,7 +157,7 @@ namespace IdentityServer4
             catch (CryptographicException e)
             {   
                 // cookie was protected with a different key/algorithm
-                _logger.LogDebug("Unable to unprotect cookie {0}: {1}", name, e.Message);
+                _logger.LogDebug(e, "Unable to unprotect cookie {0}", name);
             }
             
             return rank;

--- a/src/IdentityServer4/Services/DefaultPersistedGrantService.cs
+++ b/src/IdentityServer4/Services/DefaultPersistedGrantService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -92,7 +92,7 @@ namespace IdentityServer4.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError("Failed processing results from grant store. Exception: {0}", ex.Message);
+                _logger.LogError(ex, "Failed processing results from grant store.");
             }
 
             return Enumerable.Empty<Consent>();

--- a/src/IdentityServer4/Services/DefaultUserSession.cs
+++ b/src/IdentityServer4/Services/DefaultUserSession.cs
@@ -269,7 +269,7 @@ namespace IdentityServer4.Services
             }
             catch (Exception ex)
             {
-                Logger.LogError("Error decoding client list: {0}", ex.Message);
+                Logger.LogError(ex, "Error decoding client list");
                 // clear so we don't keep failing
                 await SetClientsAsync(null);
             }

--- a/src/IdentityServer4/Stores/Default/DefaultGrantStore.cs
+++ b/src/IdentityServer4/Stores/Default/DefaultGrantStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -97,7 +97,7 @@ namespace IdentityServer4.Stores
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogError("Failed to deserailize JSON from grant store. Exception: {0}", ex.Message);
+                    Logger.LogError(ex, "Failed to deserialize JSON from grant store.");
                 }
             }
             else

--- a/src/IdentityServer4/Stores/Default/ProtectedDataMessageStore.cs
+++ b/src/IdentityServer4/Stores/Default/ProtectedDataMessageStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -40,7 +40,7 @@ namespace IdentityServer4.Stores
                 }
                 catch(Exception ex)
                 {
-                    _logger.LogError("Exception reading message: {0}", ex.Message);
+                    _logger.LogError(ex, "Exception reading protected message");
                 }
             }
 
@@ -60,7 +60,7 @@ namespace IdentityServer4.Stores
             }
             catch(Exception ex)
             {
-                _logger.LogError("Exception writing message: {0}", ex.Message);
+                _logger.LogError(ex, "Exception writing protected message");
             }
 
             return Task.FromResult(value);

--- a/src/IdentityServer4/Validation/PrivateKeyJwtSecretValidator.cs
+++ b/src/IdentityServer4/Validation/PrivateKeyJwtSecretValidator.cs
@@ -69,7 +69,7 @@ namespace IdentityServer4.Validation
             }
             catch (Exception e)
             {
-                _logger.LogError("Could not parse assertion as JWT token: {e}", e);
+                _logger.LogError(e, "Could not parse assertion as JWT token");
                 return fail;
             }
 
@@ -109,7 +109,7 @@ namespace IdentityServer4.Validation
             }
             catch (Exception e)
             {
-                _logger.LogError("JWT token validation error: " + e.Message);
+                _logger.LogError(e, "JWT token validation error");
                 return fail;
             }
         }


### PR DESCRIPTION
**What issue does this PR address?**

This is related to issue #1946. Made changes to log full exceptions rather than just exception messages. This will aid in debugging since the full exception information, including inner exceptions will be available in logs.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] <strike>Unit Tests for the changes have been added (for bug fixes / features)</strike> N/A

**Other information**:

I was initially just going to do this in the `ProtectedDataMessageStore` class, but I found several other places where a full exception could be logged rather than just the exception message. 