### PR TITLE
Introduce option to omit ~/resources in JWT access tokens

### DIFF
--- a/docs/reference/options.rst
+++ b/docs/reference/options.rst
@@ -38,6 +38,11 @@ Authentication
 * ``RequireCspFrameSrcForSignout``
     If set, will require frame-src CSP headers being emitting on the end session callback endpoint which renders iframes to clients for front-channel signout notification. Defaults to true.
 
+AccessToken
+^^^^^^^^^^^
+* ``IncludeIssuerResourcesInAudienceClaim``
+    Specifies whether JWT access tokens issued by IdentityServer will include '~/resources' in the 'aud' claim.
+
 Events
 ^^^^^^
 Allows configuring if and which events should be submitted to a registered event sink. See :ref:`here <refEvents>` for more information on events.
@@ -63,7 +68,7 @@ UserInteraction
     Sets the name of the return URL parameter passed to a custom redirect from the authorization endpoint. Defaults to *returnUrl*.
 * ``CookieMessageThreshold``
     Certain interactions between IdentityServer and some UI pages require a cookie to pass state and context (any of the pages above that have a configurable "message id" parameter).
-    Since browsers have limits on the number of cookies and their size, this setting is used to prevent too many cookies being created. 
+    Since browsers have limits on the number of cookies and their size, this setting is used to prevent too many cookies being created.
     The value sets the maximum number of message cookies of any type that will be created.
     The oldest message cookies will be purged once the limit has been reached.
     This effectively indicates how many tabs can be opened by a user when using IdentityServer.
@@ -89,7 +94,7 @@ The underlying CORS implementation is provided from ASP.NET Core, and as such it
     If you wish to customize the set of CORS origins allowed to connect, then it is recommended that you provide a custom implementation of ``ICorsPolicyService``.
 
 * ``CorsPaths``
-    The endpoints within IdentityServer where CORS is supported. 
+    The endpoints within IdentityServer where CORS is supported.
     Defaults to the discovery, user info, token, and revocation endpoints.
 
 * ``PreflightCacheDuration``

--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/AccessTokenOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/AccessTokenOptions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System;
+
+namespace IdentityServer4.Configuration
+{
+    /// <summary>
+    /// Access token options.
+    /// </summary>
+    public class AccessTokenOptions
+    {
+        /// <summary>
+        /// Specifies whether JWT access tokens issued by IdentityServer will include '~/resources' in the 'aud' claim.
+        /// </summary>
+        public bool IncludeIssuerResourcesInAudienceClaim { get; set; } = true;
+    }
+}

--- a/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -96,5 +96,10 @@ namespace IdentityServer4.Configuration
         /// Gets or sets the Content Security Policy options.
         /// </summary>
         public CspOptions Csp { get; set; } = new CspOptions();
+
+        /// <summary>
+        /// Gets or sets the access token options.
+        /// </summary>
+        public AccessTokenOptions AccessToken { get; set; } = new AccessTokenOptions();
     }
 }

--- a/src/IdentityServer4/Validation/TokenValidator.cs
+++ b/src/IdentityServer4/Validation/TokenValidator.cs
@@ -169,9 +169,14 @@ namespace IdentityServer4.Validation
                 }
 
                 _log.AccessTokenType = AccessTokenType.Jwt.ToString();
+
+                var validAudience = _options.AccessToken.IncludeIssuerResourcesInAudienceClaim
+                    ? string.Format(Constants.AccessTokenAudience, _context.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash())
+                    : null;
+
                 result = await ValidateJwtAsync(
                     token,
-                    string.Format(Constants.AccessTokenAudience, _context.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash()),
+                    validAudience,
                     await _keys.GetValidationKeysAsync());
             }
             else
@@ -279,6 +284,7 @@ namespace IdentityServer4.Validation
                 ValidIssuer = _context.HttpContext.GetIdentityServerIssuerUri(),
                 IssuerSigningKeys = validationKeys,
                 ValidateLifetime = validateLifetime,
+                ValidateAudience = audience.IsPresent(),
                 ValidAudience = audience
             };
 


### PR DESCRIPTION
**What issue does this PR address?**
Make Audience ~/resources optional for access tokens.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)
