### PR TITLE
add AddValidationKeys signature accepting X509Certificate2[] (#3383)

### DIFF
--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Crypto.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Crypto.cs
@@ -192,6 +192,21 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds the validation keys.
         /// </summary>
         /// <param name="builder">The builder.</param>
+        /// <param name="certificates">The certificates.</param>
+        /// <returns></returns>
+        public static IIdentityServerBuilder AddValidationKeys(this IIdentityServerBuilder builder, params X509Certificate2[] certificates)
+        {
+            var keys = certificates.Select(certificate => new X509SecurityKey(certificate)).Cast<AsymmetricSecurityKey>();
+
+            builder.Services.AddSingleton<IValidationKeysStore>(new DefaultValidationKeysStore(keys));
+
+            return builder;
+        }
+   
+        /// <summary>
+        /// Adds the validation keys.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
         /// <param name="keys">The keys.</param>
         /// <returns></returns>
         public static IIdentityServerBuilder AddValidationKeys(this IIdentityServerBuilder builder, params AsymmetricSecurityKey[] keys)


### PR DESCRIPTION
Added new signature for AddValidationKeys that accepts X509Certificate2[] as params

**What issue does this PR address?**
missing method AddValidationKeys that accepts X509Certificate2[]

**Does this PR introduce a breaking change?**
not in my opinion

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)

- [ ] Unit Tests for the changes have been added (for bug fixes / features)
no

**Other information**:
