### PR TITLE
Add support to carry an error description back to third party clients on authorize error results

### DIFF
--- a/src/IdentityServer4/src/Endpoints/AuthorizeEndpointBase.cs
+++ b/src/IdentityServer4/src/Endpoints/AuthorizeEndpointBase.cs
@@ -81,7 +81,7 @@ namespace IdentityServer4.Endpoints
             var interactionResult = await _interactionGenerator.ProcessInteractionAsync(request, consent);
             if (interactionResult.IsError)
             {
-                return await CreateErrorResultAsync("Interaction generator error", request, interactionResult.Error, logError: false);
+                return await CreateErrorResultAsync("Interaction generator error", request, interactionResult.Error, interactionResult.ErrorDescription, false);
             }
             if (interactionResult.IsLogin)
             {

--- a/src/IdentityServer4/src/ResponseHandling/Models/InteractionResponse.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Models/InteractionResponse.cs
@@ -44,6 +44,14 @@ namespace IdentityServer4.ResponseHandling
         public string Error { get; set; }
 
         /// <summary>
+        /// Gets or sets the error description.
+        /// </summary>
+        /// <value>
+        /// The error description.
+        /// </value>
+        public string ErrorDescription { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the user must be redirected to a custom page.
         /// </summary>
         /// <value>

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
@@ -88,6 +88,23 @@ namespace IdentityServer4.UnitTests.Endpoints.Authorize
 
         [Fact]
         [Trait("Category", Category)]
+        public async Task interaction_produces_error_should_show_error_page_with_error_description_if_present()
+        {
+            var errorDescription = "some error description";
+
+             _stubInteractionGenerator.Response.Error = "error";
+            _stubInteractionGenerator.Response.ErrorDescription = errorDescription;
+
+             var result = await _subject.ProcessAuthorizeRequestAsync(_params, _user, null);
+
+             result.Should().BeOfType<AuthorizeResult>();
+            var authorizeResult = ((AuthorizeResult)result);
+            authorizeResult.Response.IsError.Should().BeTrue();
+            authorizeResult.Response.ErrorDescription.Should().Be(errorDescription);
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
         public async Task interaction_produces_login_result_should_trigger_login()
         {
             _stubInteractionGenerator.Response.IsLogin = true;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -86,7 +86,10 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
         [Fact]
         public async Task access_denied_should_return_to_client()
         {
+            const string errorDescription = "some error description";
+
             _response.Error = OidcConstants.AuthorizeErrors.AccessDenied;
+            _response.ErrorDescription = errorDescription;
             _response.Request = new ValidatedAuthorizeRequest
             {
                 ResponseMode = OidcConstants.ResponseModes.Query,
@@ -99,6 +102,12 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
             _context.Response.StatusCode.Should().Be(302);
             var location = _context.Response.Headers["Location"].First();
             location.Should().StartWith("http://client/callback");
+
+            var queryString = new Uri(location).Query;
+            var queryParams = QueryHelpers.ParseQuery(queryString);
+
+            queryParams["error"].Should().Equal(OidcConstants.AuthorizeErrors.AccessDenied);
+            queryParams["error_description"].Should().Equal(errorDescription);
         }
 
         [Fact]


### PR DESCRIPTION
Duplicate/re-open of #2902 


**What issue does this PR address?**
[Only specific error types can result in a redirect back to the third party client](https://github.com/IdentityServer/IdentityServer4/blob/master/src/Endpoints/Results/AuthorizeResult.cs#L76-L83) and we'd like to give our third party clients more context on why authorization couldn't progress with the use of the error_description query param that's currently not hooked up but is sent back empty.

I think it's related to these open issues
- #1972
- #2031

**Does this PR introduce a breaking change?**
No, shouldn't do

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/dev/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
This is required following our discussions on our approach to extending the authorize flow for tenanting @brockallen @thirkcircus 