### PR TITLE
Update secrets.rst

### DIFF
--- a/docs/topics/secrets.rst
+++ b/docs/topics/secrets.rst
@@ -83,7 +83,7 @@ Secret extensibility typically consists of three things:
 Secret parsers and validators are implementations of the ``ISecretParser`` and ``ISecretValidator`` interfaces. 
 To make them available to IdentityServer, you need to register them with the DI container, e.g.::
 
-    builder.AddSecretParser<ClientAssertionSecretParser>()
+    builder.AddSecretParser<JwtBearerClientAssertionSecretParser>()
     builder.AddSecretValidator<PrivateKeyJwtSecretValidator>()
 
 Our default private key JWT secret validator expects the full (leaf) certificate as base64 on the secret definition.


### PR DESCRIPTION
**What issue does this PR address?**
This is an update for documentation only to mention JwtBearerClientAssertionSecretParser class instead of old ClientAssertionSecretParser, that does not exist anymore.

**Does this PR introduce a breaking change?**
No, it is just documnetation update.

**Please check if the PR fulfills these requirements**
they are not applicable here.

- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
