### PR TITLE
Update AccessTokenTypes to AccessTokenType

### DIFF
--- a/docs/topics/reference_tokens.rst
+++ b/docs/topics/reference_tokens.rst
@@ -13,7 +13,7 @@ The API receiving this reference must then open a back-channel communication to 
 
 You can switch the token type of a client using the following setting::
 
-    client.AccessTokenType = AccessTokenTypes.Reference;
+    client.AccessTokenType = AccessTokenType.Reference;
 
 IdentityServer provides an implementation of the OAuth 2.0 introspection specification which allows APIs to dereference the tokens.
 You can either use our dedicated `introspection middleware <https://github.com/IdentityModel/IdentityModel.AspNetCore.OAuth2Introspection>`_


### PR DESCRIPTION
should be AccessTokenType.Reference

**What issue does this PR address?**


**Does this PR introduce a breaking change?**


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
