### PR TITLE
Docs: Add developer Signing Credential during the IdentityServer configuration

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -100,10 +100,6 @@ Loading the resource and client definitions happens in ``Startup.cs`` - the temp
         {
             builder.AddDeveloperSigningCredential();
         }
-        else
-        {
-            throw new Exception("need to configure key material");
-        }
 
         // rest omitted
     }

--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -95,7 +95,7 @@ Loading the resource and client definitions happens in ``Startup.cs`` - the temp
             .AddInMemoryClients(Config.GetClients());
         
         // To know how to obtain the Environment property,
-        // take a look at the full Startup.cs file in our reporisory
+        // take a look at the full Startup.cs file in our repository
         if (Environment.IsDevelopment())
         {
             builder.AddDeveloperSigningCredential();

--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -93,6 +93,17 @@ Loading the resource and client definitions happens in ``Startup.cs`` - the temp
             .AddInMemoryIdentityResources(Config.GetIdentityResources())
             .AddInMemoryApiResources(Config.GetApis())
             .AddInMemoryClients(Config.GetClients());
+        
+        // To know how to obtain the Environment property,
+        // take a look at the full Startup.cs file in our reporisory
+        if (Environment.IsDevelopment())
+        {
+            builder.AddDeveloperSigningCredential();
+        }
+        else
+        {
+            throw new Exception("need to configure key material");
+        }
 
         // rest omitted
     }


### PR DESCRIPTION
It's just a small documentation improvement.
I've noticed some people (me too) get stuck with the "Missing KeySet" error when following this guide (due to the missing AddDeveloperSigningCredential). I thought it's worth to mention it in the example.
