### PR TITLE
Correct URL for direct download of library

### DIFF
--- a/docs/quickstarts/7_javascript_client.rst
+++ b/docs/quickstarts/7_javascript_client.rst
@@ -50,7 +50,7 @@ Reference oidc-client
 In the MVC project, we used a library to handle the OpenID Connect protocol. 
 In this project we need a similar library, except one that works in JavaScript and is designed to run in the browser.
 The `oidc-client library <https://github.com/IdentityModel/oidc-client-js>`_ is one such library. 
-It is available via `NPM <https://github.com/IdentityModel/oidc-client-js>`_, `Bower <https://bower.io/search/?q=oidc-client>`_,  as well as a `direct download <https://github.com/IdentityModel/oidc-client-js/tree/master/dist>`_ from github.
+It is available via `NPM <https://github.com/IdentityModel/oidc-client-js>`_, `Bower <https://bower.io/search/?q=oidc-client>`_,  as well as a `direct download <https://github.com/IdentityModel/oidc-client-js/tree/release/dist>`_ from github.
 
 **NPM**
 


### PR DESCRIPTION
Appears this link had died because the **master** branch was renamed to **release** at some point. This fixes it.

**What issue does this PR address?**
A dead link (which 404s).

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
This is a docs only change to fix a dead link.