### PR TITLE
API example uses userinfo endpoint

### DIFF
--- a/docs/quickstarts/7_javascript_client.rst
+++ b/docs/quickstarts/7_javascript_client.rst
@@ -172,7 +172,7 @@ Add this code to implement those three functions in our application::
 
     function api() {
         mgr.getUser().then(function (user) {
-            var url = "http://localhost:5001/identity";
+            var url = "http://localhost:5000/connect/userinfo";
 
             var xhr = new XMLHttpRequest();
             xhr.open("GET", url);

--- a/docs/quickstarts/7_javascript_client.rst
+++ b/docs/quickstarts/7_javascript_client.rst
@@ -188,7 +188,7 @@ Add this code to implement those three functions in our application::
         mgr.signoutRedirect();
     }
 
-See: `Protecting an API using Client Credentials <http://docs.identityserver.io/en/release/quickstarts/1_client_credentials.html?highlight=http%3A%2F%2Flocalhost%3A5001%2Fidentity>` for information on how to create the api used in the code above.
+See: `Protecting an API using Client Credentials <http://docs.identityserver.io/en/release/quickstarts/1_client_credentials.html>` for information on how to create the api used in the code above.
 
 **callback.html**
 

--- a/docs/quickstarts/7_javascript_client.rst
+++ b/docs/quickstarts/7_javascript_client.rst
@@ -172,7 +172,7 @@ Add this code to implement those three functions in our application::
 
     function api() {
         mgr.getUser().then(function (user) {
-            var url = "http://localhost:5000/connect/userinfo";
+            var url = "http://localhost:5001/identity";
 
             var xhr = new XMLHttpRequest();
             xhr.open("GET", url);
@@ -187,6 +187,8 @@ Add this code to implement those three functions in our application::
     function logout() {
         mgr.signoutRedirect();
     }
+
+See: `Protecting an API using Client Credentials <http://docs.identityserver.io/en/release/quickstarts/1_client_credentials.html?highlight=http%3A%2F%2Flocalhost%3A5001%2Fidentity>` for information on how to create the api used in the code above.
 
 **callback.html**
 


### PR DESCRIPTION
**What issue does this PR address?**
When running though this sample it does not show anything about creating an api at `http://localhost:5001/identity`.   So unless you have an API set up with its IP and route you cant actually test this.   

By doing this you can automatically test that the bearer token is in fact working rather than having to set up an API on port 5001 which wasn't part of this sample anyway.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

I can add a new image for the one below 

>And click the “API” button to invoke the web API: 

If you guys want but I don't want to bother if your not interested in this change.
