### PR TITLE
Remove obsolete constructor on DefaultCustomTokenValidator

### DIFF
--- a/src/Validation/Default/DefaultCustomTokenValidator.cs
+++ b/src/Validation/Default/DefaultCustomTokenValidator.cs
@@ -13,7 +13,6 @@ namespace IdentityServer4.Validation
     /// <summary>
     /// Default custom token validator
     /// </summary>
-    [Obsolete("Deriving from/using this type is not recommended. It will change in the next version")]
     public class DefaultCustomTokenValidator : ICustomTokenValidator
     {
         /// <summary>
@@ -34,16 +33,11 @@ namespace IdentityServer4.Validation
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultCustomTokenValidator"/> class.
         /// </summary>
-        /// <param name="profile">The profile service</param>
-        /// <param name="clients">The client store.</param>
-        /// <param name="logger">The logger</param>
-        public DefaultCustomTokenValidator(IProfileService profile, IClientStore clients, ILogger<DefaultCustomTokenValidator> logger)
+        public DefaultCustomTokenValidator()
         {
-            Logger = logger;
-            Profile = profile;
-            Clients = clients;
-        }
 
+        }
+        
         /// <summary>
         /// Custom validation logic for access tokens.
         /// </summary>

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -202,10 +202,7 @@ namespace IdentityServer4.UnitTests.Validation
                 profile: profile,
                 referenceTokenStore: store,
                 refreshTokenStore: refreshTokenStore,
-                customValidator: new DefaultCustomTokenValidator(
-                    profile: profile,
-                    clients: clients,
-                    logger: TestLogger.Create<DefaultCustomTokenValidator>()),
+                customValidator: new DefaultCustomTokenValidator(),
                     keys: new DefaultKeyMaterialService(new[] { new DefaultValidationKeysStore(new[] { TestCert.LoadSigningCredentials().Key }) }),
                 logger: logger,
                 options: options,


### PR DESCRIPTION
This is technically a breaking change - but we had the obsolete attribute on it for a while now.