### PR TITLE
 Better exception logging in TokenValidator

### DIFF
--- a/src/IdentityServer4/Validation/TokenValidator.cs
+++ b/src/IdentityServer4/Validation/TokenValidator.cs
@@ -316,7 +316,6 @@ namespace IdentityServer4.Validation
             }
             catch (Exception ex)
             {
-                _logger.LogError("JWT token validation error: {exception}", ex.ToString());
                 return Invalid(OidcConstants.ProtectedResourceErrors.InvalidToken);
             }
         }
@@ -468,7 +467,7 @@ namespace IdentityServer4.Validation
             }
             catch (Exception ex)
             {
-                _logger.LogError("Malformed JWT token: {exception}", ex.ToString());
+                _logger.LogError(ex, "Malformed JWT token: {exception}", ex.Message);
                 return null;
             }
         }

--- a/src/IdentityServer4/Validation/TokenValidator.cs
+++ b/src/IdentityServer4/Validation/TokenValidator.cs
@@ -316,6 +316,7 @@ namespace IdentityServer4.Validation
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "JWT token validation error: {exception}", ex.Message);
                 return Invalid(OidcConstants.ProtectedResourceErrors.InvalidToken);
             }
         }


### PR DESCRIPTION
* Use different overload of `LogError`