### PR TITLE
Extension Grant flows need all the data of the request at the final build of the claims.

### DIFF
--- a/src/IdentityServer4/Models/Contexts/ProfileDataRequestContext.cs
+++ b/src/IdentityServer4/Models/Contexts/ProfileDataRequestContext.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Generic;
 using System.Security.Claims;
 using System;
+using IdentityServer4.Validation;
 
 namespace IdentityServer4.Models
 {
@@ -33,6 +34,31 @@ namespace IdentityServer4.Models
             Caller = caller ?? throw new ArgumentNullException(nameof(caller));
             RequestedClaimTypes = requestedClaimTypes ?? throw new ArgumentNullException(nameof(requestedClaimTypes));
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProfileDataRequestContext" /> class.
+        /// </summary>
+        /// <param name="validatedRequest">The ValidatedRequest.</param>
+        /// <param name="subject">The subject.</param>
+        /// <param name="client">The client.</param>
+        /// <param name="caller">The caller.</param>
+        /// <param name="requestedClaimTypes">The requested claim types.</param>
+        public ProfileDataRequestContext(ValidatedRequest validatedRequest, ClaimsPrincipal subject, Client client, string caller, IEnumerable<string> requestedClaimTypes)
+        {
+            ValidatedRequest = validatedRequest ?? throw new ArgumentNullException(nameof(validatedRequest));
+            Subject = subject ?? throw new ArgumentNullException(nameof(subject));
+            Client = client ?? throw new ArgumentNullException(nameof(client));
+            Caller = caller ?? throw new ArgumentNullException(nameof(caller));
+            RequestedClaimTypes = requestedClaimTypes ?? throw new ArgumentNullException(nameof(requestedClaimTypes));
+        }
+
+        /// <summary>
+        /// Gets or sets the validatedRequest.
+        /// </summary>
+        /// <value>
+        /// The validatedRequest.
+        /// </value>
+        public ValidatedRequest ValidatedRequest { get; set; }
 
         /// <summary>
         /// Gets or sets the subject.

--- a/src/IdentityServer4/Models/Contexts/ProfileDataRequestContext.cs
+++ b/src/IdentityServer4/Models/Contexts/ProfileDataRequestContext.cs
@@ -36,23 +36,6 @@ namespace IdentityServer4.Models
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ProfileDataRequestContext" /> class.
-        /// </summary>
-        /// <param name="validatedRequest">The ValidatedRequest.</param>
-        /// <param name="subject">The subject.</param>
-        /// <param name="client">The client.</param>
-        /// <param name="caller">The caller.</param>
-        /// <param name="requestedClaimTypes">The requested claim types.</param>
-        public ProfileDataRequestContext(ValidatedRequest validatedRequest, ClaimsPrincipal subject, Client client, string caller, IEnumerable<string> requestedClaimTypes)
-        {
-            ValidatedRequest = validatedRequest ?? throw new ArgumentNullException(nameof(validatedRequest));
-            Subject = subject ?? throw new ArgumentNullException(nameof(subject));
-            Client = client ?? throw new ArgumentNullException(nameof(client));
-            Caller = caller ?? throw new ArgumentNullException(nameof(caller));
-            RequestedClaimTypes = requestedClaimTypes ?? throw new ArgumentNullException(nameof(requestedClaimTypes));
-        }
-
-        /// <summary>
         /// Gets or sets the validatedRequest.
         /// </summary>
         /// <value>

--- a/src/IdentityServer4/Services/DefaultClaimsService.cs
+++ b/src/IdentityServer4/Services/DefaultClaimsService.cs
@@ -76,12 +76,14 @@ namespace IdentityServer4.Services
                 additionalClaimTypes = FilterRequestedClaimTypes(additionalClaimTypes).ToList();
 
                 var context = new ProfileDataRequestContext(
-                    request,
                     subject,
                     request.Client,
                     IdentityServerConstants.ProfileDataCallers.ClaimsProviderIdentityToken,
-                    additionalClaimTypes);
-                context.RequestedResources = resources;
+                    additionalClaimTypes)
+                {
+                    RequestedResources = resources,
+                    ValidatedRequest = request
+                };
 
                 await Profile.GetProfileDataAsync(context);
 
@@ -190,12 +192,14 @@ namespace IdentityServer4.Services
                 additionalClaimTypes = FilterRequestedClaimTypes(additionalClaimTypes).ToList();
 
                 var context = new ProfileDataRequestContext(
-                    request,
                     subject,
                     request.Client,
                     IdentityServerConstants.ProfileDataCallers.ClaimsProviderAccessToken,
-                    additionalClaimTypes.Distinct());
-                context.RequestedResources = resources;
+                    additionalClaimTypes.Distinct())
+                {
+                    RequestedResources = resources,
+                    ValidatedRequest = request
+                };
 
                 await Profile.GetProfileDataAsync(context);
 

--- a/src/IdentityServer4/Services/DefaultClaimsService.cs
+++ b/src/IdentityServer4/Services/DefaultClaimsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -76,6 +76,7 @@ namespace IdentityServer4.Services
                 additionalClaimTypes = FilterRequestedClaimTypes(additionalClaimTypes).ToList();
 
                 var context = new ProfileDataRequestContext(
+                    request,
                     subject,
                     request.Client,
                     IdentityServerConstants.ProfileDataCallers.ClaimsProviderIdentityToken,
@@ -189,6 +190,7 @@ namespace IdentityServer4.Services
                 additionalClaimTypes = FilterRequestedClaimTypes(additionalClaimTypes).ToList();
 
                 var context = new ProfileDataRequestContext(
+                    request,
                     subject,
                     request.Client,
                     IdentityServerConstants.ProfileDataCallers.ClaimsProviderAccessToken,


### PR DESCRIPTION
**What issue does this PR address?**
Given an Extension Grant as an entry condition, there is a need for the IProfileService to have knowledge of the incoming request parameters.
At the moment the only way to pass that knowledge of incoming parameters was to make up a fake claim on the identity in the IExtenstionGrantValidator implementations.

Given that extension grants are custom, the need for all data to be known when the final claims are built should be allowed.


**Does this PR introduce a breaking change?**
Probably, I added a new property to a class.  My C# chops on that type of addition is a little foggy right now.  If it does, I guess I could inherit and add an extension that upcasts to pull the new property.  My understanding is that adding a new property will not break unless some serialization/deserialization happens.  I can't imagine anyone doing that to a temporary context object.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)
Since this is a pass along parameter it is up to the IProfileService implementation to do unit tests on incoming ValidateRequest object in the context.

**Other information**:
