### PR TITLE
Add  Content-Security-Policy options

### DIFF
--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/CspOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/CspOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/CspOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/CspOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using IdentityServer4.Models;
+
+namespace IdentityServer4.Configuration
+{
+    /// <summary>
+    /// Options for Content Security Policy
+    /// </summary>
+    public class CspOptions
+    {
+        /// <summary>
+        /// Gets or sets the minimum CSP level.
+        /// </summary>
+        public CspLevel Level { get; set; } = CspLevel.Two;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the deprected X-Content-Security-Policy header should be added.
+        /// </summary>
+        public bool AddDeprecatedHeader { get; set; } = true;
+    }
+}

--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -91,5 +91,10 @@ namespace IdentityServer4.Configuration
         /// The cors options.
         /// </value>
         public CorsOptions Cors { get; set; } = new CorsOptions();
+
+        /// <summary>
+        /// Gets or sets the Content Security Policy options.
+        /// </summary>
+        public CspOptions Csp { get; set; } = new CspOptions();
     }
 }

--- a/src/IdentityServer4/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/AuthorizeResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer4/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/AuthorizeResult.cs
@@ -127,18 +127,7 @@ namespace IdentityServer4.Endpoints.Results
 
         private void AddSecurityHeaders(HttpContext context)
         {
-            var formOrigin = Response.Request.RedirectUri.GetOrigin();
-            var csp = $"default-src 'none'; script-src 'sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY='; ";
-
-            if (!context.Response.Headers.ContainsKey("Content-Security-Policy"))
-            {
-                context.Response.Headers.Add("Content-Security-Policy", csp);
-            }
-
-            if (!context.Response.Headers.ContainsKey("X-Content-Security-Policy"))
-            {
-                context.Response.Headers.Add("X-Content-Security-Policy", csp);
-            }
+            context.Response.AddScriptCspHeaders(_options.Csp, "sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY=");
 
             var referrer_policy = "no-referrer";
             if (!context.Response.Headers.ContainsKey("Referrer-Policy"))

--- a/src/IdentityServer4/Endpoints/Results/CheckSessionResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/CheckSessionResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer4/Endpoints/Results/CheckSessionResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/CheckSessionResult.cs
@@ -40,19 +40,8 @@ namespace IdentityServer4.Endpoints.Results
 
         private void AddCspHeaders(HttpContext context)
         {
-            var value = "default-src 'none'; script-src 'sha256-ZT3q7lL9GXNGhPTB1Vvrvds2xw/kOV0zoeok2tiV23I='";
-
-            if (!context.Response.Headers.ContainsKey("Content-Security-Policy"))
-            {
-                context.Response.Headers.Add("Content-Security-Policy", value);
-            }
-
-            if (!context.Response.Headers.ContainsKey("X-Content-Security-Policy"))
-            {
-                context.Response.Headers.Add("X-Content-Security-Policy", value);
-            }
+            context.Response.AddScriptCspHeaders(_options.Csp, "sha256-ZT3q7lL9GXNGhPTB1Vvrvds2xw/kOV0zoeok2tiV23I=");
         }
-
         private string GetHtml(string cookieName)
         {
             return Html.Replace("{cookieName}", cookieName);

--- a/src/IdentityServer4/Endpoints/Results/EndSessionCallbackResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/EndSessionCallbackResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer4/Endpoints/Results/EndSessionCallbackResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/EndSessionCallbackResult.cs
@@ -59,28 +59,18 @@ namespace IdentityServer4.Endpoints.Results
 
         private void AddCspHeaders(HttpContext context)
         {
-            // the hash matches the embedded style element being used below
-            var value = "default-src 'none'; style-src 'sha256-u+OupXgfekP+x/f6rMdoEAspPCYUtca912isERnoEjY='";
-
+            string frameSources = null;
             if (_options.Authentication.RequireCspFrameSrcForSignout)
             {
                 var origins = _result.FrontChannelLogoutUrls?.Select(x => x.GetOrigin());
                 if (origins != null && origins.Any())
                 {
-                    var list = origins.Distinct().Aggregate((x, y) => $"{x} {y}");
-                    value += $";frame-src {list}";
+                    frameSources = origins.Distinct().Aggregate((x, y) => $"{x} {y}");
                 }
             }
 
-            if (!context.Response.Headers.ContainsKey("Content-Security-Policy"))
-            {
-                context.Response.Headers.Add("Content-Security-Policy", value);
-            }
-
-            if (!context.Response.Headers.ContainsKey("X-Content-Security-Policy"))
-            {
-                context.Response.Headers.Add("X-Content-Security-Policy", value);
-            }
+            // the hash matches the embedded style element being used below
+            context.Response.AddStyleCspHeaders(_options.Csp, "sha256-u+OupXgfekP+x/f6rMdoEAspPCYUtca912isERnoEjY=", frameSources);
         }
 
         private string GetHtml()

--- a/src/IdentityServer4/Extensions/HttpResponseExtensions.cs
+++ b/src/IdentityServer4/Extensions/HttpResponseExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer4/Extensions/HttpResponseExtensions.cs
+++ b/src/IdentityServer4/Extensions/HttpResponseExtensions.cs
@@ -1,9 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using IdentityServer4;
+using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
+using IdentityServer4.Models;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -27,7 +29,8 @@ namespace Microsoft.AspNetCore.Http
 
         public static void SetCache(this HttpResponse response, int maxAge)
         {
-            if (maxAge == 0 ) {
+            if (maxAge == 0)
+            {
                 SetNoCache(response);
             }
             else if (maxAge > 0)
@@ -65,6 +68,39 @@ namespace Microsoft.AspNetCore.Http
                 url = response.HttpContext.GetIdentityServerBaseUrl().EnsureTrailingSlash() + url.RemoveLeadingSlash();
             }
             response.Redirect(url);
+        }
+
+        internal static void AddScriptCspHeaders(this HttpResponse response, CspOptions options, string hash)
+        {
+            var csp1part = options.Level == CspLevel.One ? "'unsafe-inline' " : string.Empty;
+            var cspHeader = $"default-src 'none'; script-src {csp1part}'{hash}'";
+
+            AddCspHeaders(response.Headers, options, cspHeader);
+        }
+
+        internal static void AddStyleCspHeaders(this HttpResponse response, CspOptions options, string hash, string frameSources)
+        {
+            var csp1part = options.Level == CspLevel.One ? "'unsafe-inline' " : string.Empty;
+            var cspHeader = $"default-src 'none'; style-src {csp1part}'{hash}'";
+
+            if (!string.IsNullOrEmpty(frameSources))
+            {
+                cspHeader += $"; frame-src {frameSources}";
+            }
+
+            AddCspHeaders(response.Headers, options, cspHeader);
+        }
+
+        private static void AddCspHeaders(IHeaderDictionary headers, CspOptions options, string cspHeader)
+        {
+            if (!headers.ContainsKey("Content-Security-Policy"))
+            {
+                headers.Add("Content-Security-Policy", cspHeader);
+            }
+            if (options.AddDeprecatedHeader && !headers.ContainsKey("X-Content-Security-Policy"))
+            {
+                headers.Add("X-Content-Security-Policy", cspHeader);
+            }
         }
     }
 }

--- a/src/IdentityServer4/Models/Enums.cs
+++ b/src/IdentityServer4/Models/Enums.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer4/Models/Enums.cs
+++ b/src/IdentityServer4/Models/Enums.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -66,5 +66,21 @@ namespace IdentityServer4.Models
         /// Absolute token expiration
         /// </summary>
         Absolute = 1
+    }
+
+    /// <summary>
+    /// Content Security Policy Level
+    /// </summary>
+    public enum CspLevel
+    {
+        /// <summary>
+        /// Level 1
+        /// </summary>
+        One = 0,
+
+        /// <summary>
+        /// Level 2
+        /// </summary>
+        Two = 1
     }
 }

--- a/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -177,6 +177,10 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
             _context.Response.Headers["Cache-Control"].First().Should().Contain("no-store");
             _context.Response.Headers["Cache-Control"].First().Should().Contain("no-cache");
             _context.Response.Headers["Cache-Control"].First().Should().Contain("max-age=0");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("default-src 'none';");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY='");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("default-src 'none';");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY='");
             _context.Response.Body.Seek(0, SeekOrigin.Begin);
             using (var rdr = new StreamReader(_context.Response.Body))
             {

--- a/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -49,9 +49,9 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
             _context.Response.StatusCode.Should().Be(200);
             _context.Response.ContentType.Should().StartWith("text/html");
             _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("default-src 'none';");
-            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VDXN0nOpFPQ102CIVz+eimHA5e+wTeoUUQj5ZYbtn8w='");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-ZT3q7lL9GXNGhPTB1Vvrvds2xw/kOV0zoeok2tiV23I='");
             _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("default-src 'none';");
-            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VDXN0nOpFPQ102CIVz+eimHA5e+wTeoUUQj5ZYbtn8w='");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'sha256-ZT3q7lL9GXNGhPTB1Vvrvds2xw/kOV0zoeok2tiV23I='");
             _context.Response.Body.Seek(0, SeekOrigin.Begin);
             using (var rdr = new StreamReader(_context.Response.Body))
             {
@@ -67,8 +67,8 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
 
             await _subject.ExecuteAsync(_context);
 
-            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-VDXN0nOpFPQ102CIVz+eimHA5e+wTeoUUQj5ZYbtn8w='");
-            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-VDXN0nOpFPQ102CIVz+eimHA5e+wTeoUUQj5ZYbtn8w='");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-ZT3q7lL9GXNGhPTB1Vvrvds2xw/kOV0zoeok2tiV23I='");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-ZT3q7lL9GXNGhPTB1Vvrvds2xw/kOV0zoeok2tiV23I='");
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
 
             await _subject.ExecuteAsync(_context);
 
-            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VDXN0nOpFPQ102CIVz+eimHA5e+wTeoUUQj5ZYbtn8w='");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-ZT3q7lL9GXNGhPTB1Vvrvds2xw/kOV0zoeok2tiV23I='");
             _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();
         }
     }

--- a/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using IdentityServer.UnitTests.Common;
+using IdentityServer4.Models;
 
 namespace IdentityServer4.UnitTests.Endpoints.Results
 {
@@ -57,6 +58,28 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
                 var html = rdr.ReadToEnd();
                 html.Should().Contain("<script id='cookie-name' type='application/json'>foobar</script>");
             }
+        }
+
+        [Fact]
+        public async Task form_post_mode_should_add_unsafe_inline_for_csp_level_1()
+        {
+            _options.Csp.Level = CspLevel.One;
+
+            await _subject.ExecuteAsync(_context);
+
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-VDXN0nOpFPQ102CIVz+eimHA5e+wTeoUUQj5ZYbtn8w='");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-VDXN0nOpFPQ102CIVz+eimHA5e+wTeoUUQj5ZYbtn8w='");
+        }
+
+        [Fact]
+        public async Task form_post_mode_should_not_add_deprecated_header_when_it_is_disabled()
+        {
+            _options.Csp.AddDeprecatedHeader = false;
+
+            await _subject.ExecuteAsync(_context);
+
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VDXN0nOpFPQ102CIVz+eimHA5e+wTeoUUQj5ZYbtn8w='");
+            _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();
         }
     }
 }

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -57,6 +57,12 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
             _context.Response.Headers["Cache-Control"].First().Should().Contain("no-store");
             _context.Response.Headers["Cache-Control"].First().Should().Contain("no-cache");
             _context.Response.Headers["Cache-Control"].First().Should().Contain("max-age=0");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("default-src 'none';");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("style-src 'sha256-u+OupXgfekP+x/f6rMdoEAspPCYUtca912isERnoEjY=';");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("frame-src http://foo.com http://bar.com");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("default-src 'none';");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("style-src 'sha256-u+OupXgfekP+x/f6rMdoEAspPCYUtca912isERnoEjY=';");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("frame-src http://foo.com http://bar.com");
             _context.Response.Body.Seek(0, SeekOrigin.Begin);
             using (var rdr = new StreamReader(_context.Response.Body))
             {

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Extensions;
+using IdentityServer4.Models;
 using IdentityServer4.UnitTests.Common;
 using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Http;
@@ -70,6 +71,32 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
                 html.Should().Contain("<iframe src='http://foo.com'></iframe>");
                 html.Should().Contain("<iframe src='http://bar.com'></iframe>");
             }
+        }
+
+        [Fact]
+        public async Task fsuccess_should_add_unsafe_inline_for_csp_level_1()
+        {
+            _result.IsError = false;
+
+            _options.Csp.Level = CspLevel.One;
+
+            await _subject.ExecuteAsync(_context);
+
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("style-src 'unsafe-inline' 'sha256-u+OupXgfekP+x/f6rMdoEAspPCYUtca912isERnoEjY='");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("style-src 'unsafe-inline' 'sha256-u+OupXgfekP+x/f6rMdoEAspPCYUtca912isERnoEjY='");
+        }
+
+        [Fact]
+        public async Task form_post_mode_should_not_add_deprecated_header_when_it_is_disabled()
+        {
+            _result.IsError = false;
+
+            _options.Csp.AddDeprecatedHeader = false;
+
+            await _subject.ExecuteAsync(_context);
+
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("style-src 'sha256-u+OupXgfekP+x/f6rMdoEAspPCYUtca912isERnoEjY='");
+            _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
This pull requests adds two new options that can be used to control the Content-Security-Policy options.

- The option `Level` add backwards compatibility with browsers that only support CSP level 1.
- The option `AddDeprecatedHeader` can be used to disable the `X-Content-Security-Policy` header.

**Does this PR introduce a breaking change?**
Nope, but I wonder if we should move `AuthenticationOptions.RequireCspFrameSrcForSignout` to the new `CspOptions` class.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
This pull request addresses the issue reported in #1842. 
