### PR TITLE
check that HttpContext is set before setting AudienceUri (#3436)

### DIFF
--- a/src/IdentityServer4/src/Validation/Default/JwtRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/JwtRequestValidator.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json.Linq;
 namespace IdentityServer4.Validation
 {
     /// <summary>
-    /// Validates JWT requwest objects
+    /// Validates JWT request objects
     /// </summary>
     public class JwtRequestValidator
     {
@@ -39,7 +39,10 @@ namespace IdentityServer4.Validation
         /// </summary>
         public JwtRequestValidator(IHttpContextAccessor contextAccessor, ILogger<JwtRequestValidator> logger)
         {
-            AudienceUri = contextAccessor.HttpContext.GetIdentityServerIssuerUri();
+            if (contextAccessor.HttpContext != null)
+            {
+                AudienceUri = contextAccessor.HttpContext.GetIdentityServerIssuerUri();
+            }
             Logger = logger;
         }
 


### PR DESCRIPTION
**What issue does this PR address?**
Allows the `JwtRequestValidator` to be constructable when the HttpContext is not set because it is constructed outside the context of a request. This was discovered by using SimpleInjector `Verify` that attempts to construct all dependencies to weed out DI configuration-related errors.

Addresses issue #3436 

**Does this PR introduce a breaking change?**
No
