### PR TITLE
Added check to scope validator for missing identity and api scopes

### DIFF
--- a/src/IdentityServer4/src/Validation/Default/ScopeValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/ScopeValidator.cs
@@ -129,6 +129,12 @@ namespace IdentityServer4.Validation
             {
                 GrantedResources.OfflineAccess = true;
                 requestedScopes = requestedScopes.Where(x => x != IdentityServerConstants.StandardScopes.OfflineAccess).ToArray();
+
+                if (!requestedScopes.Any())
+                {
+                    _logger.LogError("No identity or API scopes requested");
+                    return false;
+                }
             }
 
             var resources = await _store.FindResourcesByScopeAsync(requestedScopes);

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/ScopeValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/ScopeValidation.cs
@@ -129,6 +129,18 @@ namespace IdentityServer4.UnitTests.Validation
 
         [Fact]
         [Trait("Category", Category)]
+        public async Task Only_Offline_Access_Requested()
+        {
+            var scopes = "offline_access".ParseScopesString();
+
+            var validator = Factory.CreateScopeValidator(_store);
+            var result = await validator.AreScopesValidAsync(scopes);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
         public async Task All_Scopes_Valid()
         {
             var scopes = "openid email resource1 resource2".ParseScopesString();


### PR DESCRIPTION
Fix for IdentityServer bug reported in #3332 

This stops IdentityServer issuing access tokens when only the offline_access scope is requested.