### PR TITLE
Response generator & tests

### DIFF
--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/DeviceFlowOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/DeviceFlowOptions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+namespace IdentityServer4.Configuration
+{
+    /// <summary>
+    /// Configures device flow
+    /// </summary>
+    public class DeviceFlowOptions
+    {
+        /// <summary>
+        /// Gets or sets the default type of the user code.
+        /// </summary>
+        /// <value>
+        /// The default type of the user code.
+        /// </value>
+        public string DefaultUserCodeType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the polling interval in seconds.
+        /// </summary>
+        /// <value>
+        /// The interval in seconds.
+        /// </value>
+        public int Interval { get; set; }
+    }
+}

--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/DeviceFlowOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/DeviceFlowOptions.cs
@@ -15,7 +15,7 @@ namespace IdentityServer4.Configuration
         /// <value>
         /// The default type of the user code.
         /// </value>
-        public string DefaultUserCodeType { get; set; }
+        public string DefaultUserCodeType { get; set; } = IdentityServerConstants.UserCodeTypes.Numeric;
 
         /// <summary>
         /// Gets or sets the polling interval in seconds.

--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -96,5 +96,13 @@ namespace IdentityServer4.Configuration
         /// Gets or sets the Content Security Policy options.
         /// </summary>
         public CspOptions Csp { get; set; } = new CspOptions();
+
+        /// <summary>
+        /// Gets or sets the device flow.
+        /// </summary>
+        /// <value>
+        /// The device flow.
+        /// </value>
+        public DeviceFlowOptions DeviceFlow { get; set; } = new DeviceFlowOptions();
     }
 }

--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -90,5 +90,21 @@ namespace IdentityServer4.Configuration
         /// The cookie message threshold.
         /// </value>
         public int CookieMessageThreshold { get; set; } = Constants.UIConstants.CookieMessageThreshold;
+
+        /// <summary>
+        /// Gets or sets the device verification URL.  If a local URL, the value must start with a leading slash.
+        /// </summary>
+        /// <value>
+        /// The device verification URL.
+        /// </value>
+        public string DeviceVerificationUrl { get; set; } = Constants.UIConstants.DefaultRoutePaths.DeviceVerification;
+
+        /// <summary>
+        /// Gets or sets the device verification user code paramater.
+        /// </summary>
+        /// <value>
+        /// The device verification user code parameter.
+        /// </value>
+        public string DeviceVerificationUserCodeParameter { get; set; } = Constants.UIConstants.DefaultRoutePathParams.UserCode;
     }
 }

--- a/src/IdentityServer4/Constants.cs
+++ b/src/IdentityServer4/Constants.cs
@@ -182,6 +182,7 @@ namespace IdentityServer4
                 public const string Logout = "logoutId";
                 public const string EndSessionCallback = "endSessionId";
                 public const string Custom = "returnUrl";
+                public const string UserCode = "userCode";
             }
 
             public static class DefaultRoutePaths
@@ -190,6 +191,7 @@ namespace IdentityServer4
                 public const string Logout = "/account/logout";
                 public const string Consent = "/consent";
                 public const string Error = "/home/error";
+                public const string DeviceVerification = "/device";
             }
         }
 

--- a/src/IdentityServer4/IdentityServerConstants.cs
+++ b/src/IdentityServer4/IdentityServerConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 #pragma warning disable 1591
@@ -88,6 +88,13 @@ namespace IdentityServer4
             public const string ReferenceToken = "reference_token";
             public const string RefreshToken = "refresh_token";
             public const string UserConsent = "user_consent";
+            public const string DeviceCode = "device_code";
+            public const string UserCode = "user_code";
+        }
+
+        public static class UserCodeTypes
+        {
+            public const string Numeric = "Numeric";
         }
     }
 }

--- a/src/IdentityServer4/Models/Client.cs
+++ b/src/IdentityServer4/Models/Client.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -274,6 +274,22 @@ namespace IdentityServer4.Models
         /// The properties.
         /// </value>
         public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Gets or sets the type of the device flow user code.
+        /// </summary>
+        /// <value>
+        /// The type of the device flow user code.
+        /// </value>
+        public string UserCodeType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the device code lifetime.
+        /// </summary>
+        /// <value>
+        /// The device code lifetime.
+        /// </value>
+        public int DeviceCodeLifetime { get; set; } = 300;
 
         /// <summary>
         /// Validates the grant types.

--- a/src/IdentityServer4/Models/DeviceCode.cs
+++ b/src/IdentityServer4/Models/DeviceCode.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+
+namespace IdentityServer4.Models
+{
+    public class DeviceCode
+    {
+        /// <summary>
+        /// Gets or sets the creation time.
+        /// </summary>
+        /// <value>
+        /// The creation time.
+        /// </value>
+        public DateTime CreationTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lifetime.
+        /// </summary>
+        /// <value>
+        /// The lifetime.
+        /// </value>
+        public int Lifetime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client identifier.
+        /// </summary>
+        /// <value>
+        /// The client identifier.
+        /// </value>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is open identifier.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is open identifier; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsOpenId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is authorized.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is authorized; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsAuthorized { get; set; }
+
+        /// <summary>
+        /// Gets or sets the authorized scopes.
+        /// </summary>
+        /// <value>
+        /// The authorized scopes.
+        /// </value>
+        public IEnumerable<string> AuthorizedScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subject.
+        /// </summary>
+        /// <value>
+        /// The subject.
+        /// </value>
+        public string Subject { get; set; }
+    }
+}

--- a/src/IdentityServer4/Models/DeviceCode.cs
+++ b/src/IdentityServer4/Models/DeviceCode.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 
 namespace IdentityServer4.Models
 {
@@ -63,6 +64,6 @@ namespace IdentityServer4.Models
         /// <value>
         /// The subject.
         /// </value>
-        public string Subject { get; set; }
+        public ClaimsPrincipal Subject { get; set; }
     }
 }

--- a/src/IdentityServer4/Models/UserCode.cs
+++ b/src/IdentityServer4/Models/UserCode.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+
+namespace IdentityServer4.Models
+{
+    public class UserCode
+    {
+        /// <summary>
+        /// Gets or sets the creation time.
+        /// </summary>
+        /// <value>
+        /// The creation time.
+        /// </value>
+        public DateTime CreationTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lifetime.
+        /// </summary>
+        /// <value>
+        /// The lifetime.
+        /// </value>
+        public int Lifetime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client identifier.
+        /// </summary>
+        /// <value>
+        /// The client identifier.
+        /// </value>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the device code.
+        /// </summary>
+        /// <value>
+        /// The device code.
+        /// </value>
+        public string DeviceCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the requested scopes.
+        /// </summary>
+        /// <value>
+        /// The requested scopes.
+        /// </value>
+        public IEnumerable<string> RequestedScopes { get; set; }
+    }
+}

--- a/src/IdentityServer4/ResponseHandling/DeviceAuthorizationResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/DeviceAuthorizationResponseGenerator.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading.Tasks;
 using IdentityServer4.Configuration;
+using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;
 using IdentityServer4.Stores;
@@ -92,9 +93,9 @@ namespace IdentityServer4.ResponseHandling
             response.UserCode = await userCodeGenerator.GenerateAsync();
 
             // generate verification URIs
-            response.VerificationUri = baseUrl + Options.UserInteraction.DeviceVerificationUrl;
+            response.VerificationUri = baseUrl.RemoveTrailingSlash() + Options.UserInteraction.DeviceVerificationUrl;
             if (!string.IsNullOrWhiteSpace(Options.UserInteraction.DeviceVerificationUserCodeParameter))
-                response.VerificationUriComplete = $"{baseUrl}{Options.UserInteraction.DeviceVerificationUserCodeParameter}?{Options.UserInteraction.DeviceVerificationUserCodeParameter}={response.UserCode}";
+                response.VerificationUriComplete = $"{response.VerificationUri}?{Options.UserInteraction.DeviceVerificationUserCodeParameter}={response.UserCode}";
 
             // expiration
             response.DeviceCodeLifetime = validationResult.ValidatedRequest.Client.DeviceCodeLifetime;

--- a/src/IdentityServer4/ResponseHandling/DeviceAuthorizationResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/DeviceAuthorizationResponseGenerator.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System;
+using System.Threading.Tasks;
+using IdentityServer4.Configuration;
+using IdentityServer4.Models;
+using IdentityServer4.Services;
+using IdentityServer4.Stores;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+
+namespace IdentityServer4.ResponseHandling
+{
+    /// <summary>
+    /// The device authorizaiton response generator
+    /// </summary>
+    /// <seealso cref="IdentityServer4.ResponseHandling.IDeviceAuthorizationResponseGenerator" />
+    public class DeviceAuthorizationResponseGenerator : IDeviceAuthorizationResponseGenerator
+    {
+        /// <summary>
+        /// The options
+        /// </summary>
+        protected readonly IdentityServerOptions Options;
+
+        /// <summary>
+        /// The user code service
+        /// </summary>
+        protected readonly IUserCodeService UserCodeService;
+
+        /// <summary>
+        /// The device code store
+        /// </summary>
+        protected readonly IDeviceCodeStore DeviceCodeStore;
+
+        /// <summary>
+        /// The user code store
+        /// </summary>
+        protected readonly IUserCodeStore UserCodeStore;
+
+        /// <summary>
+        /// The clock
+        /// </summary>
+        protected readonly ISystemClock Clock;
+
+        /// <summary>
+        /// The logger
+        /// </summary>
+        protected readonly ILogger Logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceAuthorizationResponseGenerator"/> class.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <param name="userCodeService">The user code service.</param>
+        /// <param name="deviceCodeStore">The device code store.</param>
+        /// <param name="userCodeStore">The user code store.</param>
+        /// <param name="clock">The clock.</param>
+        /// <param name="logger">The logger.</param>
+        public DeviceAuthorizationResponseGenerator(IdentityServerOptions options, IUserCodeService userCodeService, IDeviceCodeStore deviceCodeStore, IUserCodeStore userCodeStore, ISystemClock clock, ILogger<DeviceAuthorizationResponseGenerator> logger)
+        {
+            Options = options;
+            UserCodeService = userCodeService;
+            DeviceCodeStore = deviceCodeStore;
+            UserCodeStore = userCodeStore;
+            Clock = clock;
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Processes the response.
+        /// </summary>
+        /// <param name="validationResult">The validation result.</param>
+        /// <param name="baseUrl">The base URL.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">validationResult or Client</exception>
+        /// <exception cref="ArgumentException">Value cannot be null or whitespace. - baseUrl</exception>
+        public virtual async Task<DeviceAuthorizationResponse> ProcessAsync(DeviceAuthorizationRequestValidationResult validationResult, string baseUrl)
+        {
+            if (validationResult == null) throw new ArgumentNullException(nameof(validationResult));
+            if (validationResult.ValidatedRequest.Client == null) throw new ArgumentNullException(nameof(validationResult.ValidatedRequest.Client));
+            if (string.IsNullOrWhiteSpace(baseUrl)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(baseUrl));
+
+            Logger.LogTrace("Creating response for device authorization request");
+
+            var response = new DeviceAuthorizationResponse();
+
+            // generate user_code
+            var userCodeGenerator = await UserCodeService.GetGenerator(validationResult.ValidatedRequest.Client.UserCodeType ?? Options.DeviceFlow.DefaultUserCodeType);
+            response.UserCode = await userCodeGenerator.GenerateAsync();
+
+            // generate verification URIs
+            response.VerificationUri = baseUrl + Options.UserInteraction.DeviceVerificationUrl;
+            if (!string.IsNullOrWhiteSpace(Options.UserInteraction.DeviceVerificationUserCodeParameter))
+                response.VerificationUriComplete = $"{baseUrl}{Options.UserInteraction.DeviceVerificationUserCodeParameter}?{Options.UserInteraction.DeviceVerificationUserCodeParameter}={response.UserCode}";
+
+            // expiration
+            response.DeviceCodeLifetime = validationResult.ValidatedRequest.Client.DeviceCodeLifetime;
+
+            // interval
+            response.Interval = Options.DeviceFlow.Interval;
+
+            // store device request (device code & user code)
+            response.DeviceCode = await DeviceCodeStore.StoreDeviceCodeAsync(new DeviceCode
+            {
+                ClientId = validationResult.ValidatedRequest.Client.ClientId,
+                IsOpenId = validationResult.ValidatedRequest.IsOpenIdRequest,
+                Lifetime = response.DeviceCodeLifetime,
+                CreationTime = Clock.UtcNow.UtcDateTime
+            });
+
+            await UserCodeStore.StoreUserCodeAsync(response.UserCode, new UserCode
+            {
+                ClientId = validationResult.ValidatedRequest.Client.ClientId,
+                DeviceCode = response.DeviceCode,
+                RequestedScopes = validationResult.ValidatedRequest.RequestedScopes,
+                Lifetime = response.DeviceCodeLifetime,
+                CreationTime = Clock.UtcNow.UtcDateTime,
+            });
+
+            return response;
+        }
+    }
+}

--- a/src/IdentityServer4/ResponseHandling/Interfaces/IDeviceAuthorizationResponseGenerator.cs
+++ b/src/IdentityServer4/ResponseHandling/Interfaces/IDeviceAuthorizationResponseGenerator.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+using IdentityServer4.Validation;
+
+namespace IdentityServer4.ResponseHandling
+{
+    /// <summary>
+    /// Interface for the device authorization response generator
+    /// </summary>
+    public interface IDeviceAuthorizationResponseGenerator
+    {
+        /// <summary>
+        /// Processes the response.
+        /// </summary>
+        /// <param name="validationResult">The validation result.</param>
+        /// <param name="baseUrl">The base URL.</param>
+        /// <returns></returns>
+        Task<DeviceAuthorizationResponse> ProcessAsync(DeviceAuthorizationRequestValidationResult validationResult, string baseUrl);
+    }
+}

--- a/src/IdentityServer4/ResponseHandling/Models/DeviceAuthorizationResponse.cs
+++ b/src/IdentityServer4/ResponseHandling/Models/DeviceAuthorizationResponse.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+namespace IdentityServer4.ResponseHandling
+{
+    public class DeviceAuthorizationResponse
+    {
+        public string DeviceCode { get; set; }
+        public string UserCode { get; set; }
+        public string VerificationUri { get; set; }
+
+        public string VerificationUriComplete { get; set; }
+        public int DeviceCodeLifetime { get; set; }
+        public int Interval { get; set; }
+    }
+}

--- a/src/IdentityServer4/Services/DefaultUserCodeService.cs
+++ b/src/IdentityServer4/Services/DefaultUserCodeService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.Services
+{
+    /// <summary>
+    /// Default user code service implementation.
+    /// </summary>
+    /// <seealso cref="IdentityServer4.Services.IProfileService" />
+    public class DefaultUserCodeService : IUserCodeService
+    {
+        private readonly IEnumerable<IUserCodeGenerator> _generators;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultUserCodeService"/> class.
+        /// </summary>
+        /// <param name="generators">The generators.</param>
+        /// <exception cref="ArgumentNullException">generators</exception>
+        public DefaultUserCodeService(IEnumerable<IUserCodeGenerator> generators)
+        {
+            _generators = generators ?? throw new ArgumentNullException(nameof(generators));
+        }
+
+        /// <summary>
+        /// Gets the user code generator.
+        /// </summary>
+        /// <param name="userCodeType">Type of user code.</param>
+        /// <returns></returns>
+        public Task<IUserCodeGenerator> GetGenerator(string userCodeType) =>
+            Task.FromResult(_generators.FirstOrDefault(x => x.UserCodeType == userCodeType));
+
+    }
+}

--- a/src/IdentityServer4/Services/Interfaces/IUserCodeGenerator.cs
+++ b/src/IdentityServer4/Services/Interfaces/IUserCodeGenerator.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+
+namespace IdentityServer4.Services
+{
+    /// <summary>
+    /// Implements device flow user code generation
+    /// </summary>
+    public interface IUserCodeGenerator
+    {
+        /// <summary>
+        /// Gets the type of the user code.
+        /// </summary>
+        /// <value>
+        /// The type of the user code.
+        /// </value>
+        string UserCodeType { get; }
+
+        /// <summary>
+        /// Generates the user code.
+        /// </summary>
+        /// <returns></returns>
+        Task<string> GenerateAsync();
+    }
+}

--- a/src/IdentityServer4/Services/Interfaces/IUserCodeService.cs
+++ b/src/IdentityServer4/Services/Interfaces/IUserCodeService.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+
+namespace IdentityServer4.Services
+{
+    /// <summary>
+    /// Implements user code generation
+    /// </summary>
+    public interface IUserCodeService
+    {
+        /// <summary>
+        /// Gets the user code generator.
+        /// </summary>
+        /// <param name="userCodeType">Type of user code.</param>
+        /// <returns></returns>
+        Task<IUserCodeGenerator> GetGenerator(string userCodeType);
+    }
+}

--- a/src/IdentityServer4/Services/NumericUserCodeService.cs
+++ b/src/IdentityServer4/Services/NumericUserCodeService.cs
@@ -12,7 +12,7 @@ namespace IdentityServer4.Services
         /// <value>
         /// The type of the user code.
         /// </value>
-        public string UserCodeType => "Numeric";
+        public string UserCodeType => IdentityServerConstants.UserCodeTypes.Numeric;
 
         /// <summary>
         /// Generates the user code.

--- a/src/IdentityServer4/Services/NumericUserCodeService.cs
+++ b/src/IdentityServer4/Services/NumericUserCodeService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.Services
+{
+    public class NumericUserCodeService : IUserCodeGenerator
+    {
+        /// <summary>
+        /// Gets the type of the user code.
+        /// </summary>
+        /// <value>
+        /// The type of the user code.
+        /// </value>
+        public string UserCodeType => "Numeric";
+
+        /// <summary>
+        /// Generates the user code.
+        /// </summary>
+        /// <returns></returns>
+        public Task<string> GenerateAsync()
+        {
+            var next = Next(100000000, 999999999);
+            return Task.FromResult(next.ToString());
+        }
+
+        private int Next(int minValue, int maxValue)
+        {
+            if (minValue > maxValue) throw new ArgumentOutOfRangeException(nameof(minValue));
+            if (minValue == maxValue) return minValue;
+            long diff = maxValue - minValue;
+
+            var uint32Buffer = new byte[8];
+
+            using (var rng = new RNGCryptoServiceProvider())
+            {
+                while (true)
+                {
+                    rng.GetBytes(uint32Buffer);
+                    var rand = BitConverter.ToUInt32(uint32Buffer, 0);
+
+                    const long max = 1 + (long)uint.MaxValue;
+                    var remainder = max % diff;
+                    if (rand < max - remainder)
+                    {
+                        return (int)(minValue + rand % diff);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/IdentityServer4/Stores/Default/DefaultDeviceCodeStore.cs
+++ b/src/IdentityServer4/Stores/Default/DefaultDeviceCodeStore.cs
@@ -22,7 +22,7 @@ namespace IdentityServer4.Stores
         /// <param name="serializer">The serializer.</param>
         /// <param name="handleGenerationService">The handle generation service.</param>
         /// <param name="logger">The logger.</param>
-        protected DefaultDeviceCodeStore(
+        public DefaultDeviceCodeStore(
             IPersistedGrantStore store,
             IPersistentGrantSerializer serializer,
             IHandleGenerationService handleGenerationService,

--- a/src/IdentityServer4/Stores/Default/DefaultDeviceCodeStore.cs
+++ b/src/IdentityServer4/Stores/Default/DefaultDeviceCodeStore.cs
@@ -4,60 +4,59 @@
 
 using System.Threading.Tasks;
 using IdentityServer4.Models;
+using IdentityServer4.Services;
 using IdentityServer4.Stores.Serialization;
 using Microsoft.Extensions.Logging;
-using IdentityServer4.Extensions;
-using IdentityServer4.Services;
 
 namespace IdentityServer4.Stores
 {
     /// <summary>
-    /// Default authorization code store.
+    /// Default device code store.
     /// </summary>
-    public class DefaultAuthorizationCodeStore : DefaultGrantStore<AuthorizationCode>, IAuthorizationCodeStore
+    public class DefaultDeviceCodeStore : DefaultGrantStore<DeviceCode>, IDeviceCodeStore
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultAuthorizationCodeStore"/> class.
+        /// Initializes a new instance of the <see cref="DefaultDeviceCodeStore"/> class.
         /// </summary>
         /// <param name="store">The store.</param>
         /// <param name="serializer">The serializer.</param>
         /// <param name="handleGenerationService">The handle generation service.</param>
         /// <param name="logger">The logger.</param>
-        public DefaultAuthorizationCodeStore(
+        protected DefaultDeviceCodeStore(
             IPersistedGrantStore store,
             IPersistentGrantSerializer serializer,
             IHandleGenerationService handleGenerationService,
-            ILogger<DefaultAuthorizationCodeStore> logger)
-            : base(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode, store, serializer, handleGenerationService, logger)
+            ILogger logger)
+            : base(IdentityServerConstants.PersistedGrantTypes.DeviceCode, store, serializer, handleGenerationService, logger)
         {
         }
 
         /// <summary>
-        /// Stores the authorization code asynchronous.
+        /// Stores the device code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        public Task<string> StoreAuthorizationCodeAsync(AuthorizationCode code)
+        public Task<string> StoreDeviceCodeAsync(DeviceCode code)
         {
-            return CreateItemAsync(code, code.ClientId, code.Subject.GetSubjectId(), code.CreationTime, code.Lifetime);
+            return CreateItemAsync(code, code.ClientId, null, code.CreationTime, code.Lifetime);
         }
 
         /// <summary>
-        /// Gets the authorization code asynchronous.
+        /// Gets the device code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        public Task<AuthorizationCode> GetAuthorizationCodeAsync(string code)
+        public Task<DeviceCode> GetDeviceCodeAsync(string code)
         {
             return GetItemAsync(code);
         }
 
         /// <summary>
-        /// Removes the authorization code asynchronous.
+        /// Removes the device code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        public Task RemoveAuthorizationCodeAsync(string code)
+        public Task RemoveDeviceCodeAsync(string code)
         {
             return RemoveItemAsync(code);
         }

--- a/src/IdentityServer4/Stores/Default/DefaultUserCodeStore.cs
+++ b/src/IdentityServer4/Stores/Default/DefaultUserCodeStore.cs
@@ -4,60 +4,60 @@
 
 using System.Threading.Tasks;
 using IdentityServer4.Models;
+using IdentityServer4.Services;
 using IdentityServer4.Stores.Serialization;
 using Microsoft.Extensions.Logging;
-using IdentityServer4.Extensions;
-using IdentityServer4.Services;
 
 namespace IdentityServer4.Stores
 {
     /// <summary>
-    /// Default authorization code store.
+    /// Default user code store.
     /// </summary>
-    public class DefaultAuthorizationCodeStore : DefaultGrantStore<AuthorizationCode>, IAuthorizationCodeStore
+    public class DefaultUserCodeStore : DefaultGrantStore<UserCode>, IUserCodeStore
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultAuthorizationCodeStore"/> class.
+        /// Initializes a new instance of the <see cref="DefaultUserCodeStore"/> class.
         /// </summary>
         /// <param name="store">The store.</param>
         /// <param name="serializer">The serializer.</param>
         /// <param name="handleGenerationService">The handle generation service.</param>
         /// <param name="logger">The logger.</param>
-        public DefaultAuthorizationCodeStore(
+        protected DefaultUserCodeStore(
             IPersistedGrantStore store,
             IPersistentGrantSerializer serializer,
             IHandleGenerationService handleGenerationService,
-            ILogger<DefaultAuthorizationCodeStore> logger)
-            : base(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode, store, serializer, handleGenerationService, logger)
+            ILogger logger)
+            : base(IdentityServerConstants.PersistedGrantTypes.DeviceCode, store, serializer, handleGenerationService, logger)
         {
         }
 
         /// <summary>
-        /// Stores the authorization code asynchronous.
+        /// Stores the user code.
         /// </summary>
         /// <param name="code">The code.</param>
+        /// <param name="data">The data.</param>
         /// <returns></returns>
-        public Task<string> StoreAuthorizationCodeAsync(AuthorizationCode code)
+        public Task StoreUserCodeAsync(string code, UserCode data)
         {
-            return CreateItemAsync(code, code.ClientId, code.Subject.GetSubjectId(), code.CreationTime, code.Lifetime);
+            return StoreItemAsync(code, data, data.ClientId, null, data.CreationTime, data.Lifetime);
         }
 
         /// <summary>
-        /// Gets the authorization code asynchronous.
+        /// Gets the user code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        public Task<AuthorizationCode> GetAuthorizationCodeAsync(string code)
+        public Task<UserCode> GetUserCodeAsync(string code)
         {
             return GetItemAsync(code);
         }
 
         /// <summary>
-        /// Removes the authorization code asynchronous.
+        /// Removes the user code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        public Task RemoveAuthorizationCodeAsync(string code)
+        public Task RemoveUserCodeAsync(string code)
         {
             return RemoveItemAsync(code);
         }

--- a/src/IdentityServer4/Stores/Default/DefaultUserCodeStore.cs
+++ b/src/IdentityServer4/Stores/Default/DefaultUserCodeStore.cs
@@ -22,7 +22,7 @@ namespace IdentityServer4.Stores
         /// <param name="serializer">The serializer.</param>
         /// <param name="handleGenerationService">The handle generation service.</param>
         /// <param name="logger">The logger.</param>
-        protected DefaultUserCodeStore(
+        public DefaultUserCodeStore(
             IPersistedGrantStore store,
             IPersistentGrantSerializer serializer,
             IHandleGenerationService handleGenerationService,

--- a/src/IdentityServer4/Stores/IDeviceCodeStore.cs
+++ b/src/IdentityServer4/Stores/IDeviceCodeStore.cs
@@ -2,35 +2,35 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Models;
 using System.Threading.Tasks;
+using IdentityServer4.Models;
 
 namespace IdentityServer4.Stores
 {
     /// <summary>
-    /// Interface for the authorization code store
+    /// Interface for the device code store
     /// </summary>
-    public interface IAuthorizationCodeStore
+    public interface IDeviceCodeStore
     {
         /// <summary>
-        /// Stores the authorization code.
+        /// Stores the device code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        Task<string> StoreAuthorizationCodeAsync(AuthorizationCode code);
+        Task<string> StoreDeviceCodeAsync(DeviceCode code);
 
         /// <summary>
-        /// Gets the authorization code.
+        /// Gets the device code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        Task<AuthorizationCode> GetAuthorizationCodeAsync(string code);
+        Task<DeviceCode> GetDeviceCodeAsync(string code);
 
         /// <summary>
-        /// Removes the authorization code.
+        /// Removes the device code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        Task RemoveAuthorizationCodeAsync(string code);
-   }
+        Task RemoveDeviceCodeAsync(string code);
+    }
 }

--- a/src/IdentityServer4/Stores/IUserCodeStore.cs
+++ b/src/IdentityServer4/Stores/IUserCodeStore.cs
@@ -2,35 +2,36 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Models;
 using System.Threading.Tasks;
+using IdentityServer4.Models;
 
 namespace IdentityServer4.Stores
 {
     /// <summary>
-    /// Interface for the authorization code store
+    /// Interface for the user code store
     /// </summary>
-    public interface IAuthorizationCodeStore
+    public interface IUserCodeStore
     {
         /// <summary>
-        /// Stores the authorization code.
+        /// Stores the user code.
         /// </summary>
         /// <param name="code">The code.</param>
+        /// <param name="data">The data.</param>
         /// <returns></returns>
-        Task<string> StoreAuthorizationCodeAsync(AuthorizationCode code);
+        Task StoreUserCodeAsync(string code, UserCode data);
 
         /// <summary>
-        /// Gets the authorization code.
+        /// Gets the user code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        Task<AuthorizationCode> GetAuthorizationCodeAsync(string code);
+        Task<UserCode> GetUserCodeAsync(string code);
 
         /// <summary>
-        /// Removes the authorization code.
+        /// Removes the user code.
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
-        Task RemoveAuthorizationCodeAsync(string code);
-   }
+        Task RemoveUserCodeAsync(string code);
+    }
 }

--- a/test/IdentityServer.UnitTests/Common/MockDeviceCodeStore.cs
+++ b/test/IdentityServer.UnitTests/Common/MockDeviceCodeStore.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using IdentityServer4.Models;
+using IdentityServer4.Stores;
+
+namespace IdentityServer.UnitTests.Common
+{
+    public class MockDeviceCodeStore : IDeviceCodeStore
+    {
+        public Dictionary<string, DeviceCode> Codes { get; set; } = new Dictionary<string, DeviceCode>();
+
+        public Task<string> StoreDeviceCodeAsync(DeviceCode code)
+        {
+            var id = Guid.NewGuid().ToString();
+            Codes[id] = code;
+            return Task.FromResult(id);
+        }
+
+        public Task<DeviceCode> GetDeviceCodeAsync(string code)
+        {
+            DeviceCode val = null;
+            if (code != null)
+            {
+                Codes.TryGetValue(code, out val);
+            }
+            return Task.FromResult(val);
+        }
+
+        public Task RemoveDeviceCodeAsync(string code)
+        {
+            if (code != null && Codes.ContainsKey(code))
+            {
+                Codes.Remove(code);
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Common/MockUserCodeStore.cs
+++ b/test/IdentityServer.UnitTests/Common/MockUserCodeStore.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using IdentityServer4.Models;
+using IdentityServer4.Stores;
+
+namespace IdentityServer.UnitTests.Common
+{
+    public class MockUserCodeStore : IUserCodeStore
+    {
+        public Dictionary<string, UserCode> Codes { get; set; } = new Dictionary<string, UserCode>();
+
+        public Task StoreUserCodeAsync(string code, UserCode data)
+        {
+            Codes[code] = data;
+            return Task.CompletedTask;
+        }
+
+        public Task<UserCode> GetUserCodeAsync(string code)
+        {
+            UserCode val = null;
+            if (code != null)
+            {
+                Codes.TryGetValue(code, out val);
+            }
+            return Task.FromResult(val);
+        }
+
+        public Task RemoveUserCodeAsync(string code)
+        {
+            if (code != null && Codes.ContainsKey(code))
+            {
+                Codes.Remove(code);
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/ResponseHandling/DeviceAuthorizationResponseGeneratorTests.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/DeviceAuthorizationResponseGeneratorTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer.UnitTests.Common;
+using IdentityServer4.Configuration;
+using IdentityServer4.Models;
+using IdentityServer4.ResponseHandling;
+using IdentityServer4.Services;
+using IdentityServer4.Stores;
+using IdentityServer4.Validation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IdentityServer4.UnitTests.ResponseHandling
+{
+    public class DeviceAuthorizationResponseGeneratorTests
+    {
+        private List<IdentityResource> identityResources = new List<IdentityResource> {new IdentityResources.OpenId(), new IdentityResources.Profile()};
+        private List<ApiResource> apiResources = new List<ApiResource> {new ApiResource("resource") {Scopes = new List<Scope> {new Scope("api1")}}};
+        private MockDeviceCodeStore deviceCodeStore = new MockDeviceCodeStore();
+        private MockUserCodeStore userCodeStore = new MockUserCodeStore();
+        private IdentityServerOptions options = new IdentityServerOptions();
+        
+        private readonly DeviceAuthorizationResponseGenerator generator;
+        private readonly DeviceAuthorizationRequestValidationResult testResult;
+        private readonly string testBaseUrl = "http://localhost:5000/";
+
+        public DeviceAuthorizationResponseGeneratorTests()
+        {
+            var resourceStore = new InMemoryResourcesStore(identityResources, apiResources);
+            var scopeValidator = new ScopeValidator(resourceStore, new NullLogger<ScopeValidator>());
+            
+            testResult = new DeviceAuthorizationRequestValidationResult(new ValidatedDeviceAuthorizationRequest
+            {
+                Client = new Client {ClientId = Guid.NewGuid().ToString()},
+                IsOpenIdRequest = true,
+                ValidatedScopes = scopeValidator
+            });
+
+            generator = new DeviceAuthorizationResponseGenerator(options, new DefaultUserCodeService(new[] {new NumericUserCodeService()}),
+                deviceCodeStore, userCodeStore, new StubClock(), new NullLogger<DeviceAuthorizationResponseGenerator>());
+        }
+
+        [Fact]
+        public void ProcessAsync_when_valiationresult_null_exect_exception()
+        {
+            Func<Task> act = () => generator.ProcessAsync(null, testBaseUrl);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ProcessAsync_when_valiationresult_client_null_exect_exception()
+        {
+            var validationResult = new DeviceAuthorizationRequestValidationResult(new ValidatedDeviceAuthorizationRequest());
+            Func <Task> act = () => generator.ProcessAsync(validationResult, testBaseUrl);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ProcessAsync_when_baseurl_null_exect_exception()
+        {
+            Func<Task> act = () => generator.ProcessAsync(testResult, null);
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public async Task ProcessAsync_when_generated_expect_user_code_stored()
+        {
+            var response = await generator.ProcessAsync(testResult, testBaseUrl);
+
+            response.UserCode.Should().NotBeNullOrWhiteSpace();
+
+            var userCode = userCodeStore.Codes[response.UserCode];
+            userCode.Should().NotBeNull();
+            userCode.DeviceCode.Should().Be(response.DeviceCode);
+            userCode.ClientId.Should().Be(testResult.ValidatedRequest.Client.ClientId);
+            userCode.Lifetime.Should().Be(testResult.ValidatedRequest.Client.DeviceCodeLifetime);
+
+            // TODO: verify scopes
+        }
+
+        [Fact]
+        public async Task ProcessAsync_when_generated_expect_correct_uris()
+        {
+            const string baseUrl = "http://localhost:5000/";
+            options.UserInteraction.DeviceVerificationUrl = "/device";
+            options.UserInteraction.DeviceVerificationUserCodeParameter = "userCode";
+
+            var response = await generator.ProcessAsync(testResult, baseUrl);
+
+            response.VerificationUri.Should().Be("http://localhost:5000/device");
+            response.VerificationUriComplete.Should().StartWith("http://localhost:5000/device?userCode=");
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Services/Default/NumericUserCodeServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/NumericUserCodeServiceTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Services;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Services.Default
+{
+    public class NumericUserCodeServiceTests
+    {
+        [Fact]
+        public async Task GenerateAsync_should_have_minimal_duplicates()
+        {
+            const int count = 500000;
+            var taks = new List<Task<string>>(count);
+            var sut = new NumericUserCodeService();
+
+            for (var i = 0; i < count; i++) taks.Add(sut.GenerateAsync());
+
+            var codes = await Task.WhenAll(taks);
+
+            // ~ 1 duplicate per 25000 is acceptable
+            var duplicates = codes.GroupBy(x => x).Where(x => 2 < x.Count()).Select(x => x.Key).ToList();
+            duplicates.Should().BeEmpty();
+
+        }
+    }
+}


### PR DESCRIPTION
Device authorization response generator & tests.

User codes currently use a 9 digit code, which starts having collisions near 25,000, which I think is acceptable. Collisions are not currently handled.

Interval is set globally in the IdentityOptions.

