### PR TITLE
Fix firefox back navigation error after authorize

### DIFF
--- a/src/Endpoints/Results/AuthorizeResult.cs
+++ b/src/Endpoints/Results/AuthorizeResult.cs
@@ -127,7 +127,7 @@ namespace IdentityServer4.Endpoints.Results
 
         private void AddSecurityHeaders(HttpContext context)
         {
-            context.Response.AddScriptCspHeaders(_options.Csp, "sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY=");
+            context.Response.AddScriptCspHeaders(_options.Csp, "sha256-qVoI0C254Vi3s3Iwsa3nl2rir6x9eGaSW3YUjo7k7Ms="); 
 
             var referrer_policy = "no-referrer";
             if (!context.Response.Headers.ContainsKey("Referrer-Policy"))
@@ -159,7 +159,7 @@ namespace IdentityServer4.Endpoints.Results
             return uri;
         }
 
-        private const string FormPostHtml = "<html><head><base target='_self'/></head><body><form method='post' action='{uri}'>{body}<noscript><button>Click to continue</button></noscript></form><script>(function(){document.forms[0].submit();})();</script></body></html>";
+        private const string FormPostHtml = "<html><head><base target='_self'/></head><body><form method='post' action='{uri}'>{body}<noscript><button>Click to continue</button></noscript></form><script>window.onload=function(){document.forms[0].submit();};</script></body></html>";
 
         private string GetFormPostHtml()
         {

--- a/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -179,9 +179,9 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
             _context.Response.Headers["Cache-Control"].First().Should().Contain("no-cache");
             _context.Response.Headers["Cache-Control"].First().Should().Contain("max-age=0");
             _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("default-src 'none';");
-            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY='");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-qVoI0C254Vi3s3Iwsa3nl2rir6x9eGaSW3YUjo7k7Ms='");
             _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("default-src 'none';");
-            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY='");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'sha256-qVoI0C254Vi3s3Iwsa3nl2rir6x9eGaSW3YUjo7k7Ms='");
             _context.Response.Body.Seek(0, SeekOrigin.Begin);
             using (var rdr = new StreamReader(_context.Response.Body))
             {
@@ -207,8 +207,8 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
 
             await _subject.ExecuteAsync(_context);
 
-            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY='");
-            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY='");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-qVoI0C254Vi3s3Iwsa3nl2rir6x9eGaSW3YUjo7k7Ms='");
+            _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("script-src 'unsafe-inline' 'sha256-qVoI0C254Vi3s3Iwsa3nl2rir6x9eGaSW3YUjo7k7Ms='");
         }
 
         [Fact]
@@ -226,7 +226,7 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
 
             await _subject.ExecuteAsync(_context);
 
-            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-VuNUSJ59bpCpw62HM2JG/hCyGiqoPN3NqGvNXQPU+rY='");
+            _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-qVoI0C254Vi3s3Iwsa3nl2rir6x9eGaSW3YUjo7k7Ms='");
             _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();
         }
     }


### PR DESCRIPTION
Fix firefox back navigation over authorize.
Please see related issue: #2873 

This PR shouldn't introduce any breaking change but please be aware that I've only tested with latest chrome, firefox and safari.