### PR TITLE
Changed level from error to warn on refresh token

### DIFF
--- a/src/Validation/Default/TokenRequestValidator.cs
+++ b/src/Validation/Default/TokenRequestValidator.cs
@@ -479,7 +479,7 @@ namespace IdentityServer4.Validation
 
             if (result.IsError)
             {
-                LogError("Refresh token validation failed. aborting.");
+                LogWarning("Refresh token validation failed. aborting.");
                 return Invalid(OidcConstants.TokenErrors.InvalidGrant);
             }
 
@@ -716,6 +716,26 @@ namespace IdentityServer4.Validation
             else
             {
                 _logger.LogError("{details}", details);
+            }
+        }
+
+        private void LogWarning(string message = null, params object[] values)
+        {
+            var details = new TokenRequestValidationLog(_validatedRequest);
+            if (message.IsPresent())
+            {
+                try
+                {
+                    _logger.LogWarning(message + ", request details: {details}", values, details);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError("Error logging {exception}, request details: {details}", ex.Message, details);
+                }
+            }
+            else
+            {
+                _logger.LogWarning("{details}", details);
             }
         }
 

--- a/src/Validation/Default/TokenValidator.cs
+++ b/src/Validation/Default/TokenValidator.cs
@@ -379,7 +379,7 @@ namespace IdentityServer4.Validation
             var refreshToken = await _refreshTokenStore.GetRefreshTokenAsync(tokenHandle);
             if (refreshToken == null)
             {
-                _logger.LogError("Invalid refresh token");
+                _logger.LogWarning("Invalid refresh token");
                 return Invalid(OidcConstants.TokenErrors.InvalidGrant);
             }
 
@@ -388,7 +388,7 @@ namespace IdentityServer4.Validation
             /////////////////////////////////////////////
             if (refreshToken.CreationTime.HasExceeded(refreshToken.Lifetime, _clock.UtcNow.DateTime))
             {
-                _logger.LogError("Refresh token has expired. Removing from store.");
+                _logger.LogWarning("Refresh token has expired. Removing from store.");
 
                 await _refreshTokenStore.RemoveRefreshTokenAsync(tokenHandle);
                 return Invalid(OidcConstants.TokenErrors.InvalidGrant);


### PR DESCRIPTION
Expired tokens
Invalid tokens

Could we please lower the log level for refresh token errors? This would reduce log clutter caused by expired refresh tokens and race conditions with one-time-only refresh tokens. Same thing was done for Identity Server 3 by John Korsnes, commit b8a375bd of 09.02.2015

