### PR TITLE
Add server_error and temporarily_unavailable error codes

### DIFF
--- a/src/Models/TokenRequestErrors.cs
+++ b/src/Models/TokenRequestErrors.cs
@@ -37,6 +37,16 @@ namespace IdentityServer4.Models
         /// <summary>
         /// invalid_scope
         /// </summary>
-        InvalidScope
+        InvalidScope,
+        
+        /// <summary>
+        /// server_error
+        /// </summary>
+        ServerError,
+        
+        /// <summary>
+        /// temporarily_unavailable
+        /// </summary>
+        TemporarilyUnavailable
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
RFC 6749 section 4.1.2.1 and 4.2.2.1 define the server_error and temporarily_unavailable error codes for Authorization Code Grant.
Add them here to prevent the need for consumers to create their own constants or using incorrect error messages.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
