### PR TITLE
Updated ConsentPageResult to use GetIdentityServerBasePath

### DIFF
--- a/src/Endpoints/Results/ConsentPageResult.cs
+++ b/src/Endpoints/Results/ConsentPageResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -55,7 +55,7 @@ namespace IdentityServer4.Endpoints.Results
         {
             Init(context);
 
-            var returnUrl = context.Request.PathBase.ToString().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
+            var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
             returnUrl = returnUrl.AddQueryString(_request.Raw.ToQueryString());
 
             var consentUrl = _options.UserInteraction.ConsentUrl;


### PR DESCRIPTION
Behavior on `ConsentPageResult` was inconsistent with `LoginPageResult`.

Caused an issue when using `SetIdentityServerBasePath` where the user would get redirected to the wrong endpoint.