### PR TITLE
Use Task.CompletedTask to reduce allocations

### DIFF
--- a/src/AspNetIdentity/src/SecurityStampValidatorCallback.cs
+++ b/src/AspNetIdentity/src/SecurityStampValidatorCallback.cs
@@ -21,13 +21,13 @@ namespace IdentityServer4.AspNetIdentity
         /// <returns></returns>
         public static Task UpdatePrincipal(SecurityStampRefreshingPrincipalContext context)
         {
-            var newClaimTypes = context.NewPrincipal.Claims.Select(x=>x.Type).ToArray();
+            var newClaimTypes = context.NewPrincipal.Claims.Select(x => x.Type).ToArray();
             var currentClaimsToKeep = context.CurrentPrincipal.Claims.Where(x => !newClaimTypes.Contains(x.Type)).ToArray();
 
             var id = context.NewPrincipal.Identities.First();
             id.AddClaims(currentClaimsToKeep);
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**

Very simple change to reduce memory allocations.

**Does this PR introduce a breaking change?**

No impact on existing codebase.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] ~~Unit Tests for the changes have been added (for bug fixes / features)~~ No unit tests for `AspNetIdentity` project

**Other information**:

Created simple benchmarks [project](https://github.com/mkrtich-m/IdentityServer4.Benchmarks) to test my change using BenchmarkDotnet.

Here are the results:

|             Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|  WithTaskCompleted | 1.146 us | 0.0222 us | 0.0197 us | 0.2155 |     - |     - |     680 B |
| WithTaskFromResult | 1.181 us | 0.0188 us | 0.0157 us | 0.2384 |     - |     - |     752 B |
