### PR TITLE
Update authorize.rst Fix IdentityModel example

### DIFF
--- a/docs/endpoints/authorize.rst
+++ b/docs/endpoints/authorize.rst
@@ -75,7 +75,7 @@ IdentityModel
 ^^^^^^^^^^^^^
 You can programmatically create URLs for the authorize endpoint using the `IdentityModel <https://github.com/IdentityModel/IdentityModel2>`_ library::
 
-    var request = new AuthorizeRequest(doc.AuthorizeEndpoint);
+    var request = new RequestUrl(doc.AuthorizeEndpoint);
     var url = request.CreateAuthorizeUrl(
         clientId:     "client",
         responseType: OidcConstants.ResponseTypes.CodeIdToken,


### PR DESCRIPTION
Use RequestUrl class instead of nonexistent AuthorizeRequest

**What issue does this PR address?**

authorize.rst -> IdentityModel example states to use nonexistent AuthorizeRequest instead of RequestUrl (which I consider to the be right pick here?)

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)