### PR TITLE
Unlimited refresh lifetime in 1.5.2

### DIFF
--- a/src/IdentityServer4/Services/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer4/Services/DefaultRefreshTokenService.cs
@@ -106,15 +106,17 @@ namespace IdentityServer4.Services
             {
                 _logger.LogDebug("Refresh token expiration is sliding - extending lifetime");
 
-                // make sure we don't exceed absolute exp
-                // cap it at absolute exp
+                // if absolute exp > 0, make sure we don't exceed absolute exp
+                // if absolute exp = 0, allow indefinite slide
                 var currentLifetime = refreshToken.CreationTime.GetLifetimeInSeconds();
                 _logger.LogDebug("Current lifetime: " + currentLifetime.ToString());
 
                 var newLifetime = currentLifetime + client.SlidingRefreshTokenLifetime;
                 _logger.LogDebug("New lifetime: " + newLifetime.ToString());
 
-                if (newLifetime > client.AbsoluteRefreshTokenLifetime)
+                // zero absolute refresh token lifetime represents unbounded absolute lifetime
+                // if absolute lifetime > 0, cap at absolute lifetime
+                if (client.AbsoluteRefreshTokenLifetime > 0 && newLifetime > client.AbsoluteRefreshTokenLifetime)
                 {
                     newLifetime = client.AbsoluteRefreshTokenLifetime;
                     _logger.LogDebug("New lifetime exceeds absolute lifetime, capping it to " + newLifetime.ToString());

--- a/src/IdentityServer4/Stores/Default/DefaultGrantStore.cs
+++ b/src/IdentityServer4/Stores/Default/DefaultGrantStore.cs
@@ -65,27 +65,20 @@ namespace IdentityServer4.Stores
         /// </summary>
         /// <param name="key">The key.</param>
         /// <returns></returns>
-        protected async Task<T> GetItemAsync(string key)
+        protected virtual async Task<T> GetItemAsync(string key)
         {
             var hashedKey = GetHashedKey(key);
 
             var grant = await _store.GetAsync(hashedKey);
             if (grant != null && grant.Type == _grantType)
             {
-                if (!grant.Expiration.HasExpired())
+                try
                 {
-                    try
-                    {
-                        return _serializer.Deserialize<T>(grant.Data);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError("Failed to deserailize JSON from grant store. Exception: {0}", ex.Message);
-                    }
+                    return _serializer.Deserialize<T>(grant.Data);
                 }
-                else
+                catch (Exception ex)
                 {
-                    _logger.LogDebug("{grantType} grant with value: {key} found in store, but has expired.", _grantType, key);
+                    _logger.LogError("Failed to deserialize JSON from grant store.", ex.Message);
                 }
             }
             else

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
@@ -1,0 +1,238 @@
+﻿using FluentAssertions;
+using IdentityServer4;
+using IdentityServer4.Models;
+using IdentityServer4.Services;
+using IdentityServer4.Stores;
+using IdentityServer4.Stores.Serialization;
+using IdentityServer4.UnitTests.Common;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Services.Default
+{
+    public class DefaultRefreshTokenServiceTests
+    {
+        private DefaultRefreshTokenService _subject;
+        private DefaultRefreshTokenStore _store;
+
+        private ClaimsPrincipal _user = IdentityServerPrincipal.Create("123", "bob");
+
+        public DefaultRefreshTokenServiceTests()
+        {
+            _store = new DefaultRefreshTokenStore(
+                new InMemoryPersistedGrantStore(),
+                new PersistentGrantSerializer(),
+                new DefaultHandleGenerationService(),
+                TestLogger.Create<DefaultRefreshTokenStore>());
+
+            _subject = new DefaultRefreshTokenService(
+                _store,
+                TestLogger.Create<DefaultRefreshTokenService>());
+        }
+
+        [Fact]
+        public async Task CreateRefreshToken_token_exists_in_store()
+        {
+            var client = new Client();
+            var accessToken = new Token();
+
+            var handle = await _subject.CreateRefreshTokenAsync(_user, accessToken, client);
+
+            (await _store.GetRefreshTokenAsync(handle)).Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task CreateRefreshToken_should_match_absolute_lifetime()
+        {
+            var client = new Client
+            {
+                ClientId = "client1",
+                RefreshTokenUsage = TokenUsage.ReUse,
+                RefreshTokenExpiration = TokenExpiration.Absolute,
+                AbsoluteRefreshTokenLifetime = 10
+            };
+
+            var handle = await _subject.CreateRefreshTokenAsync(_user, new Token(), client);
+
+            var refreshToken = (await _store.GetRefreshTokenAsync(handle));
+
+            refreshToken.Should().NotBeNull();
+            refreshToken.Lifetime.ShouldBeEquivalentTo(client.AbsoluteRefreshTokenLifetime);
+        }
+
+        [Fact]
+        public async Task CreateRefreshToken_should_match_sliding_lifetime()
+        {
+            var client = new Client
+            {
+                ClientId = "client1",
+                RefreshTokenUsage = TokenUsage.ReUse,
+                RefreshTokenExpiration = TokenExpiration.Sliding,
+                SlidingRefreshTokenLifetime = 10
+            };
+
+            var handle = await _subject.CreateRefreshTokenAsync(_user, new Token(), client);
+
+            var refreshToken = (await _store.GetRefreshTokenAsync(handle));
+
+            refreshToken.Should().NotBeNull();
+            refreshToken.Lifetime.Should().Be(client.SlidingRefreshTokenLifetime);
+        }
+
+        [Fact]
+        public async Task UpdateRefreshToken_one_time_use_should_create_new_token()
+        {
+            var client = new Client
+            {
+                ClientId = "client1",
+                RefreshTokenUsage = TokenUsage.OneTimeOnly
+            };
+
+            var refreshToken = new RefreshToken
+            {
+                CreationTime = DateTime.UtcNow,
+                Lifetime = 10,
+                AccessToken = new Token
+                {
+                    ClientId = client.ClientId,
+                    Audiences = { "aud" },
+                    CreationTime = DateTime.UtcNow,
+                    Claims = new List<Claim>()
+                    {
+                        new Claim("sub", "123")
+                    }
+                }
+            };
+
+            var handle = await _store.StoreRefreshTokenAsync(refreshToken);
+
+            (await _subject.UpdateRefreshTokenAsync(handle, refreshToken, client))
+                .Should().NotBeNull()
+                .And
+                .NotBe(handle);
+        }
+
+        [Fact]
+        public async Task UpdateRefreshToken_sliding_with_non_zero_absolute_should_update_lifetime()
+        {
+            var client = new Client
+            {
+                ClientId = "client1",
+                RefreshTokenUsage = TokenUsage.ReUse,
+                RefreshTokenExpiration = TokenExpiration.Sliding,
+                SlidingRefreshTokenLifetime = 10,
+                AbsoluteRefreshTokenLifetime = 100
+            };
+
+            var now = DateTime.UtcNow;
+
+            var handle = await _store.StoreRefreshTokenAsync(new RefreshToken
+            {
+                CreationTime = now.AddSeconds(-10),
+                AccessToken = new Token
+                {
+                    ClientId = client.ClientId,
+                    Audiences = { "aud" },
+                    CreationTime = DateTime.UtcNow,
+                    Claims = new List<Claim>()
+                    {
+                        new Claim("sub", "123")
+                    }
+                }
+            });
+
+            var refreshToken = await _store.GetRefreshTokenAsync(handle);
+            var newHandle = await _subject.UpdateRefreshTokenAsync(handle, refreshToken, client);
+
+            newHandle.Should().NotBeNull().And.Be(handle);
+
+            var newRefreshToken = await _store.GetRefreshTokenAsync(newHandle);
+
+            newRefreshToken.Should().NotBeNull();
+            newRefreshToken.Lifetime.Should().Be((int)(now - newRefreshToken.CreationTime).TotalSeconds + client.SlidingRefreshTokenLifetime);
+        }
+
+        [Fact]
+        public async Task UpdateRefreshToken_lifetime_exceeds_absolute_should_be_absolute_lifetime()
+        {
+            var client = new Client
+            {
+                ClientId = "client1",
+                RefreshTokenUsage = TokenUsage.ReUse,
+                RefreshTokenExpiration = TokenExpiration.Sliding,
+                SlidingRefreshTokenLifetime = 10,
+                AbsoluteRefreshTokenLifetime = 1000
+            };
+
+            var now = DateTime.UtcNow;
+
+            var handle = await _store.StoreRefreshTokenAsync(new RefreshToken
+            {
+                CreationTime = now.AddSeconds(-1000),
+                AccessToken = new Token
+                {
+                    ClientId = client.ClientId,
+                    Audiences = { "aud" },
+                    CreationTime = DateTime.UtcNow,
+                    Claims = new List<Claim>()
+                    {
+                        new Claim("sub", "123")
+                    }
+                }
+            });
+
+            var refreshToken = await _store.GetRefreshTokenAsync(handle);
+            var newHandle = await _subject.UpdateRefreshTokenAsync(handle, refreshToken, client);
+
+            newHandle.Should().NotBeNull().And.Be(handle);
+
+            var newRefreshToken = await _store.GetRefreshTokenAsync(newHandle);
+
+            newRefreshToken.Should().NotBeNull();
+            newRefreshToken.Lifetime.Should().Be(client.AbsoluteRefreshTokenLifetime);
+        }
+
+        [Fact]
+        public async Task UpdateRefreshToken_sliding_with_zero_absolute_should_update_lifetime()
+        {
+            var client = new Client
+            {
+                ClientId = "client1",
+                RefreshTokenUsage = TokenUsage.ReUse,
+                RefreshTokenExpiration = TokenExpiration.Sliding,
+                SlidingRefreshTokenLifetime = 10,
+                AbsoluteRefreshTokenLifetime = 0
+            };
+
+            var now = DateTime.UtcNow;
+
+            var handle = await _store.StoreRefreshTokenAsync(new RefreshToken
+            {
+                CreationTime = now.AddSeconds(-1000),
+                AccessToken = new Token
+                {
+                    ClientId = client.ClientId,
+                    Audiences = { "aud" },
+                    CreationTime = DateTime.UtcNow,
+                    Claims = new List<Claim>()
+                    {
+                        new Claim("sub", "123")
+                    }
+                }
+            });
+
+            var refreshToken = await _store.GetRefreshTokenAsync(handle);
+            var newHandle = await _subject.UpdateRefreshTokenAsync(handle, refreshToken, client);
+
+            newHandle.Should().NotBeNull().And.Be(handle);
+
+            var newRefreshToken = await _store.GetRefreshTokenAsync(newHandle);
+
+            newRefreshToken.Should().NotBeNull();
+            newRefreshToken.Lifetime.Should().Be((int)(now - newRefreshToken.CreationTime).TotalSeconds + client.SlidingRefreshTokenLifetime);
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Stores/Default/DefaultPersistedGrantStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/Default/DefaultPersistedGrantStoreTests.cs
@@ -98,26 +98,6 @@ namespace IdentityServer4.UnitTests.Stores.Default
         }
 
         [Fact]
-        public async Task expired_code_should_not_load()
-        {
-            var code1 = new AuthorizationCode()
-            {
-                ClientId = "test",
-                CreationTime = DateTime.UtcNow.AddHours(-1),
-                Lifetime = 10,
-                Subject = _user,
-                CodeChallenge = "challenge",
-                RedirectUri = "http://client/cb",
-                Nonce = "nonce",
-                RequestedScopes = new string[] { "scope1", "scope2" }
-            };
-            var handle = await _codes.StoreAuthorizationCodeAsync(code1);
-            
-            var code2 = await _codes.GetAuthorizationCodeAsync(handle);
-            code2.Should().BeNull();
-        }
-
-        [Fact]
         public async Task StoreRefreshTokenAsync_should_persist_grant()
         {
             var token1 = new RefreshToken()
@@ -180,34 +160,6 @@ namespace IdentityServer4.UnitTests.Stores.Default
             var handle = await _refreshTokens.StoreRefreshTokenAsync(token1);
             await _refreshTokens.RemoveRefreshTokenAsync(handle);
             var token2 = await _refreshTokens.GetRefreshTokenAsync(handle);
-            token2.Should().BeNull();
-        }
-
-        [Fact]
-        public async Task expired_refresh_token_should_not_load()
-        {
-            var token1 = new RefreshToken()
-            {
-                CreationTime = DateTime.UtcNow.AddHours(-1),
-                Lifetime = 10,
-                AccessToken = new Token
-                {
-                    ClientId = "client",
-                    Audiences = { "aud" },
-                    CreationTime = DateTime.UtcNow,
-                    Type = "type",
-                    Claims = new List<Claim>
-                    {
-                        new Claim("sub", "123"),
-                        new Claim("scope", "foo")
-                    }
-                },
-                Version = 1
-            };
-
-            var handle = await _refreshTokens.StoreRefreshTokenAsync(token1);
-            var token2 = await _refreshTokens.GetRefreshTokenAsync(handle);
-
             token2.Should().BeNull();
         }
 
@@ -297,29 +249,6 @@ namespace IdentityServer4.UnitTests.Stores.Default
         }
 
         [Fact]
-        public async Task expired_reference_token_should_not_load()
-        {
-            var token1 = new Token()
-            {
-                ClientId = "client",
-                Audiences = { "aud" },
-                CreationTime = DateTime.UtcNow.AddHours(-1),
-                Type = "type",
-                Claims = new List<Claim>
-                {
-                    new Claim("sub", "123"),
-                    new Claim("scope", "foo")
-                },
-                Version = 1
-            };
-
-            var handle = await _referenceTokens.StoreReferenceTokenAsync(token1);
-
-            var token2 = await _referenceTokens.GetReferenceTokenAsync(handle);
-            token2.Should().BeNull();
-        }
-
-        [Fact]
         public async Task RemoveReferenceTokenAsync_by_sub_and_client_should_remove_grant()
         {
             var token1 = new Token()
@@ -376,24 +305,6 @@ namespace IdentityServer4.UnitTests.Stores.Default
 
             await _userConsent.StoreUserConsentAsync(consent1);
             await _userConsent.RemoveUserConsentAsync("123", "client");
-            var consent2 = await _userConsent.GetUserConsentAsync("123", "client");
-            consent2.Should().BeNull();
-        }
-
-        [Fact]
-        public async Task expired_user_consent_should_not_load()
-        {
-            var consent1 = new Consent()
-            {
-                ClientId = "client",
-                SubjectId = "123",
-                Scopes = new string[] { "foo", "bar" },
-                CreationTime = DateTime.UtcNow.AddHours(-1),
-                Expiration = DateTime.UtcNow.AddSeconds(-1)
-            };
-
-            await _userConsent.StoreUserConsentAsync(consent1);
-
             var consent2 = await _userConsent.GetUserConsentAsync("123", "client");
             consent2.Should().BeNull();
         }


### PR DESCRIPTION
**What issue does this PR address?**

This PR makes RefreshToken behavior to match the documentation ;)
It replays [this 2.x branch PR](https://github.com/IdentityServer/IdentityServer4/pull/1879) (also removes 4 tests that were removed from 2.x branch too - all the rest tests still succeed).

We're still bound to ASP.NET Core 1.x and spend some (happy debugging) hours trying to catch strange RefreshToken behavior, until we found this in logs:
```
Updating refresh token
Current lifetime: 402
New lifetime: 7602
Refresh token expiration is sliding - extending lifetime
New lifetime exceeds absolute lifetime, capping it to 0
Updated refresh token in store
```

**Does this PR introduce a breaking change?**

looks like nope

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)


**Other information**:
