### PR TITLE
Updated text to refer to the 'AddJwtBearer()' method

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -173,7 +173,7 @@ Update `Startup` to look like this::
 
 
 ``AddAuthentication`` adds the authentication services to DI and configures ``"Bearer"`` as the default scheme.
-``AddIdentityServerAuthentication`` adds the IdentityServer access token validation handler into DI for use by the authentication services.
+``AddJwtBearer`` adds the JWT validation handler into DI for use by the authentication services.
 ``UseAuthentication`` adds the authentication middleware to the pipeline so authentication will be performed automatically on every call into the host.
 
 If you use the browser to navigate to the controller (``http://localhost:5001/identity``), 
@@ -193,7 +193,7 @@ raw HTTP to access it. However, we have a client library called IdentityModel, t
 encapsulates the protocol interaction in an easy to use API.
 
 Add the `IdentityModel` NuGet package to your client. 
-This can be done either via Visual Studio's nuget dialog, by adding it manually to the .csproj file, or by using the CLI::
+This can be done either via Visual Studio's NuGet dialog, by adding it manually to the .csproj file, or by using the CLI::
 
     dotnet add package IdentityModel
 


### PR DESCRIPTION
Previous code example was based on the IS4 'AddIdentityServerAuthentication()' method; at some point it was changed to use ASP.NET 'AddJwtBearer()' method, but the text explanation was not updated.