### PR TITLE
Change: Made DefaultUserSession.AuthenticateAsync overrideable

### DIFF
--- a/src/Services/Default/DefaultUserSession.cs
+++ b/src/Services/Default/DefaultUserSession.cs
@@ -120,16 +120,16 @@ namespace IdentityServer4.Services
             return defaultScheme.Name;
         }
 
-        // we need this helper (and can't call HttpContext.AuthenticateAsync) so we don't run 
+        // we need this helper (and can't call HttpContext.AuthenticateAsync) so we don't run
         // claims transformation when we get the principal. this also ensures that we don't
         // re-issue a cookie that includes the claims from claims transformation.
-        // 
+        //
         // also, by caching the _principal/_properties it allows someone to issue a new
         // cookie (via HttpContext.SignInAsync) and we'll use those new values, rather than
         // just reading the incoming cookie
-        // 
+        //
         // this design requires this to be in DI as scoped
-        private async Task AuthenticateAsync()
+        protected virtual async Task AuthenticateAsync()
         {
             if (Principal == null || Properties == null)
             {


### PR DESCRIPTION
Made DefaultUserSession.AuthenticateAsync overrideable so that  it will be easier to support user impersonation.

**What issue does this PR address?**
We need to support impersonations - you are logged in as one user, but then you temporarily switch to another user. Necessary for any setup with a lot of customers, when your support team must be able to act as a user, but you don't want to know everybody's passwords. 

To support that we have introduced a special cookie with target user name. If cookie is set and real logged in user can impersonate, then user principal in the session gets changed into target user principle. I found no better way of implementing it than to sublcass DefaultUserSession like this:

```csharp
protected override async Task AuthenticateAsync()
{
    if ( Principal == null || Properties == null )
    {
        await base.AuthenticateAsync();
        if ( Principal == null ) return;
        // Check that user can impersonate
        var canImpersonate = Principal.GetFirstUserClaim( LogexClaimTypes.CanImpersonate );
        if ( canImpersonate != "true" ) return; 
        var context = HttpContextAccessor.HttpContext;
        // Check impersonation cookie
        if ( !context.Request.Cookies.TryGetValue( CookieConstants.ImpersonateCookie, out var impersonatedUserLogin )
             || string.IsNullOrWhiteSpace( impersonatedUserLogin ))
        {
            return;
        }
        // Get user to impersonate
        var user = _userStore.FindByUsername( impersonatedUserLogin, false );
        if ( user == null )
        {
            Logger.LogError( "Impersonation user {login} is not found", impersonatedUserLogin );
            return;
        }
        var identity = Principal.Identities.First();
        var claims = Principal.Claims
            .Where( x => x.Type != JwtClaimTypes.Subject
                      && x.Type != identity.NameClaimType )
            .ToList();
        claims.Add( new Claim( JwtClaimTypes.Subject, user.SubjectId ) );
        claims.Add( new Claim( identity.NameClaimType, user.Username ) );
        claims.Add( new Claim( LogexClaimTypes.Impersonator, Principal.GetSubjectId() ) );
        var replacementIdentity = new ClaimsIdentity(
            claims,
            Principal.Identity.AuthenticationType,
            identity.NameClaimType,
            LogexClaimTypes.Role );
        Principal = new ClaimsPrincipal( replacementIdentity );
    }
}
```

Works fine (so far), but I need `AuthenticateAsync` method to be open for modifications.

**Does this PR introduce a breaking change?**
No breaking changes.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
