### PR TITLE
Incorrect secret type for missing secret in BasicAuth

### DIFF
--- a/src/Validation/Default/BasicAuthenticationSecretParser.cs
+++ b/src/Validation/Default/BasicAuthenticationSecretParser.cs
@@ -96,21 +96,40 @@ namespace IdentityServer4.Validation
 
             if (clientId.IsPresent())
             {
-                if (clientId.Length > _options.InputLengthRestrictions.ClientId ||
-                    (secret.IsPresent() && secret.Length > _options.InputLengthRestrictions.ClientSecret))
+                if (clientId.Length > _options.InputLengthRestrictions.ClientId)
                 {
-                    _logger.LogWarning("Client ID or secret exceeds allowed length.");
+                    _logger.LogError("Client ID exceeds maximum length.");
                     return notfound;
                 }
 
-                var parsedSecret = new ParsedSecret
+                if (secret.IsPresent())
                 {
-                    Id = Decode(clientId),
-                    Credential = secret.IsMissing() ? null : Decode(secret),
-                    Type = IdentityServerConstants.ParsedSecretTypes.SharedSecret
-                };
+                    if (secret.Length > _options.InputLengthRestrictions.ClientSecret)
+                    {
+                        _logger.LogError("Client secret exceeds maximum length.");
+                        return notfound;
+                    }
 
-                return Task.FromResult(parsedSecret);
+                    return new ParsedSecret
+                    {
+                        Id = Decode(clientId),
+                        Credential = Decode(secret),
+                        Type = IdentityServerConstants.ParsedSecretTypes.SharedSecret
+                    };
+                }
+                else
+                {
+                    // client secret is optional
+                    _logger.LogDebug("client id without secret found");
+
+                    var parsedSecret = new ParsedSecret
+                    {
+                        Id = Decode(clientId),
+                        Type = IdentityServerConstants.ParsedSecretTypes.NoSecret
+                    };
+                    
+                    return Task.FromResult(parsedSecret);
+                }
             }
 
             _logger.LogDebug("No Basic Authentication secret found");

--- a/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
@@ -68,7 +68,7 @@ namespace IdentityServer4.UnitTests.Validation.Secrets
 
             var secret = await _parser.ParseAsync(context);
 
-            secret.Type.Should().Be(IdentityServerConstants.ParsedSecretTypes.SharedSecret);
+            secret.Type.Should().Be(IdentityServerConstants.ParsedSecretTypes.NoSecret);
             secret.Id.Should().Be("client");
             secret.Credential.Should().BeNull();
         }


### PR DESCRIPTION
**What issue does this PR address?**
When in Basic Authorization client secret is missing parser set incorrect type (set SharedSecret but not NoSecret) what make exception in secret validator:
https://github.com/IdentityServer/IdentityServer4/blob/63a50d7838af25896fbf836ea4e4f37b5e179cd8/src/Validation/Default/HashedSharedSecretValidator.cs#L63

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [ x] Unit Tests for the changes have been added (for bug fixes / features)

