### PR TITLE
Unify empty string

### DIFF
--- a/host/Quickstart/Account/AccountController.cs
+++ b/host/Quickstart/Account/AccountController.cs
@@ -159,7 +159,7 @@ namespace IdentityServer4.Quickstart.UI
                 }
 
                 await _events.RaiseAsync(new UserLoginFailureEvent(model.Username, "invalid credentials"));
-                ModelState.AddModelError("", AccountOptions.InvalidCredentialsErrorMessage);
+                ModelState.AddModelError(string.Empty, AccountOptions.InvalidCredentialsErrorMessage);
             }
 
             // something went wrong, show form with error

--- a/host/Quickstart/Consent/ConsentController.cs
+++ b/host/Quickstart/Consent/ConsentController.cs
@@ -32,7 +32,7 @@ namespace IdentityServer4.Quickstart.UI
             IIdentityServerInteractionService interaction,
             IClientStore clientStore,
             IResourceStore resourceStore,
-            IEventService events, 
+            IEventService events,
             ILogger<ConsentController> logger)
         {
             _interaction = interaction;
@@ -82,7 +82,7 @@ namespace IdentityServer4.Quickstart.UI
 
             if (result.HasValidationError)
             {
-                ModelState.AddModelError("", result.ValidationError);
+                ModelState.AddModelError(string.Empty, result.ValidationError);
             }
 
             if (result.ShowView)

--- a/src/Extensions/PrincipalExtensions.cs
+++ b/src/Extensions/PrincipalExtensions.cs
@@ -107,7 +107,7 @@ namespace IdentityServer4.Extensions
             var sub = principal.FindFirst(JwtClaimTypes.Subject);
             if (sub != null) return sub.Value;
 
-            return "";
+            return string.Empty;
         }
 
         /// <summary>

--- a/src/Extensions/StringsExtensions.cs
+++ b/src/Extensions/StringsExtensions.cs
@@ -21,7 +21,7 @@ namespace IdentityServer4.Extensions
         {
             if (list == null)
             {
-                return "";
+                return string.Empty;
             }
 
             var sb = new StringBuilder(100);

--- a/src/Services/Default/DefaultEventService.cs
+++ b/src/Services/Default/DefaultEventService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -61,7 +61,7 @@ namespace IdentityServer4.Events
         /// <exception cref="System.ArgumentNullException">evt</exception>
         public async Task RaiseAsync(Event evt)
         {
-            if (evt == null) throw new ArgumentNullException("evt");
+            if (evt == null) throw new ArgumentNullException(nameof(evt));
 
             if (CanRaiseEvent(evt))
             {
@@ -89,7 +89,7 @@ namespace IdentityServer4.Events
                 case EventTypes.Error:
                     return Options.Events.RaiseErrorEvents;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(nameof(evtType));
             }
         }
 

--- a/src/Stores/Caching/CachingResourceStore.cs
+++ b/src/Stores/Caching/CachingResourceStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -59,7 +59,7 @@ namespace IdentityServer4.Stores
 
         private string GetKey(IEnumerable<string> names)
         {
-            if (names == null || !names.Any()) return "";
+            if (names == null || !names.Any()) return string.Empty;
             return names.OrderBy(x => x).Aggregate((x, y) => x + "," + y);
         }
 

--- a/src/Validation/Default/BasicAuthenticationSecretParser.cs
+++ b/src/Validation/Default/BasicAuthenticationSecretParser.cs
@@ -121,7 +121,7 @@ namespace IdentityServer4.Validation
         // 2.3.1
         private string Decode(string value)
         {
-            if (value.IsMissing()) return "";
+            if (value.IsMissing()) return string.Empty;
 
             return Uri.UnescapeDataString(value.Replace("+", "%20"));
         }

--- a/test/IdentityServer.IntegrationTests/Pipeline/ConfigurationTests.cs
+++ b/test/IdentityServer.IntegrationTests/Pipeline/ConfigurationTests.cs
@@ -22,7 +22,7 @@ namespace IdentityServer.IntegrationTests.Pipeline
             {
                 s.Configure<IdentityServerOptions>(opts=>
                 {
-                    opts.PublicOrigin = "";
+                    opts.PublicOrigin = string.Empty;
                 });
             };
             _pipeline.Initialize();

--- a/test/IdentityServer.UnitTests/Validation/ResponseTypeEqualityComparison.cs
+++ b/test/IdentityServer.UnitTests/Validation/ResponseTypeEqualityComparison.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -41,7 +41,7 @@ namespace IdentityServer4.UnitTests.Validation
             {
                 ResponseTypeEqualityComparer comparer = new ResponseTypeEqualityComparer();
                 string x = null;
-                string y = "";
+                string y = string.Empty;
                 var result = comparer.Equals(x, y);
                 var expected = (x == y);
                 result.Should().Be(expected);
@@ -51,7 +51,7 @@ namespace IdentityServer4.UnitTests.Validation
             public void Right_null_other_not()
             {
                 ResponseTypeEqualityComparer comparer = new ResponseTypeEqualityComparer();
-                string x = "";
+                string x = string.Empty;
                 string y = null;
                 var result = comparer.Equals(x, y);
                 var expected = (x == y);

--- a/test/IdentityServer.UnitTests/Validation/ScopeValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/ScopeValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -84,7 +84,7 @@ namespace IdentityServer4.UnitTests.Validation
         [Trait("Category", Category)]
         public void Parse_Scopes_with_Empty_Scope_List()
         {
-            var scopes = "".ParseScopesString();
+            var scopes = string.Empty.ParseScopesString();
 
             scopes.Should().BeNull();
         }

--- a/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
@@ -79,7 +79,7 @@ namespace IdentityServer4.UnitTests.Validation.Secrets
         {
             var context = new DefaultHttpContext();
 
-            context.Request.Headers.Add("Authorization", new StringValues(""));
+            context.Request.Headers.Add("Authorization", new StringValues(string.Empty));
 
             var secret = await _parser.ParseAsync(context);
 


### PR DESCRIPTION
**What issue does this PR address?**
- unify empty string ("" / string.Empty) in C#
-nameof for ArgumentExceptions

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
