### PR TITLE
Fix the scheme name for external providers

### DIFF
--- a/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/IdentityServer/Quickstart/Account/ExternalController.cs
+++ b/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/IdentityServer/Quickstart/Account/ExternalController.cs
@@ -86,7 +86,7 @@ namespace Host.Quickstart.Account
         public async Task<IActionResult> Callback()
         {
             // read external identity from the temporary cookie
-            var result = await HttpContext.AuthenticateAsync(IdentityConstants.ExternalScheme);
+            var result = await HttpContext.AuthenticateAsync(IdentityServerConstants.ExternalCookieAuthenticationScheme);
             if (result?.Succeeded != true)
             {
                 throw new Exception("External authentication error");


### PR DESCRIPTION
**What issue does this PR address?**
Just changed one line to fix external provider callback
IdentityConstants.ExternalScheme --> IdentityServerConstants.ExternalCookieAuthenticationScheme

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
