### PR TITLE
Updates fluent assertions to v5 and fixes complile errors

### DIFF
--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -179,7 +179,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
             _mockPipeline.LoginRequest.IdP.Should().Be("idp_value");
             _mockPipeline.LoginRequest.Tenant.Should().Be("tenant_value");
             _mockPipeline.LoginRequest.LoginHint.Should().Be("login_hint_value");
-            _mockPipeline.LoginRequest.AcrValues.ShouldAllBeEquivalentTo(new string[] { "acr_2", "acr_1" });
+            _mockPipeline.LoginRequest.AcrValues.Should().BeEquivalentTo(new string[] { "acr_2", "acr_1" });
             _mockPipeline.LoginRequest.Parameters.AllKeys.Should().Contain("foo");
             _mockPipeline.LoginRequest.Parameters["foo"].Should().Be("bar");
         }
@@ -265,7 +265,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
             authorization.IdentityToken.Should().NotBeNull();
             authorization.State.Should().Be("123_state");
             var scopes = authorization.Scope.Split(' ');
-            scopes.ShouldAllBeEquivalentTo(new string[] { "profile", "api1", "openid" });
+            scopes.Should().BeEquivalentTo(new string[] { "profile", "api1", "openid" });
         }
 
         [Fact]
@@ -980,7 +980,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
                 nonce: "123_nonce");
 
             Func<Task> a = () => _mockPipeline.BrowserClient.GetAsync(url);
-            a.ShouldThrow<Exception>();
+            a.Should().Throw<Exception>();
         }
 
         [Fact]

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -137,7 +137,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
             _mockPipeline.ConsentRequest.ClientId.Should().Be("client2");
             _mockPipeline.ConsentRequest.DisplayMode.Should().Be("popup");
             _mockPipeline.ConsentRequest.UiLocales.Should().Be("ui_locale_value");
-            _mockPipeline.ConsentRequest.ScopesRequested.ShouldAllBeEquivalentTo(new string[] { "api2", "openid", "api1" });
+            _mockPipeline.ConsentRequest.ScopesRequested.Should().BeEquivalentTo(new string[] { "api2", "openid", "api1" });
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
             authorization.IdentityToken.Should().NotBeNull();
             authorization.State.Should().Be("123_state");
             var scopes = authorization.Scope.Split(' ');
-            scopes.ShouldAllBeEquivalentTo(new string[] { "api2", "openid" });
+            scopes.Should().BeEquivalentTo(new string[] { "api2", "openid" });
         }
 
         [Fact()]

--- a/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
 
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.0.0" />
   </ItemGroup>
 
   

--- a/test/IdentityServer.UnitTests/Hosting/EndpointRouterTests.cs
+++ b/test/IdentityServer.UnitTests/Hosting/EndpointRouterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -34,7 +34,7 @@ namespace IdentityServer4.UnitTests.Hosting
         public void Endpoint_ctor_requires_path_to_start_with_slash()
         {
             Action a = () => new Endpoint("ep1", "ep1", typeof(MyEndpointHandler));
-            a.ShouldThrow<ArgumentException>();
+            a.Should().Throw<ArgumentException>();
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
+++ b/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
@@ -103,7 +103,7 @@ namespace IdentityServer4.UnitTests.ResponseHandling
         {
             Func<Task> act = () => _subject.ProcessConsentAsync(null, new ConsentResponse());
 
-            act.ShouldThrow<ArgumentNullException>()
+            act.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("request");
         }
         
@@ -134,7 +134,7 @@ namespace IdentityServer4.UnitTests.ResponseHandling
 
             Func<Task> act = () => _subject.ProcessConsentAsync(request);
 
-            act.ShouldThrow<ArgumentException>()
+            act.Should().Throw<ArgumentException>()
                 .And.Message.Should().Contain("PromptMode");
         }
 
@@ -152,7 +152,7 @@ namespace IdentityServer4.UnitTests.ResponseHandling
 
             Func<Task> act = () => _subject.ProcessConsentAsync(request);
 
-            act.ShouldThrow<ArgumentException>()
+            act.Should().Throw<ArgumentException>()
                 .And.Message.Should().Contain("PromptMode");
         }
 

--- a/test/IdentityServer.UnitTests/ResponseHandling/UserInfoResponseGeneratorTests.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/UserInfoResponseGeneratorTests.cs
@@ -191,7 +191,7 @@ namespace IdentityServer4.UnitTests.ResponseHandling
 
             Func<Task> act = () => _subject.ProcessAsync(result);
 
-            act.ShouldThrow<InvalidOperationException>()
+            act.Should().Throw<InvalidOperationException>()
                 .And.Message.Should().Contain("subject");
         }
 

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
@@ -171,7 +171,7 @@ namespace IdentityServer4.UnitTests.Services.Default
 
             var scopes = claims.Where(x => x.Type == JwtClaimTypes.Scope).Select(x => x.Value);
             scopes.Count().Should().Be(4);
-            scopes.ToArray().ShouldBeEquivalentTo(new string[] { "api1", "api2", "id1", "id2" });
+            scopes.ToArray().Should().BeEquivalentTo(new string[] { "api1", "api2", "id1", "id2" });
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultIdentityServerInteractionServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultIdentityServerInteractionServiceTests.cs
@@ -110,7 +110,7 @@ namespace IdentityServer4.UnitTests.Services.Default
                 new ConsentResponse() { ScopesConsented = new[] { "openid" } }, 
                 null);
 
-            act.ShouldThrow<ArgumentNullException>()
+            act.Should().Throw<ArgumentNullException>()
                 .And.Message.Should().Contain("subject");
         }
 

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultPersistedGrantServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultPersistedGrantServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -215,12 +215,12 @@ namespace IdentityServer4.UnitTests.Services.Default
             var grant1 = grants.First(x => x.ClientId == "client1");
             grant1.SubjectId.Should().Be("123");
             grant1.ClientId.Should().Be("client1");
-            grant1.Scopes.ShouldBeEquivalentTo(new string[] { "foo1", "foo2", "bar1", "bar2", "baz1", "baz2", "quux1", "quux2" });
+            grant1.Scopes.Should().BeEquivalentTo(new string[] { "foo1", "foo2", "bar1", "bar2", "baz1", "baz2", "quux1", "quux2" });
 
             var grant2 = grants.First(x => x.ClientId == "client2");
             grant2.SubjectId.Should().Be("123");
             grant2.ClientId.Should().Be("client2");
-            grant2.Scopes.ShouldBeEquivalentTo(new string[] { "foo3", "bar3", "baz3", "quux3" });
+            grant2.Scopes.Should().BeEquivalentTo(new string[] { "foo3", "bar3", "baz3", "quux3" });
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
@@ -63,7 +63,7 @@ namespace IdentityServer.UnitTests.Services.Default
             var refreshToken = (await _store.GetRefreshTokenAsync(handle));
 
             refreshToken.Should().NotBeNull();
-            refreshToken.Lifetime.ShouldBeEquivalentTo(client.AbsoluteRefreshTokenLifetime);
+            refreshToken.Lifetime.Should().Be(client.AbsoluteRefreshTokenLifetime);
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Stores/Default/DefaultPersistedGrantStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/Default/DefaultPersistedGrantStoreTests.cs
@@ -73,7 +73,7 @@ namespace IdentityServer4.UnitTests.Stores.Default
             code1.CodeChallenge.Should().Be(code2.CodeChallenge);
             code1.RedirectUri.Should().Be(code2.RedirectUri);
             code1.Nonce.Should().Be(code2.Nonce);
-            code1.RequestedScopes.ShouldBeEquivalentTo(code2.RequestedScopes);
+            code1.RequestedScopes.Should().BeEquivalentTo(code2.RequestedScopes);
         }
 
         [Fact]
@@ -291,7 +291,7 @@ namespace IdentityServer4.UnitTests.Stores.Default
 
             consent2.ClientId.Should().Be(consent1.ClientId);
             consent2.SubjectId.Should().Be(consent1.SubjectId);
-            consent2.Scopes.ShouldBeEquivalentTo(new string[] { "bar", "foo" });
+            consent2.Scopes.Should().BeEquivalentTo(new string[] { "bar", "foo" });
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Stores/InMemoryClientStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/InMemoryClientStoreTests.cs
@@ -20,7 +20,7 @@ namespace IdentityServer.UnitTests.Stores
             };
 
             Action act = () => new InMemoryClientStore(clients);
-            act.ShouldThrow<ArgumentException>();
+            act.Should().Throw<ArgumentException>();
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Stores/InMemoryResourcesStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/InMemoryResourcesStoreTests.cs
@@ -27,10 +27,10 @@ namespace IdentityServer.UnitTests.Stores
             };
 
             Action act = () => new InMemoryResourcesStore(identityResources, null);
-            act.ShouldThrow<ArgumentException>();
+            act.Should().Throw<ArgumentException>();
 
             act = () => new InMemoryResourcesStore(null, apiResources);
-            act.ShouldThrow<ArgumentException>();
+            act.Should().Throw<ArgumentException>();
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
+++ b/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
@@ -23,7 +23,7 @@ namespace IdentityServer4.UnitTests.Validation.AuthorizeRequest
 
             Func<Task> act = () => validator.ValidateAsync(null);
 
-            act.ShouldThrow<ArgumentNullException>();
+            act.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Validation/GrantTypesValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/GrantTypesValidation.cs
@@ -57,7 +57,7 @@ namespace IdentityServer4.UnitTests.Validation
 
             Action act = () => client.AllowedGrantTypes = new[] { type1, type2 };
 
-            act.ShouldThrow<InvalidOperationException>();            
+            act.Should().Throw<InvalidOperationException>();            
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace IdentityServer4.UnitTests.Validation
 
             Action act = () => client.AllowedGrantTypes = new[] { "custom1", type2, "custom2", type1 };
 
-            act.ShouldThrow<InvalidOperationException>();
+            act.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace IdentityServer4.UnitTests.Validation
 
             Action act = () => client.AllowedGrantTypes = new[] { "custom1", "custom2", "custom1" };
 
-            act.ShouldThrow<InvalidOperationException>();
+            act.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace IdentityServer4.UnitTests.Validation
 
             Action act = () => client.AllowedGrantTypes = null;
 
-            act.ShouldThrow<ArgumentNullException>();
+            act.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace IdentityServer4.UnitTests.Validation
 
             Action act = () => client.AllowedGrantTypes = new[] { "custo m2" };
 
-            act.ShouldThrow<InvalidOperationException>();
+            act.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace IdentityServer4.UnitTests.Validation
 
             Action act = () => client.AllowedGrantTypes = new[] { "custom1", "custo m2", "custom1" };
 
-            act.ShouldThrow<InvalidOperationException>();
+            act.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -124,7 +124,7 @@ namespace IdentityServer4.UnitTests.Validation
 
             Action act = () => client.AllowedGrantTypes.Add("authorization_code");
 
-            act.ShouldThrow<InvalidOperationException>();
+            act.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_General_Invalid.cs
+++ b/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_General_Invalid.cs
@@ -29,7 +29,7 @@ namespace IdentityServer4.UnitTests.Validation.TokenRequest
 
             Func<Task> act = () => validator.ValidateRequestAsync(null, null);
 
-            act.ShouldThrow<ArgumentNullException>();
+            act.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace IdentityServer4.UnitTests.Validation.TokenRequest
 
             Func<Task> act = () => validator.ValidateRequestAsync(parameters, null);
 
-            act.ShouldThrow<ArgumentNullException>();
+            act.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]


### PR DESCRIPTION
**What issue does this PR address?**
The latest version of fluent assertions has breaking changes in it's api. This PR is meant to update the package to the latest verison and fix any failing tests caused by internal issues. 

**Does this PR introduce a breaking change?**
No, it's purely a change to the tests. 

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
