### PR TITLE
upgrade to MinVer 1.0.0 RC1

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="MinVer" Version="1.0.0" PrivateAssets="All" />
     
     <PackageReference Update="IdentityModel" Version="3.10.6" />
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.1.0-rc.1" PrivateAssets="All" />
     
     <PackageReference Update="IdentityModel" Version="3.10.6" />
 


### PR DESCRIPTION
**What issue does this PR address?**

If even you don't end up using https://github.com/adamralph/minver/issues/212, it would be great to have at least one project outside those managed by me on the RC before I release MinVer 1.1.0 RTM.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] ~Unit Tests for the changes have been added (for bug fixes / features)~

**Other information**:

MinVer 1.1.0 also gets rid of these warnings (https://github.com/adamralph/minver/issues/209):

> warning NU5105: The package version '2.4.1-alpha.0.18' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter. This message can be ignored if the package is not intended for older clients.