### PR TITLE
Create jwk document when signing with JsonWebKey

### DIFF
--- a/src/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -343,6 +343,23 @@ namespace IdentityServer4.ResponseHandling
 
                     webKeys.Add(webKey);
                 }
+
+                if (key is JsonWebKey jsonWebKey)
+                {
+                    var webKey = new Models.JsonWebKey
+                    {
+                        kty = jsonWebKey.Kty,
+                        use = jsonWebKey.Use ?? "sig",
+                        kid = jsonWebKey.Kid,
+                        x5t = jsonWebKey.X5t,
+                        e = jsonWebKey.E,
+                        n = jsonWebKey.N,
+                        x5c = jsonWebKey.X5c?.Count == 0 ? null : jsonWebKey.X5c.ToArray(),
+                        alg = jsonWebKey.Alg
+                    };
+
+                    webKeys.Add(webKey);
+                }
             }
 
             return webKeys;


### PR DESCRIPTION
**What issue does this PR address?**
We can use Json Web Key as signing credential, but it's not correctly published in JWK document.
This patch will extract and publish public key from the signing key.

```csharp
var jwk = new JsonWebKey(File.ReadAllText(@"tempkey.jwk"));
services.AddIdentityServer().AddSigningCredential(new SigningCredentials(jwk, jwk.Alg))
```

Before
```bash
$ curl http://localhost:5000/.well-known/openid-configuration/jwks
{"keys":[]}
```

After
```bash
$ curl http://localhost:5000/.well-known/openid-configuration/jwks
{"keys":[{"kty":"RSA","use":"sig","kid":"035bde8d153c62981943dc1c89a4665f","e":"AQAB","n":"gx9xGYUqBdsxC0TFZjy4qLQDn6f711LSRkpWpezKgpneKJoL1LKd0Y4SghANh5w3hDKXdLbMHcqHtdPXNbZset7FV9lJy2XN8aiWvenXeYbDu7D0VtBZe8ayiYZQGn6flD0iCBtqfMiFtozhg2KzTCfLc5_jNFBzoblnonB5ntWppSR9Yk_lbqlQ6SXuFo35TUaVjz39aIKwvIhhw6pwZvOgSVbuAvbZuHcZqE5rTJ2I_rZGkVoo-Pzr5cNc9mwARmhj9Z05ok7seCozXzxpEnNKUNYrYuPK39cPCt13ir6hH35g17OGTf2tDvVCNm_ue_PuqaTL4vI3ZHG1ZZ6sEw","alg":"RS256"}]}
```
**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
None