### PR TITLE
Minor typo fix

### DIFF
--- a/docs/topics/grant_types.rst
+++ b/docs/topics/grant_types.rst
@@ -67,7 +67,7 @@ or authentication and access token requests (JavaScript applications).
 
 In the implicit flow, all tokens are transmitted via the browser, and advanced features like refresh tokens are thus not allowed.
 
-:ref:`This <refImplicitQuickstart>` quickstart shows authentication for service-side web apps, and 
+:ref:`This <refImplicitQuickstart>` quickstart shows authentication for server-side web apps, and 
 :ref:`this <refJavaScriptQuickstart>` shows JavaScript.
 
 Authorization code


### PR DESCRIPTION
When describing implicit grant type, word 'service-side' is changed to 'server-side'.