### PR TITLE
Add AddPersistedGrantStore<T> extension method for IIdentityServerBuilder

### DIFF
--- a/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -111,6 +111,20 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Adds a persisted grant store.
+        /// </summary>
+        /// <typeparam name="T">The type of the concrete grant store that is registered in DI.</typeparam>
+        /// <param name="builder">The builder.</param>
+        /// <returns>The builder.</returns>
+        public static IIdentityServerBuilder AddPersistedGrantStore<T>(this IIdentityServerBuilder builder)
+            where T : class, IPersistedGrantStore
+        {
+            builder.Services.AddTransient<IPersistedGrantStore, T>();
+
+            return builder;
+        }
+
+        /// <summary>
         /// Adds a CORS policy service.
         /// </summary>
         /// <typeparam name="T">The type of the concrete scope store class that is registered in DI.</typeparam>


### PR DESCRIPTION
**What issue does this PR address?**

There are already methods to add most services (`IClientStore`, `IResourceStore`, `IProfileService`, etc.), but not `IPersistedGrantStore`. There's only `AddInMemoryPersistedGrants`, which isn't appropriate in many situations (in my case I need to persist refresh tokens).

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features): *There are no tests for the existing methods, and a test for this doesn't seem to add much value. I'll add a test anyway if you want me to.*

**Other information**:

N/A