### PR TITLE
Suggestion for an update to the documentation for using the IdentityServer4.EntityFramework NuGet package.

### DIFF
--- a/docs/quickstarts/8_entity_framework.rst
+++ b/docs/quickstarts/8_entity_framework.rst
@@ -131,6 +131,8 @@ It should look something like this:
 You should now see a `~/Data/Migrations/IdentityServer` folder in the project. 
 This contains the code for the newly created migrations.
 
+.. Note:: If your database project is a separate class library and you fixed the error 'Unable to create an object of type ‘<your-name>DbContext’. Add an implementation of ‘IDesignTimeDbContextFactory’ to the project, or see https://go.microsoft.com/fwlink/?linkid=851728 for additional patterns supported at design time.' by adding implementations of the IDesignTimeDbContextFactory, you will also need implementations of the factory for both the PersistedGrantDbContext as well as the ConfigurationDbContext. 
+
 Initialize the database
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
While using the documentation to add the IdentityServer4.EntityFramework NuGet package to our project, we were unable to create the contexts as proposed in the documentation.

While researching the issue a bit further, we found out that it was because:
1. We were using a separate library for our database context.
2. We added an implementation of the IDesignTimeDbContextFactory for our own context. 

This caused the following error: "No DbContext named 'PersistedGrantDbContext' was found."

After removing our IDesignTimeDbContextFactory, we got the error 'Unable to create an object of type ‘<your-name>DbContext’. Add an implementation of ‘IDesignTimeDbContextFactory’ to the project, or see https://go.microsoft.com/fwlink/?linkid=851728 for additional patterns supported at design time.' and as such were able to solve it by creating an implementation of the IDesignTimeDbContextFactory for both the PersistedGrantDbContext and the ConfigurationDbContext.

I've added a suggestion for a note that could be added to the documentation page, but I basically wanted to let you guys know which issue we ran into and how we solved it. I think that by adding a small addition to the documentation, other people that want to use your solution can do so more easily.