### PR TITLE
Scrub id token hint from endsession request log

### DIFF
--- a/src/Logging/Models/EndSessionRequestValidationLog.cs
+++ b/src/Logging/Models/EndSessionRequestValidationLog.cs
@@ -22,7 +22,7 @@ namespace IdentityServer4.Logging.Models
 
         public EndSessionRequestValidationLog(ValidatedEndSessionRequest request)
         {
-            Raw = request.Raw.ToDictionary();
+            Raw = request.Raw.ToScrubbedDictionary(OidcConstants.EndSessionRequest.IdTokenHint);
 
             SubjectId = "unknown";
             if (request.Subject != null)


### PR DESCRIPTION
**What issue does this PR address?**
When the EndSession endpoint is invoked the ID token appears in log file when minimum log level is 'Information':

`2019-01-02 16:59:45.486 +01:00 [INF] End session request validation success
{"ClientId":"js_oidc","ClientName":"JavaScript OIDC Client","SubjectId":"818727","PostLogOutUri":"http://localhost:7017/index.html","State":null,"Raw":{"id_token_hint":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjZiMTc2ZDVjYzA4OGZiZDdjM2E5YTI3NWVmOTYzZGZmIiwidHlwIjoiSldUIn0.eyJuYmYiOjE1NDY0NDQ3NjEsImV4cCI6MTU0NjQ0NTA2MSwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoianNfb2lkYyIsImlhdCI6MTU0NjQ0NDc2MSwiYXRfaGFzaCI6InA4NGlWV1A1d3puVms3eEhqNG1PT1EiLCJzaWQiOiIzNjI4NzliMTRhMGZiYjYwZGFjYWI5OTkzNzJkZmYyNyIsInN1YiI6IjgxODcyNyIsImF1dGhfdGltZSI6MTU0NjQ0NDc1NiwiaWRwIjoibG9jYWwiLCJhbXIiOlsicHdkIl19.bIYO1Lg6xeuaMiRhqeoxzf3QIsa6D6jlbG3LC0cGtxXXVkXItgaQuj6-PROA_MiuyuVYmMMsZAC0AvFJZ159-nx1P3UdaduYIOBVy2yqzVEZ4OFPH1UMiKSZgbo-fS8ZcEKwDp_XTEFAEI8X6mizPsLQYAcL7oYf-7mIsoAU8VmUJO-cv7i8nwkwIYFbk2IONWEMfEc-TRAe9qFPyAlD2KDflsQgnF6iR_4G41LvQi_2O69W2y_fJeeMbMZ6dTIZWt565HG9p6JNevpORlrl95DeJZ-6Q8pDFD8eyhCyJbBPYacNIQ3hfPlirWhAMTnrAyhKDViWyXqirYy0XwDPTg","post_logout_redirect_uri":"http://localhost:7017/index.html"},"$type":"EndSessionRequestValidationLog"}
`

The ID token should be redacted.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
