### PR TITLE
Support hosting the identity server as a WebAPI

### DIFF
--- a/src/Endpoints/Results/LoginPageResult.cs
+++ b/src/Endpoints/Results/LoginPageResult.cs
@@ -53,6 +53,12 @@ namespace IdentityServer4.Endpoints.Results
         /// <returns></returns>
         public Task ExecuteAsync(HttpContext context)
         {
+            if (context.IsAjax())
+            {
+                context.Response.StatusCode = (int) System.Net.HttpStatusCode.Unauthorized;
+                return Task.CompletedTask;
+            }
+            
             Init(context);
 
             var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;

--- a/src/Extensions/HttpContextExtensions.cs
+++ b/src/Extensions/HttpContextExtensions.cs
@@ -194,5 +194,8 @@ namespace IdentityServer4.Extensions
             // no sessions, so nothing to cleanup
             return null;
         }
+
+        internal static bool IsAjax(this HttpContext context)
+            => string.Equals(context?.Request?.Headers?["X-Requested-With"], "XMLHttpRequest", StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -153,6 +153,24 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Authorize
 
         [Fact]
         [Trait("Category", Category)]
+        public async Task anonymous_xhr_user_should_receive_unauthorized()
+        {
+            var url = _mockPipeline.CreateAuthorizeUrl(
+                clientId: "client1",
+                responseType: "id_token",
+                scope: "openid",
+                redirectUri: "https://client1/callback",
+                state: "123_state",
+                nonce: "123_nonce");
+            _mockPipeline.BrowserClient.DefaultRequestHeaders.Add("X-Requested-With", "XMLHttpRequest");
+            var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            _mockPipeline.LoginWasCalled.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
         public async Task signin_request_should_have_authorization_params()
         {
             var url = _mockPipeline.CreateAuthorizeUrl(


### PR DESCRIPTION
**What issue does this PR address?**
If you host the identity server on a WebAPI project and you authenticate using a SPA framework like Angular you want to be able to setup an interceptor to detect if the user is no longer authenticated (cookie expired, never authenticated, etc) by reading the status code of XHRs. In the current implementation the code tries to perform a redirect which is not the ideal case for a WebAPI implementation.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)