### PR TITLE
Adds AllowAccessTokensViaBrowser to Implicit client example

### DIFF
--- a/docs/quickstarts/3_interactive_login.rst
+++ b/docs/quickstarts/3_interactive_login.rst
@@ -217,7 +217,9 @@ Add the following to your clients configuration::
                 {
                     IdentityServerConstants.StandardScopes.OpenId,
                     IdentityServerConstants.StandardScopes.Profile
-                }
+                },
+
+                AllowAccessTokensViaBrowser = true
             }
         };
     }

--- a/docs/quickstarts/7_javascript_client.rst
+++ b/docs/quickstarts/7_javascript_client.rst
@@ -172,7 +172,7 @@ Add this code to implement those three functions in our application::
 
     function api() {
         mgr.getUser().then(function (user) {
-            var url = "http://localhost:5001/identity";
+            var url = "http://localhost:5000/connect/userinfo";
 
             var xhr = new XMLHttpRequest();
             xhr.open("GET", url);

--- a/docs/quickstarts/7_javascript_client.rst
+++ b/docs/quickstarts/7_javascript_client.rst
@@ -188,7 +188,7 @@ Add this code to implement those three functions in our application::
         mgr.signoutRedirect();
     }
 
-See: `Protecting an API using Client Credentials <http://docs.identityserver.io/en/release/quickstarts/1_client_credentials.html?highlight=http%3A%2F%2Flocalhost%3A5001%2Fidentity>` for information on how to create the api used in the code above.
+See: `Protecting an API using Client Credentials <http://docs.identityserver.io/en/release/quickstarts/1_client_credentials.html>` for information on how to create the api used in the code above.
 
 **callback.html**
 

--- a/docs/quickstarts/7_javascript_client.rst
+++ b/docs/quickstarts/7_javascript_client.rst
@@ -172,7 +172,7 @@ Add this code to implement those three functions in our application::
 
     function api() {
         mgr.getUser().then(function (user) {
-            var url = "http://localhost:5000/connect/userinfo";
+            var url = "http://localhost:5001/identity";
 
             var xhr = new XMLHttpRequest();
             xhr.open("GET", url);
@@ -187,6 +187,8 @@ Add this code to implement those three functions in our application::
     function logout() {
         mgr.signoutRedirect();
     }
+
+See: `Protecting an API using Client Credentials <http://docs.identityserver.io/en/release/quickstarts/1_client_credentials.html?highlight=http%3A%2F%2Flocalhost%3A5001%2Fidentity>` for information on how to create the api used in the code above.
 
 **callback.html**
 


### PR DESCRIPTION
**What issue does this PR address?**

The sample for creating an Implicit client should really contain ` AllowAccessTokensViaBrowser = true`

**Does this PR introduce a breaking change?**

Nopes

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

Copying doucmentation to anwser questions on SO FTW [identityserver4 with redux -oidc client requested access token - but client is not configured to receive access tokens via browser
](https://stackoverflow.com/a/50389408/1841839)
