### PR TITLE
adds check for Client credentials and removes open id scopes

### DIFF
--- a/src/Host/Configuration/Clients.cs
+++ b/src/Host/Configuration/Clients.cs
@@ -26,7 +26,7 @@ namespace Host.Configuration
                     },
 
                     AllowedGrantTypes = GrantTypes.ClientCredentials,
-                    AllowedScopes = { "api1", "api2.read_only" }
+                    AllowedScopes = { "api1", "api2.read_only" , "openid", "profile" }
                 },
 
                 ///////////////////////////////////////////

--- a/src/IdentityServer4/Validation/TokenRequestValidator.cs
+++ b/src/IdentityServer4/Validation/TokenRequestValidator.cs
@@ -584,10 +584,10 @@ namespace IdentityServer4.Validation
                 if (!_validatedRequest.Client.AllowedScopes.IsNullOrEmpty())
                 {
                     var clientAllowedScopes = new List<string>(_validatedRequest.Client.AllowedScopes);
-
                     var grantType = parameters.Get(OidcConstants.TokenRequest.GrantType);
-                    if (GrantTypes.ClientCredentials.Any(a => a.Equals(grantType)))
+                    if (GrantTypes.ClientCredentials.Any(a => a.Equals(grantType)) && clientAllowedScopes.Any(s => s.Equals("openid") || s.Equals("profile")))
                     {
+                        _logger.LogDebug("Client credentials grant type does not support open id scopes removed.");
                         clientAllowedScopes.Remove("openid");
                         clientAllowedScopes.Remove("profile");
                     }

--- a/src/IdentityServer4/Validation/TokenRequestValidator.cs
+++ b/src/IdentityServer4/Validation/TokenRequestValidator.cs
@@ -584,6 +584,14 @@ namespace IdentityServer4.Validation
                 if (!_validatedRequest.Client.AllowedScopes.IsNullOrEmpty())
                 {
                     var clientAllowedScopes = new List<string>(_validatedRequest.Client.AllowedScopes);
+
+                    var grantType = parameters.Get(OidcConstants.TokenRequest.GrantType);
+                    if (GrantTypes.ClientCredentials.Any(a => a.Equals(grantType)))
+                    {
+                        clientAllowedScopes.Remove("openid");
+                        clientAllowedScopes.Remove("profile");
+                    }
+
                     if (_validatedRequest.Client.AllowOfflineAccess)
                     {
                         clientAllowedScopes.Add(IdentityServerConstants.StandardScopes.OfflineAccess);


### PR DESCRIPTION
**What issue does this PR address?**

[2295 Client credentials flow with no scopes breaks after implicit flow set up](https://github.com/IdentityServer/IdentityServer4/issues/2295)

When you are using GrantTypes.ClientCredentials and not send any scopes.  IDs4 automatically grants access to all of the scopes currently set in client.AllowedScopes this is a problem if the open id (openid, profile) had been added.  As these scopes are not valid for the grant type client credentials. 


**Does this PR introduce a breaking change?**

nope.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

I am happy to add a unit test for this if you like.  I just haven't checked out the test projects yet.  I added the open id scopes to the host client already.   I would almost think that any existing test we have would already be picking that up but i haven't checked.

-  Do we have constants for profile and openid?  I hate the idea of having them hard coded. 
-  Would this be better as an extension method?   `clientAllowedScopes.ValidateForGrantTYpe(grantType)
`