### PR TITLE
Update Startup.cs

### DIFF
--- a/src/IdentityServer4/host/Startup.cs
+++ b/src/IdentityServer4/host/Startup.cs
@@ -88,13 +88,13 @@ namespace Host
 
         public void Configure(IApplicationBuilder app)
         {
+            app.UseStaticFiles();
             app.UseRouting();
             app.UseMiddleware<Logging.RequestLoggerMiddleware>();
 
             app.UseDeveloperExceptionPage();
 
             app.UseIdentityServer();
-            app.UseStaticFiles();
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
This PR moves just the call from UseStaticFiles before UseRouting in the Startup

**What issue does this PR address?**
According the migrating guide (source: https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-2.2&tabs=visual-studio) UseStaticFiles should be called before UseRouting

> If the app calls UseStaticFiles, place UseStaticFiles before UseRouting

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
