### PR TITLE
Better exception logging in TokenValidator

### DIFF
--- a/src/IdentityServer4/Hosting/IdentityServerMiddleware.cs
+++ b/src/IdentityServer4/Hosting/IdentityServerMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -65,7 +65,7 @@ namespace IdentityServer4.Hosting
             catch (Exception ex)
             {
                 await events.RaiseAsync(new UnhandledExceptionEvent(ex));
-                _logger.LogCritical("Unhandled exception: {exception}", ex.ToString());
+                _logger.LogCritical(ex, "Unhandled exception: {exception}", ex.Message);
                 throw;
             }
 

--- a/src/IdentityServer4/Validation/TokenValidator.cs
+++ b/src/IdentityServer4/Validation/TokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -316,7 +316,7 @@ namespace IdentityServer4.Validation
             }
             catch (Exception ex)
             {
-                _logger.LogError("JWT token validation error: {exception}", ex.ToString());
+                _logger.LogError(ex, "JWT token validation error: {exception}", ex.Message);
                 return Invalid(OidcConstants.ProtectedResourceErrors.InvalidToken);
             }
         }
@@ -468,7 +468,7 @@ namespace IdentityServer4.Validation
             }
             catch (Exception ex)
             {
-                _logger.LogError("Malformed JWT token: {exception}", ex.ToString());
+                _logger.LogError(ex, "Malformed JWT token: {exception}", ex.Message);
                 return null;
             }
         }


### PR DESCRIPTION
* Use an overload of `LogError` that accepts an Exception object.