### PR TITLE
Authentication errors should redirect by default

### DIFF
--- a/src/IdentityServer4/src/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/AuthorizeResult.cs
@@ -78,9 +78,8 @@ namespace IdentityServer4.Endpoints.Results
                 Response.Error == OidcConstants.AuthorizeErrors.ConsentRequired ||
                 Response.Error == OidcConstants.AuthorizeErrors.InteractionRequired;
 
-            if (Response.Error != OidcConstants.AuthorizeErrors.InvalidRequestUri 
-                !isPromptNoneError ||
-                (isPromptNoneError && Response.Request?.PromptMode == OidcConstants.PromptModes.None)
+            if (Response.Error != OidcConstants.AuthorizeErrors.InvalidRequestUri &&
+                (!isPromptNoneError || (isPromptNoneError && Response.Request?.PromptMode == OidcConstants.PromptModes.None))
             )
             {
                 // this scenario we can return back to the client

--- a/src/IdentityServer4/src/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/AuthorizeResult.cs
@@ -71,14 +71,15 @@ namespace IdentityServer4.Endpoints.Results
 
         private async Task ProcessErrorAsync(HttpContext context)
         {
-            // these are the conditions where we can send a response 
-            // back directly to the client, otherwise we're only showing the error UI
+            // these are the conditions where we can only send a response 
+            // back directly to the client when the prompt mode is none
             var isPromptNoneError = Response.Error == OidcConstants.AuthorizeErrors.AccountSelectionRequired ||
                 Response.Error == OidcConstants.AuthorizeErrors.LoginRequired ||
                 Response.Error == OidcConstants.AuthorizeErrors.ConsentRequired ||
                 Response.Error == OidcConstants.AuthorizeErrors.InteractionRequired;
 
-            if (Response.Error == OidcConstants.AuthorizeErrors.AccessDenied ||
+            if (Response.Error != OidcConstants.AuthorizeErrors.InvalidRequestUri 
+                !isPromptNoneError ||
                 (isPromptNoneError && Response.Request?.PromptMode == OidcConstants.PromptModes.None)
             )
             {


### PR DESCRIPTION
I'm creating this PR as a discussion point ONLY 

I'm aware you're nervous of incorporating breaking changes and if agreed you'd likely roll this into your own vNext branches which I've seen discussed but do not appear to be public(?)

However, if you'd like me to create a workable request then please tell me which branch you'd like me to work off of.

**What issue does this PR address?**
Authentication errors do not appear to be handled as per the OpenId/OAuth specifications.

Firstly, please see https://openid.net/specs/openid-connect-core-1_0.html#AuthError which has a paragraph stating:

> If the End-User denies the request or the End-User authentication fails, the OP (Authorization Server) informs the RP (Client) by using the Error Response parameters defined in Section 4.1.2.1 of OAuth 2.0 [RFC6749].

Now read https://tools.ietf.org/html/rfc6749#section-4.1.2.1, specifically the following paragraph:

> If the request fails due to a missing, invalid, or mismatching
   redirection URI, or if the client identifier is missing or invalid,
   the authorization server SHOULD inform the resource owner of the
   error and MUST NOT automatically redirect the user-agent to the
   invalid redirection URI.
>
>   If the resource owner denies the access request or if the request
   fails for reasons other than a missing or invalid redirection URI,
   the authorization server informs the client by adding the following
   parameters to the query component of the redirection URI using the
   "application/x-www-form-urlencoded" format, per Appendix B:

This appears to me to state that all errors (other than for bad redirect URIs) should be returned to the client.

The OIDC spec then goes on to re-enforce this:

> Unless the Redirection URI is invalid, the Authorization Server returns the Client to the Redirection URI specified in the Authorization Request with the appropriate error and state parameters.

Again, I only made this initial PR to help portray what I understand to be required here. I'm looking for your thoughts before taking this any further as to not waste time.

**Does this PR introduce a breaking change?**

Yes

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
