### PR TITLE
Add Serilog instructions for ASP.NET Core 2

### DIFF
--- a/docs/topics/logging.rst
+++ b/docs/topics/logging.rst
@@ -13,10 +13,45 @@ We are roughly following the Microsoft guidelines for usage of log levels:
 * ``Error`` For errors and exceptions that cannot be handled. Examples: failed validation of a protocol request.
 * ``Critical`` For failures that require immediate attention. Examples: missing store implementation, invalid key material...
 
-Setup
-^^^^^
+Setup for Serilog
+^^^^^^^^^^^^^^^^^
 We personally like `Serilog <https://serilog.net/>`_ a lot. Give it a try.
 
+
+ASP.NET Core 2.0+
+~~~~~~~~~~~~~~~~~
+For the following configuration you need the ``Serilog.AspNetCore`` and ``Serilog.Sinks.Console`` packages::
+
+
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.Title = "IdentityServer4";
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
+                .Enrich.FromLogContext()
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", theme: AnsiConsoleTheme.Literate)
+                .CreateLogger();
+
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args)
+        {
+            return WebHost.CreateDefaultBuilder(args)
+                    .UseStartup<Startup>()
+                    .UseSerilog()
+                    .Build();
+        }            
+    }
+    
+.NET Core 1.0, 1.1
+~~~~~~~~~~~~~~~~~
 For the following configuration you need the ``Serilog.Extensions.Logging`` and ``Serilog.Sinks.Console`` packages::
 
     public class Program


### PR DESCRIPTION
**What issue does this PR address?**
Serilog setup is different for ASP.NET Core 2

**Does this PR introduce a breaking change?**
Nope, updated docs only

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Tested and found to be working with:
-  IdentityServer4 v2.2.0
- Serilog.AspNetCore v2.1.1
- Serilog.Sinks.Console v3.1.1
