### PR TITLE
Support for ECDSA-based signatures (ES256, ES384, ES512)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ tools/
 # IdentityServer temp files
 identityserver4_log.txt
 tempkey.rsa
+tempkey.ecdsa

--- a/host/Startup.cs
+++ b/host/Startup.cs
@@ -46,7 +46,7 @@ namespace Host
                 //.AddInMemoryClients(_config.GetSection("Clients"))
                 .AddInMemoryIdentityResources(Resources.GetIdentityResources())
                 .AddInMemoryApiResources(Resources.GetApiResources())
-                .AddDeveloperSigningCredential()
+                .AddDeveloperSigningCredential() //(intendedSigningAlgorithm: IdentityServerConstants.SigningAlgorithms.ES256)
                 .AddExtensionGrantValidator<Extensions.ExtensionGrantValidator>()
                 .AddExtensionGrantValidator<Extensions.NoSubjectExtensionGrantValidator>()
                 .AddJwtBearerClientAuthentication()

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 
 namespace IdentityServer4
 {
+    using System.Security.Cryptography;
+
     internal static class Constants
     {
         public const string IdentityServerName               = "IdentityServer4";
@@ -91,11 +93,6 @@ namespace IdentityServer4
         {
             "pairwise", "public"
         };
-
-        public static class SigningAlgorithms
-        {
-            public const string RSA_SHA_256 = "RS256";
-        }
 
         public static readonly List<string> SupportedDisplayModes = new List<string>
         {

--- a/src/IdentityServer4.csproj
+++ b/src/IdentityServer4.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>IdentityServer4</PackageId>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
   </ItemGroup>

--- a/src/IdentityServerConstants.cs
+++ b/src/IdentityServerConstants.cs
@@ -48,6 +48,30 @@ namespace IdentityServer4
             public const string X509CertificateBase64 = "X509CertificateBase64";
         }
 
+        public static class SigningAlgorithms
+        {
+            /// <summary>
+            /// RSA 2048-bit + SHA-2 256
+            /// </summary>
+            public const string RS256 = "RS256";
+
+            /// <summary>
+            /// NIST P-256 + SHA-2 256
+            /// </summary>
+            public const string ES256 = "ES256";
+
+            /// <summary>
+            /// NIST P-384 + SHA-2 256
+            /// </summary>
+            public const string ES384 = "ES384";
+
+            /// <summary>
+            /// NIST P-521 + SHA-2 512.
+            /// No. '521' is not a typo.
+            /// </summary>
+            public const string ES512 = "ES512";
+        }
+
         public static class ProfileDataCallers
         {
             public const string UserInfoEndpoint = "UserInfoEndpoint";

--- a/src/Models/JsonWebKey.cs
+++ b/src/Models/JsonWebKey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 #pragma warning disable 1591
@@ -11,9 +11,19 @@ namespace IdentityServer4.Models
         public string use { get; set; }
         public string kid { get; set; }
         public string x5t { get; set; }
-        public string e { get; set; }
-        public string n { get; set; }
         public string[] x5c { get; set; }
         public string alg { get; set; }
+    }
+
+    public class RsaJsonWebKey : JsonWebKey
+    {
+        public string e { get; set; }
+        public string n { get; set; }
+    }
+
+    public class EcdsaWebKey : JsonWebKey
+    {
+        public string x { get; set; }
+        public string y { get; set; }
     }
 }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -11,6 +11,8 @@ using Xunit;
 
 namespace IdentityServer4.IntegrationTests.Endpoints.Discovery
 {
+    using System.Linq;
+
     public class DiscoveryEndpointTests
     {
         private const string Category = "Discovery endpoint";
@@ -52,7 +54,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Discovery
             var alg = key["alg"];
             alg.Should().NotBeNull();
 
-            alg.Value<string>().Should().Be(Constants.SigningAlgorithms.RSA_SHA_256);
+            alg.Value<string>().Should().Be(IdentityServerConstants.SigningAlgorithms.RS256);
         }
 
         [Fact]

--- a/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;net471</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/IdentityServer.UnitTests/Common/TestKeyMaterial.cs
+++ b/test/IdentityServer.UnitTests/Common/TestKeyMaterial.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Microsoft.IdentityModel.Tokens;
+
+namespace IdentityServer4.UnitTests.Common
+{
+
+    internal static class TestKeyMaterial
+    {
+        private static string Es256Json =
+            @"{
+                ""kty"":""EC"",
+                ""alg"":""ES256"",
+                ""crv"":""P-256"",
+                ""x"":""MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4"",
+                ""y"":""4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"",
+                ""d"":""870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"",
+                ""use"":""enc"",
+                ""kid"":""1""
+            }";
+
+        public static SigningCredentials Es256SigningCredentials =>
+            new SigningCredentials(new JsonWebKey(Es256Json), "ES256");
+    }
+}

--- a/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCryptoTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCryptoTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -32,6 +32,28 @@ namespace IdentityServer4.UnitTests.Extensions
                 ""dp"" :  ""GlYJ6o6wgawxCEQ5z5uWwETau5CS/Fk7kI2ceI14SZVHzlJQC2WglAcnQcqhmQCk57Xsy5iLM6vKyi8sdMJPh+nvR2HlyNA+w7YBy4L7odqn01VmLgv7zVVjZpNq4ZXEoDC1Q+xjtF1LoYaUt7wsRLp+a7znuPyHBXj1sAAeBwk="",
                 ""dq"" :  ""W8OK3S83T8VCTBzq1Ap6cb3XLcQq11yBaJpYaj0zXr/IKsbUW+dnFeBAFWEWS3gAX3Bod1tAFB3rs0D3FjhO1XE1ruHUT520iAEAwGiDaj+JLh994NzqELo3GW2PoIM/BtFNeKYgHd9UgQsgPnQJCzOb6Aev/z3yHeW9RRQPVbE="",
                 ""qi"" :  ""w4KdmiDN1GtK71JxaasqmEKPNfV3v2KZDXKnfyhUsdx/idKbdTVjvMOkxFPJ4FqV4yIVn06f3QHTm4NEG18Diqxsrzd6kXQIHOa858tLsCcmt9FoGfrgCFgVceh3K/Zah/r8rl9Y61u0Z1kZumwMvFpFE+mVU01t9HgTEAVkHTc="",
+            }";
+
+            JsonWebKey jsonWebKey = new JsonWebKey(json);
+            SigningCredentials credentials = new SigningCredentials(jsonWebKey, jsonWebKey.Alg);
+            identityServerBuilder.AddSigningCredential(credentials);
+        }
+
+        [Fact]
+        public void AddSigningCredential_ES256_with_json_web_key_containing_asymmetric_key_should_succeed()
+        {
+            IServiceCollection services = new ServiceCollection();
+            IIdentityServerBuilder identityServerBuilder = new IdentityServerBuilder(services);
+
+            String json =
+            @"{
+                ""kty"":""EC"",
+                ""alg"":""ES256"",
+                ""x"":""MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4"",
+                ""y"":""4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"",
+                ""d"":""870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"",
+                ""use"":""enc"",
+                ""kid"":""1""
             }";
 
             JsonWebKey jsonWebKey = new JsonWebKey(json);

--- a/test/IdentityServer.UnitTests/Validation/IdentityTokenValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/IdentityTokenValidation.cs
@@ -1,9 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
-
 
 using FluentAssertions;
 using IdentityModel;
+using IdentityServer4.Services;
+using IdentityServer4.Stores;
+using IdentityServer4.UnitTests.Common;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 using Xunit;
@@ -28,6 +30,23 @@ namespace IdentityServer4.UnitTests.Validation
             var jwt = await creator.CreateTokenAsync(token);
 
             var validator = Factory.CreateTokenValidator();
+            var result = await validator.ValidateIdentityTokenAsync(jwt, "roclient");
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task Valid_IdentityToken_EcdsaSha256KeyType()
+        {
+            var creator = Factory.CreateAlternateEcdsaTokenCreator();
+            var token = TokenFactory.CreateIdentityToken("roclient", "valid");
+            var jwt = await creator.CreateTokenAsync(token);
+            var ecdsaKeyMaterialService = new DefaultKeyMaterialService(new [] {new DefaultValidationKeysStore(new []
+            {
+                TestKeyMaterial.Es256SigningCredentials.Key
+            }), });
+            var validator = Factory.CreateTokenValidator(keyMaterialService: ecdsaKeyMaterialService);
             var result = await validator.ValidateIdentityTokenAsync(jwt, "roclient");
 
             result.IsError.Should().BeFalse();


### PR DESCRIPTION
**What issue does this PR address?**
This PR adds support for both signing and verifying the following ECDSA-based JWT-algorithms; ES256, ES384 and ES512.

It also extends the discovery document and  the JWKs endpoint to reflect these changes.

The ```.AddDeveloperSigningCredential()``` has been extended with an additional (optional) parameter, ```intendedSigningAlgorithm```,
that can be used to generate ECC-based development key pairs.

```IdentityServerConstants.SigningAlgorithms.*``` can be used as arguments for this parameter.

**Does this PR introduce a breaking change?**
This PR bumps the dependency on ```System.IdentityModel.Tokens.Jwt``` to ```5.4.0``` and the ```IntegrationTests``` project has been bumped to target ```net471``` instead of ```net461``` since the ```ECParameters``` class is missing in ```net46*```. This implies a breaking change for consumers of the IdentityServer which targets .NET Framework with an older version than 4.7.1.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
