### PR TITLE
Fixed variable name mismatch

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -213,7 +213,7 @@ endpoint addresses can be read from the metadata::
 Next you can use the information from the discovery document to request a token::
 
     // request token
-    var response = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+    var tokenResponse = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
     {
         Address = disco.TokenEndpoint,
 


### PR DESCRIPTION
In given code example related to request token, variable 'token' is renamed to 'tokenResponse' in order to match other occurrences within the code example.