### PR TITLE
Dont log SecurityTokenExpiredException as error, since it is not

### DIFF
--- a/src/IdentityServer4/Validation/TokenValidator.cs
+++ b/src/IdentityServer4/Validation/TokenValidator.cs
@@ -314,6 +314,11 @@ namespace IdentityServer4.Validation
                     Jwt = jwt
                 };
             }
+            catch (SecurityTokenExpiredException expiredException)
+            {
+                _logger.LogInformation(expiredException, "JWT token validation error: {exception}", expiredException.Message);
+                return Invalid(OidcConstants.ProtectedResourceErrors.InvalidToken);
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "JWT token validation error: {exception}", ex.Message);


### PR DESCRIPTION
**What issue does this PR address?**
When having "not smart" gateway that is checking accesstokens against the introspect endpoint, lots of errors are logged with SecurityTokenExpiredException, just because of expired tokens. My expectation would not be any error.

**Does this PR introduce a breaking change?**
No, since only logging level is changed..

**Please check if the PR fulfills these requirements**
- [x ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)
No tests of logging..

**Other information**:
It seems possible to also change the return value to "ExpiredToken" instead of "InvalidToken", but for the sake of simplicity and no relationship to my original problem, i kept it out for now. Any thoughts?