### PR TITLE
Make client secret optional while parsing basic authentication secret

### DIFF
--- a/src/IdentityServer4/Validation/BasicAuthenticationSecretParser.cs
+++ b/src/IdentityServer4/Validation/BasicAuthenticationSecretParser.cs
@@ -94,10 +94,10 @@ namespace IdentityServer4.Validation
             var clientId = pair.Substring(0, ix);
             var secret = pair.Substring(ix + 1);
 
-            if (clientId.IsPresent() && secret.IsPresent())
+            if (clientId.IsPresent())
             {
                 if (clientId.Length > _options.InputLengthRestrictions.ClientId ||
-                    secret.Length > _options.InputLengthRestrictions.ClientSecret)
+                    (secret.IsPresent() && secret.Length > _options.InputLengthRestrictions.ClientSecret))
                 {
                     _logger.LogWarning("Client ID or secret exceeds allowed length.");
                     return notfound;
@@ -106,7 +106,7 @@ namespace IdentityServer4.Validation
                 var parsedSecret = new ParsedSecret
                 {
                     Id = Decode(clientId),
-                    Credential = Decode(secret),
+                    Credential = secret.IsMissing() ? null : Decode(secret),
                     Type = IdentityServerConstants.ParsedSecretTypes.SharedSecret
                 };
 

--- a/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
+++ b/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
@@ -22,7 +22,7 @@ namespace IdentityServer4.IntegrationTests.Clients
                 new Client
                 {
                     ClientId = "client",
-                    ClientSecrets = 
+                    ClientSecrets =
                     {
                         new Secret("secret".Sha256())
                     },
@@ -30,7 +30,7 @@ namespace IdentityServer4.IntegrationTests.Clients
                     AllowedGrantTypes = GrantTypes.ClientCredentials,
                     AllowOfflineAccess = true,
 
-                    AllowedScopes = 
+                    AllowedScopes =
                     {
                         "api1", "api2"
                     }
@@ -70,12 +70,19 @@ namespace IdentityServer4.IntegrationTests.Clients
                 new Client
                 {
                     ClientId = "client.no_default_scopes",
-                    ClientSecrets = 
+                    ClientSecrets =
                     {
                         new Secret("secret".Sha256())
                     },
 
                     AllowedGrantTypes = GrantTypes.ClientCredentials
+                },
+                new Client
+                {
+                    ClientId = "client.no_secret",
+                    AllowedGrantTypes = GrantTypes.ClientCredentials,
+                    RequireClientSecret = false,
+                    AllowedScopes = { "api1" }
                 },
 
                 ///////////////////////////////////////////
@@ -84,7 +91,7 @@ namespace IdentityServer4.IntegrationTests.Clients
                 new Client
                 {
                     ClientId = "roclient",
-                    ClientSecrets = 
+                    ClientSecrets =
                     {
                         new Secret("secret".Sha256())
                     },
@@ -92,7 +99,7 @@ namespace IdentityServer4.IntegrationTests.Clients
                     AllowedGrantTypes = GrantTypes.ResourceOwnerPassword,
 
                     AllowOfflineAccess = true,
-                    AllowedScopes = 
+                    AllowedScopes =
                     {
                         IdentityServerConstants.StandardScopes.OpenId,
                         IdentityServerConstants.StandardScopes.Email,
@@ -130,14 +137,14 @@ namespace IdentityServer4.IntegrationTests.Clients
                 new Client
                 {
                     ClientId = "client.custom",
-                    ClientSecrets = 
+                    ClientSecrets =
                     {
                         new Secret("secret".Sha256())
                     },
 
                     AllowedGrantTypes = { "custom", "custom.nosubject" },
 
-                    AllowedScopes = 
+                    AllowedScopes =
                     {
                         "api1", "api2"
                     }
@@ -166,7 +173,7 @@ namespace IdentityServer4.IntegrationTests.Clients
                 new Client
                 {
                     ClientId = "roclient.reference",
-                    ClientSecrets = 
+                    ClientSecrets =
                     {
                         new Secret("secret".Sha256())
                     },
@@ -174,7 +181,7 @@ namespace IdentityServer4.IntegrationTests.Clients
                     AllowedGrantTypes = GrantTypes.ResourceOwnerPassword,
 
                     AllowOfflineAccess = true,
-                    AllowedScopes = 
+                    AllowedScopes =
                     {
                         "api1", "api2"
                     },
@@ -188,7 +195,7 @@ namespace IdentityServer4.IntegrationTests.Clients
                     ClientId = "certificate_base64_valid",
                     Enabled = true,
 
-                    ClientSecrets = 
+                    ClientSecrets =
                     {
                         new Secret
                         {

--- a/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -58,12 +58,29 @@ namespace IdentityServer4.UnitTests.Validation.Secrets
 
         [Fact]
         [Trait("Category", Category)]
+        public async void Valid_BasicAuthentication_Request_With_UserName_Only_And_Colon_For_Optional_ClientSecret()
+        {
+            var context = new DefaultHttpContext();
+
+            var headerValue = string.Format("Basic {0}",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes("client:")));
+            context.Request.Headers.Add("Authorization", new StringValues(headerValue));
+
+            var secret = await _parser.ParseAsync(context);
+
+            secret.Type.Should().Be(IdentityServerConstants.ParsedSecretTypes.SharedSecret);
+            secret.Id.Should().Be("client");
+            secret.Credential.Should().BeNull();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
         public async void BasicAuthentication_Request_With_Empty_Basic_Header()
         {
             var context = new DefaultHttpContext();
 
             context.Request.Headers.Add("Authorization", new StringValues(""));
-                
+
             var secret = await _parser.ParseAsync(context);
 
             secret.Should().BeNull();
@@ -150,21 +167,6 @@ namespace IdentityServer4.UnitTests.Validation.Secrets
 
             var headerValue = string.Format("Basic {0}",
                 Convert.ToBase64String(Encoding.UTF8.GetBytes("client")));
-            context.Request.Headers.Add("Authorization", new StringValues(headerValue));
-
-            var secret = await _parser.ParseAsync(context);
-
-            secret.Should().BeNull();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async void BasicAuthentication_Request_With_Malformed_Credentials_Base64_Encoding_UserName_Only_With_Colon()
-        {
-            var context = new DefaultHttpContext();
-
-            var headerValue = string.Format("Basic {0}",
-                Convert.ToBase64String(Encoding.UTF8.GetBytes("client:")));
             context.Request.Headers.Add("Authorization", new StringValues(headerValue));
 
             var secret = await _parser.ParseAsync(context);


### PR DESCRIPTION
This PR add feature request in #2267 ticket

It doesn't introduce breaking change.