### PR TITLE
Fixed bug where the Subject was not being set on the ValidatedRequest and would not end up in the TokenIssuedSuccessEvent using Code flow

### DIFF
--- a/src/Validation/Default/TokenRequestValidator.cs
+++ b/src/Validation/Default/TokenRequestValidator.cs
@@ -247,7 +247,8 @@ namespace IdentityServer4.Validation
                 return Invalid(OidcConstants.TokenErrors.InvalidGrant);
             }
 
-            _validatedRequest.AuthorizationCode = authZcode;
+            _validatedRequest.AuthorizationCode = authZcode;            
+            _validatedRequest.Subject = authZcode.Subject;
 
             /////////////////////////////////////////////
             // validate redirect_uri


### PR DESCRIPTION
**What issue does this PR address?**
When the TokenIssuedSuccessEvent is raised on a successful code authorization, the SubjectId field is blank because the Subject property was not being set in the ValidatedRequest class.  It gets set on the other authorization flows, but the line to set it here was missing.

**Does this PR introduce a breaking change?**

No


**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [No existing tests exist to check anything related to this flow] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
