### PR TITLE
Corrected internal value for ParsedSecretTypes.JwtBearer

### DIFF
--- a/src/IdentityServerConstants.cs
+++ b/src/IdentityServerConstants.cs
@@ -36,7 +36,7 @@ namespace IdentityServer4
             public const string NoSecret = "NoSecret";
             public const string SharedSecret = "SharedSecret";
             public const string X509Certificate = "X509Certificate";
-            public const string JwtBearer = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+            public const string JwtBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
         }
 
         public static class SecretTypes


### PR DESCRIPTION
ParsedSecretTypes.JwtBearer is used for [JWT Bearer client authentication](https://tools.ietf.org/html/rfc7523#section-2.2).

Tests and secret parsing all use the correct value of `urn:ietf:params:oauth:client-assertion-type:jwt-bearer` but `ParsedSecretTypes.JwtBearer`, the internal value for storing secret type, uses `urn:ietf:params:oauth:grant-type:jwt-bearer`.

This is a breaking change for anyone using the old value explicitly in their code.