### PR TITLE
Make some internal types public to facilitate custom service implementations

### DIFF
--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -14,7 +14,6 @@ namespace IdentityServer4
         public const string IdentityServerName               = "IdentityServer4";
         public const string IdentityServerAuthenticationType = IdentityServerName;
         public const string ExternalAuthenticationMethod     = "external";
-        public const string AccessTokenAudience              = "{0}resources";
         public const string DefaultHashAlgorithm             = "SHA256";
 
         public static readonly TimeSpan DefaultCookieTimeSpan = TimeSpan.FromHours(10);

--- a/src/Extensions/ClientExtensions.cs
+++ b/src/Extensions/ClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace IdentityServer4.Models
 {
-    internal static class ClientExtensions
+    public static class ClientExtensions
     {
         public static bool IsImplicitOnly(this Client client)
         {

--- a/src/Extensions/IdentityServerToolsExtensions.cs
+++ b/src/Extensions/IdentityServerToolsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -37,7 +37,7 @@ namespace IdentityServer4
                 }
             }
 
-            claims.Add(new Claim(JwtClaimTypes.Audience, string.Format(Constants.AccessTokenAudience, tools.ContextAccessor.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash())));
+            claims.Add(new Claim(JwtClaimTypes.Audience, string.Format(IdentityServerConstants.AccessTokenAudience, tools.ContextAccessor.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash())));
             if (!audiences.IsNullOrEmpty())
             {
                 foreach (var audience in audiences)

--- a/src/IdentityServerConstants.cs
+++ b/src/IdentityServerConstants.cs
@@ -12,6 +12,7 @@ namespace IdentityServer4
         public const string SignoutScheme = "idsrv";
         public const string ExternalCookieAuthenticationScheme = "idsrv.external";
         public const string DefaultCheckSessionCookieName = "idsrv.session";
+        public const string AccessTokenAudience = "{0}resources";
 
         public static class ProtocolTypes
         {

--- a/src/Models/TokenCreationRequest.cs
+++ b/src/Models/TokenCreationRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -69,7 +69,10 @@ namespace IdentityServer4.Models
         /// </value>
         public string Nonce { get; set; }
 
-        internal void Validate()
+        /// <summary>
+        /// Called to validate the <see cref="TokenCreationRequest"/> before it is processed.
+        /// </summary>
+        public void Validate()
         {
             if (Resources == null) throw new ArgumentNullException(nameof(Resources));
             if (ValidatedRequest == null) throw new ArgumentNullException(nameof(ValidatedRequest));

--- a/src/Services/Default/DefaultTokenService.cs
+++ b/src/Services/Default/DefaultTokenService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -170,7 +170,7 @@ namespace IdentityServer4.Services
             var token = new Token(OidcConstants.TokenTypes.AccessToken)
             {
                 CreationTime = Clock.UtcNow.UtcDateTime,
-                Audiences = { string.Format(Constants.AccessTokenAudience, issuer.EnsureTrailingSlash()) },
+                Audiences = { string.Format(IdentityServerConstants.AccessTokenAudience, issuer.EnsureTrailingSlash()) },
                 Issuer = issuer,
                 Lifetime = request.ValidatedRequest.AccessTokenLifetime,
                 Claims = claims,

--- a/src/Validation/Default/TokenValidator.cs
+++ b/src/Validation/Default/TokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -171,7 +171,7 @@ namespace IdentityServer4.Validation
                 _log.AccessTokenType = AccessTokenType.Jwt.ToString();
                 result = await ValidateJwtAsync(
                     token,
-                    string.Format(Constants.AccessTokenAudience, _context.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash()),
+                    string.Format(IdentityServerConstants.AccessTokenAudience, _context.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash()),
                     await _keys.GetValidationKeysAsync());
             }
             else


### PR DESCRIPTION
We have had to create a few custom services for IdSvr4 interfaces.  In several cases we've had to copy/paste internal constants, extension methods or validation methods to facilitate reuse of the default services.

This PR simply makes a few types/members public so we can reference/reuse them from our custom service types.

I used a `#pragma` to disable warnings about no xml documentation for all the many constants members that are now public - I figure the constants are fairly self-explanatory.

I realise there may be reasons for having made these types internal but if not, it would be helpful to enable their reuse.

cheers