### PR TITLE
Null check for Ensure extension methods

### DIFF
--- a/src/IdentityServer4/src/Extensions/StringsExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/StringsExtensions.cs
@@ -90,7 +90,7 @@ namespace IdentityServer4.Extensions
         [DebuggerStepThrough]
         public static string EnsureLeadingSlash(this string url)
         {
-            if (!url.StartsWith("/"))
+            if (url != null && !url.StartsWith("/"))
             {
                 return "/" + url;
             }
@@ -101,7 +101,7 @@ namespace IdentityServer4.Extensions
         [DebuggerStepThrough]
         public static string EnsureTrailingSlash(this string url)
         {
-            if (!url.EndsWith("/"))
+            if (url != null && !url.EndsWith("/"))
             {
                 return url + "/";
             }


### PR DESCRIPTION
Added null check to `EnsureLeadingSlash` and `EnsureTrailingSlash` extensions methods to be consistent with `RemoveLeadingSlash` and `RemoveTrailingSlash`.