### PR TITLE
Add more strict cache control headers when softer headers are already added by HttpContext.SignInAsync

### DIFF
--- a/src/IdentityServer4/Extensions/HttpResponseExtensions.cs
+++ b/src/IdentityServer4/Extensions/HttpResponseExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -47,6 +47,9 @@ namespace Microsoft.AspNetCore.Http
             if (!response.Headers.ContainsKey("Cache-Control"))
             {
                 response.Headers.Add("Cache-Control", "no-store, no-cache, max-age=0");
+            } else
+            {
+                response.Headers["Cache-Control"] = "no-store, no-cache, max-age=0";
             }
             if (!response.Headers.ContainsKey("Pragma"))
             {


### PR DESCRIPTION
**What issue does this PR address?**
When moving through the standard authorization code flow, the request to /connect/authorize/callback has insufficient cache control headers.

This is due to the request to AuthorizeCallbackEndpoint.ProcessAsync() eventually leading to DefaultUserSession.SetClientListPropertyValueAsync() which performs a HttpContext.SignInAsync()

This SignInAsync() by default sets a Cache-Control header of "no-cache", which means that when the request hits HttpResponseExtensions.SetNoCache() the if check fails to properly step-up the cache control to "no-store, no-cache, max-age=0"

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
If you have a preference for how to handle the if check or possibly validate the exact request url prior to modifying the cache control headers, please let me know and I can modify my PR.

Thanks,