### PR TITLE
Fix setting BearerToken

### DIFF
--- a/docs/quickstarts/5_hybrid_and_api_access.rst
+++ b/docs/quickstarts/5_hybrid_and_api_access.rst
@@ -106,7 +106,7 @@ and set it on your *HttpClient*::
         var accessToken = await HttpContext.GetTokenAsync("access_token");
 
         var client = new HttpClient();
-        client.SetBearerToken(accessToken);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         var content = await client.GetStringAsync("http://localhost:5001/identity");
 
         ViewBag.Json = JArray.Parse(content).ToString();


### PR DESCRIPTION
The `SetBearerToken()` extension method is located in `IdentityModel.dll` which won't be referenced in the MvcClient if one follows the walk-through.