### PR TITLE
explicitly set the default value of base target in html response from AuthorizeResult

### DIFF
--- a/src/IdentityServer4/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer4/Endpoints/Results/AuthorizeResult.cs
@@ -169,7 +169,7 @@ namespace IdentityServer4.Endpoints.Results
             return uri;
         }
 
-        private const string FormPostHtml = "<form method='post' action='{uri}'>{body}<noscript><button>Click to continue</button></noscript></form><script>(function(){document.forms[0].submit();})();</script>";
+        private const string FormPostHtml = "<html><head><base target='_self'/></head><body><form method='post' action='{uri}'>{body}<noscript><button>Click to continue</button></noscript></form><script>(function(){document.forms[0].submit();})();</script></body></html>";
 
         private string GetFormPostHtml()
         {

--- a/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -181,6 +181,7 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
             using (var rdr = new StreamReader(_context.Response.Body))
             {
                 var html = rdr.ReadToEnd();
+                html.Should().Contain("<base target='_self'/>");
                 html.Should().Contain("<form method='post' action='http://client/callback'>");
                 html.Should().Contain("<input type='hidden' name='state' value='state' />");
             }


### PR DESCRIPTION
**What issue does this PR address?**
Currently the authorization code flow with response method of form_post works unless attempting to do so from within a dialog window in IE. This is due to the html being returned from `IdentityServer4.Endpoints.Results.AuthorizeResult.cs` not explicitly setting the default value of base target to _self.

If not defined, all other browsers simply imply this value anyway, it purely affects dialog windows created from IE which due to a well known and publicized bug, requires it to be set explicitly.

All other html pages are fine as they can be controlled by the implementation, however this is the only html I have found that is served directly from Identity Server that is affected in this way.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [*] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [*] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Documentation of the default value https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base