### PR TITLE
Docs: Add API Resources appsettings.json similar to client

### DIFF
--- a/docs/reference/api_resource.rst
+++ b/docs/reference/api_resource.rst
@@ -90,8 +90,8 @@ Using the convenience constructor is equivalent to this::
     }
 
 
-Defining clients in appsettings.json
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Defining API resources in appsettings.json
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``AddInMemoryApiResource`` extensions method also supports adding clients from the ASP.NET Core configuration file. This allows you to define static clients directly from the appsettings.json file::
 

--- a/docs/reference/api_resource.rst
+++ b/docs/reference/api_resource.rst
@@ -88,3 +88,27 @@ Using the convenience constructor is equivalent to this::
             }
         }
     }
+
+Defining API Resources in appsettings.json
+The AddInMemoryApiResources extensions method also supports adding resources from the ASP.NET Core configuration file. This allows you to define static API resources directly from the appsettings.json file:
+
+    "IdentityServer": {
+      "IssuerUri": "urn:sso.company.com",
+      "ApiResources": [
+        {
+          "Name": "api1",
+          "DisplayName": "My API",
+
+          "Scopes": [
+            {
+              "Name": "api1",
+              "DisplayName": "My API"
+            }
+          ]
+        }
+      ]
+    }
+
+Then pass the configuration section to the AddInMemoryApiResources method:
+
+    AddInMemoryApiResources(configuration.GetSection("IdentityServer:ApiResources"))

--- a/docs/reference/api_resource.rst
+++ b/docs/reference/api_resource.rst
@@ -109,6 +109,6 @@ The ``AddInMemoryApiResource`` extensions method also supports adding clients fr
           "RequireConsent": false
         }
 
-Then pass the configuration section to the ``AddInMemoryApiResource`` method:
+Then pass the configuration section to the ``AddInMemoryApiResource`` method::
 
     AddInMemoryApiResources(configuration.GetSection("IdentityServer:ApiResources"))

--- a/docs/reference/api_resource.rst
+++ b/docs/reference/api_resource.rst
@@ -108,6 +108,8 @@ The ``AddInMemoryApiResource`` extensions method also supports adding clients fr
           "RedirectUris": [ "https://localhost:5001/signin-oidc" ],
           "RequireConsent": false
         }
+      ]
+    }
 
 Then pass the configuration section to the ``AddInMemoryApiResource`` method::
 

--- a/docs/reference/api_resource.rst
+++ b/docs/reference/api_resource.rst
@@ -97,16 +97,17 @@ The ``AddInMemoryApiResource`` extensions method also supports adding clients fr
 
     "IdentityServer": {
       "IssuerUri": "urn:sso.company.com",
-      "Clients": [
+      "ApiResources": [
         {
-          "Enabled": true,
-          "ClientId": "local-dev",
-          "ClientName": "Local Development",
-          "ClientSecrets": [ { "Value": "<Insert Sha256 hash of the secret encoded as Base64 string>" } ],
-          "AllowedGrantTypes": [ "implicit" ],
-          "AllowedScopes": [ "openid", "profile" ],
-          "RedirectUris": [ "https://localhost:5001/signin-oidc" ],
-          "RequireConsent": false
+          "Name": "api1",
+          "DisplayName": "My API",
+
+          "Scopes": [
+            {
+              "Name": "api1",
+              "DisplayName": "My API"
+            }
+          ]
         }
       ]
     }

--- a/docs/reference/api_resource.rst
+++ b/docs/reference/api_resource.rst
@@ -89,26 +89,26 @@ Using the convenience constructor is equivalent to this::
         }
     }
 
-Defining API Resources in appsettings.json
-The AddInMemoryApiResources extensions method also supports adding resources from the ASP.NET Core configuration file. This allows you to define static API resources directly from the appsettings.json file:
+
+Defining clients in appsettings.json
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``AddInMemoryApiResource`` extensions method also supports adding clients from the ASP.NET Core configuration file. This allows you to define static clients directly from the appsettings.json file::
 
     "IdentityServer": {
       "IssuerUri": "urn:sso.company.com",
-      "ApiResources": [
+      "Clients": [
         {
-          "Name": "api1",
-          "DisplayName": "My API",
-
-          "Scopes": [
-            {
-              "Name": "api1",
-              "DisplayName": "My API"
-            }
-          ]
+          "Enabled": true,
+          "ClientId": "local-dev",
+          "ClientName": "Local Development",
+          "ClientSecrets": [ { "Value": "<Insert Sha256 hash of the secret encoded as Base64 string>" } ],
+          "AllowedGrantTypes": [ "implicit" ],
+          "AllowedScopes": [ "openid", "profile" ],
+          "RedirectUris": [ "https://localhost:5001/signin-oidc" ],
+          "RequireConsent": false
         }
-      ]
-    }
 
-Then pass the configuration section to the AddInMemoryApiResources method:
+Then pass the configuration section to the ``AddInMemoryApiResource`` method:
 
     AddInMemoryApiResources(configuration.GetSection("IdentityServer:ApiResources"))


### PR DESCRIPTION
Similar to the Client section, explain the method override that allows using a configuration section to load API Resources from the appsettings.json configuration file.
