### PR TITLE
Add note about .net Core 2.1 on adding EF Tooling

### DIFF
--- a/docs/quickstarts/8_entity_framework.rst
+++ b/docs/quickstarts/8_entity_framework.rst
@@ -44,7 +44,7 @@ This requires the use of the EF Core tooling (more details `here <https://docs.m
 We will add those now, and unfortunately this must be done by hand-editing your `.csproj` file.
 To edit the `.csproj` by right-click the project and select "Edit projectname.csproj":
 
-.. Note:: Depending on how you created your initial project for the IdentityServer host, you might already have these tools configured in your `csproj` file. If they are, you can skip to the next section.
+.. Note:: Depending on how you created your initial project for the IdentityServer host, you might already have these tools configured in your `csproj` file. If they are, you can skip to the next section. This is also not necessary if aou are already using .net Core 2.1 (more details `here <https://docs.microsoft.com/de-de/dotnet/core/migration/20-21>`_).
 
 .. image:: images/8_edit_csproj.png
 

--- a/docs/reference/ef.rst
+++ b/docs/reference/ef.rst
@@ -103,6 +103,6 @@ We do not provide any support for creating your database or migrating your data 
 You are expected to manage the database creation, schema changes, and data migration in any way your organization sees fit.
 
 Using EF migrations is one possible approach to this. 
-If you do wish to use migrations, then see the :ref:`EF quickstart <refEntityFrameworkQuickstart>` for samples on how to get started, or consult the Microsoft `documentation on EF migrations <https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dotnet>`_.
+If you do wish to use migrations, then see the :ref:`EF quickstart <refEntityFrameworkQuickstart>` for samples on how to get started, or consult the Microsoft `documentation on EF migrations <https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/index>`_.
 
 We also publish `sample SQL scripts <https://github.com/IdentityServer/IdentityServer4.EntityFramework.Storage/tree/dev/migrations/SqlServer/Migrations>`_ for the current version of the database schema.

--- a/docs/topics/signin_external_providers.rst
+++ b/docs/topics/signin_external_providers.rst
@@ -150,7 +150,7 @@ The OpenID Connect authentication handler provided by ASP.NET Core utilizes this
 
 The problem with storing state in a request parameter is that the request URL can get too large (over the common limit of 2000 characters).
 The OpenID Connect authentication handler does provide an extensibility point to store the state in your server, rather than in the request URL. 
-You can implement this yourself by implementing ``ISecureDataFormat<AuthenticationProperties>`` and configuring it on the `OpenIdConnectOptions <https://github.com/aspnet/Security/blob/dev/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs#L248>`_.
+You can implement this yourself by implementing ``ISecureDataFormat<AuthenticationProperties>`` and configuring it on the `OpenIdConnectOptions <https://github.com/aspnet/AspNetCore/blob/master/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs#L249>`_.
 
 Fortunately, IdentityServer provides an implementation of this for you, backed by the ``IDistributedCache`` implementation registered in the DI container (e.g. the standard ``MemoryDistributedCache``).
 To use the IdentityServer provided secure data format implementation, simply call the ``AddOidcStateDataFormatterCache`` extension method on the ``IServiceCollection`` when configuring DI.


### PR DESCRIPTION
**What issue does this PR address?**
With .net Core 2.1 it's no longer necessary to add the CLI Tools for entity framework since they are included.

**Does this PR introduce a breaking change?**


**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
