### PR TITLE
Set typ header for access tokens

### DIFF
--- a/samples/Clients/src/SampleApi/Startup.cs
+++ b/samples/Clients/src/SampleApi/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using System;
+using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 
 namespace SampleApi
@@ -30,6 +31,22 @@ namespace SampleApi
 
                     options.ApiName = "api1";
                     options.ApiSecret = "secret";
+
+                    options.JwtBearerEvents = new Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents
+                    {
+                        OnTokenValidated = e =>
+                        {
+                            var jwt = e.SecurityToken as JwtSecurityToken;
+                            var type = jwt.Header.Typ;
+
+                            if (!string.Equals(type, "at+jwt", StringComparison.Ordinal))
+                            {
+                                e.Fail("JWT is not an access token");
+                            }
+
+                            return Task.CompletedTask;
+                        }
+                    };
                 })
                 .AddCertificate("x509", options =>
                 {

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -29,6 +29,14 @@ namespace IdentityServer4.Configuration
         public string PublicOrigin { get; set; }
 
         /// <summary>
+        /// Gets or sets the value for the JWT typ header for access tokens.
+        /// </summary>
+        /// <value>
+        /// The JWT typ value.
+        /// </value>
+        public string AccessTokenJwtType { get; set; } = "at+jwt";
+
+        /// <summary>
         /// Gets or sets the endpoint configuration.
         /// </summary>
         /// <value>

--- a/src/IdentityServer4/src/Services/Default/DefaultTokenCreationService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultTokenCreationService.cs
@@ -12,6 +12,7 @@ using System;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
+using static IdentityServer4.IdentityServerConstants;
 
 namespace IdentityServer4.Services
 {
@@ -89,6 +90,11 @@ namespace IdentityServer4.Services
                 }
 
                 header["x5t"] = Base64Url.Encode(cert.GetCertHash());
+            }
+
+            if (token.Type == TokenTypes.AccessToken)
+            {
+                header["typ"] = "at+jwt";
             }
 
             return header;

--- a/src/IdentityServer4/src/Services/Default/DefaultTokenCreationService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultTokenCreationService.cs
@@ -3,6 +3,7 @@
 
 
 using IdentityModel;
+using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using Microsoft.AspNetCore.Authentication;
@@ -37,15 +38,26 @@ namespace IdentityServer4.Services
         protected readonly ISystemClock Clock;
 
         /// <summary>
+        /// The options
+        /// </summary>
+        protected readonly IdentityServerOptions Options;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DefaultTokenCreationService"/> class.
         /// </summary>
         /// <param name="clock">The options.</param>
         /// <param name="keys">The keys.</param>
+        /// <param name="options">The options.</param>
         /// <param name="logger">The logger.</param>
-        public DefaultTokenCreationService(ISystemClock clock, IKeyMaterialService keys, ILogger<DefaultTokenCreationService> logger)
+        public DefaultTokenCreationService(
+            ISystemClock clock,
+            IKeyMaterialService keys,
+            IdentityServerOptions options,
+            ILogger<DefaultTokenCreationService> logger)
         {
             Clock = clock;
             Keys = keys;
+            Options = options;
             Logger = logger;
         }
 
@@ -94,7 +106,10 @@ namespace IdentityServer4.Services
 
             if (token.Type == TokenTypes.AccessToken)
             {
-                header["typ"] = "at+jwt";
+                if (Options.AccessTokenJwtType.IsPresent())
+                {
+                    header["typ"] = Options.AccessTokenJwtType;
+                }
             }
 
             return header;

--- a/src/IdentityServer4/src/Services/Default/DefaultTokenService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultTokenService.cs
@@ -186,7 +186,6 @@ namespace IdentityServer4.Services
             var token = new Token(OidcConstants.TokenTypes.AccessToken)
             {
                 CreationTime = Clock.UtcNow.UtcDateTime,
-                Audiences = { string.Format(IdentityServerConstants.AccessTokenAudience, issuer.EnsureTrailingSlash()) },
                 Issuer = issuer,
                 Lifetime = request.ValidatedRequest.AccessTokenLifetime,
                 Claims = claims.Distinct(new ClaimComparer()).ToList(),

--- a/src/IdentityServer4/src/Validation/Default/TokenValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/TokenValidator.cs
@@ -97,7 +97,7 @@ namespace IdentityServer4.Validation
             _logger.LogDebug("Client found: {clientId} / {clientName}", client.ClientId, client.ClientName);
 
             var keys = await _keys.GetValidationKeysAsync();
-            var result = await ValidateJwtAsync(token, clientId, keys, validateLifetime);
+            var result = await ValidateJwtAsync(token, keys, audience: clientId, validateLifetime: validateLifetime);
 
             result.Client = client;
 
@@ -171,7 +171,6 @@ namespace IdentityServer4.Validation
                 _log.AccessTokenType = AccessTokenType.Jwt.ToString();
                 result = await ValidateJwtAsync(
                     token,
-                    string.Format(IdentityServerConstants.AccessTokenAudience, _context.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash()),
                     await _keys.GetValidationKeysAsync());
             }
             else
@@ -269,7 +268,7 @@ namespace IdentityServer4.Validation
             return customResult;
         }
 
-        private async Task<TokenValidationResult> ValidateJwtAsync(string jwt, string audience, IEnumerable<SecurityKey> validationKeys, bool validateLifetime = true)
+        private async Task<TokenValidationResult> ValidateJwtAsync(string jwt, IEnumerable<SecurityKey> validationKeys, bool validateLifetime = true, string audience = null)
         {
             var handler = new JwtSecurityTokenHandler();
             handler.InboundClaimTypeMap.Clear();
@@ -279,13 +278,40 @@ namespace IdentityServer4.Validation
                 ValidIssuer = _context.HttpContext.GetIdentityServerIssuerUri(),
                 IssuerSigningKeys = validationKeys,
                 ValidateLifetime = validateLifetime,
-                ValidAudience = audience
             };
+
+            if (audience.IsPresent())
+            {
+                parameters.ValidAudience = audience;
+            }
+            else
+            {
+                parameters.ValidateAudience = false;
+            }
 
             try
             {
-                var id = handler.ValidateToken(jwt, parameters, out var _);
+                var id = handler.ValidateToken(jwt, parameters, out var securityToken);
+                var jwtSecurityToken = securityToken as JwtSecurityToken;
 
+                // if no audience is specified, we make at least sure that it is an access token
+                if (audience.IsMissing())
+                {
+                    if (_options.AccessTokenJwtType.IsPresent())
+                    {
+                        var type = jwtSecurityToken.Header.Typ;
+                        if (!string.Equals(type, _options.AccessTokenJwtType))
+                        {
+                            return new TokenValidationResult
+                            {
+                                IsError = true,
+                                Error = "invalid JWT token type"
+                            };
+                        }
+
+                    }
+                }
+                
                 // if access token contains an ID, log it
                 var jwtId = id.FindFirst(JwtClaimTypes.JwtId);
                 if (jwtId != null)

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientAssertionClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientAssertionClient.cs
@@ -170,10 +170,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
         }
 
         private Dictionary<string, object> GetPayload(TokenResponse response)

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsClient.cs
@@ -52,7 +52,7 @@ namespace IdentityServer4.IntegrationTests.Clients
         }
 
         [Fact]
-        public async Task Valid_request_should_return_expected_payload()
+        public async Task Valid_request_single_audience_should_return_expected_payload()
         {
             var response = await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
             {
@@ -74,10 +74,39 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("iss", "https://idsvr4");
             payload.Should().Contain("client_id", "client");
 
+            payload["aud"].Should().Be("api");
+
+            var scopes = payload["scope"] as JArray;
+            scopes.First().ToString().Should().Be("api1");
+        }
+
+        [Fact]
+        public async Task Valid_request_multiple_audiences_should_return_expected_payload()
+        {
+            var response = await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+            {
+                Address = TokenEndpoint,
+                ClientId = "client",
+                ClientSecret = "secret",
+                Scope = "api1 other_api"
+            });
+
+            response.IsError.Should().Be(false);
+            response.ExpiresIn.Should().Be(3600);
+            response.TokenType.Should().Be("Bearer");
+            response.IdentityToken.Should().BeNull();
+            response.RefreshToken.Should().BeNull();
+
+            var payload = GetPayload(response);
+
+            payload.Count().Should().Be(6);
+            payload.Should().Contain("iss", "https://idsvr4");
+            payload.Should().Contain("client_id", "client");
+
             var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
             audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
             audiences.Should().Contain("api");
+            audiences.Should().Contain("other_api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
@@ -107,10 +136,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("client_id", "client.cnf");
             
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
@@ -142,10 +168,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("iss", "https://idsvr4");
             payload.Should().Contain("client_id", "client");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.Count().Should().Be(2);
@@ -177,13 +200,14 @@ namespace IdentityServer4.IntegrationTests.Clients
 
             var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
             audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
             audiences.Should().Contain("api");
+            audiences.Should().Contain("other_api");
 
-            var scopes = payload["scope"] as JArray;
-            scopes.Count().Should().Be(2);
-            scopes.First().ToString().Should().Be("api1");
-            scopes.Skip(1).First().ToString().Should().Be("api2");
+            var scopes = ((JArray)payload["scope"]).Select(x => x.ToString());
+            scopes.Count().Should().Be(3);
+            scopes.Should().Contain("api1");
+            scopes.Should().Contain("api2");
+            scopes.Should().Contain("other_api");
         }
 
         [Fact]
@@ -229,10 +253,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("iss", "https://idsvr4");
             payload.Should().Contain("client_id", "client");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
@@ -261,10 +282,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("iss", "https://idsvr4");
             payload.Should().Contain("client_id", "client.no_secret");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenResponseClients.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenResponseClients.cs
@@ -89,10 +89,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "bob");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
@@ -211,10 +208,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "bob");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ExtensionGrantClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ExtensionGrantClient.cs
@@ -74,10 +74,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "818727");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
@@ -118,10 +115,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("iss", "https://idsvr4");
             payload.Should().Contain("client_id", "client.custom");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
@@ -159,10 +153,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "818727");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var amr = payload["amr"] as JArray;
             amr.Count().Should().Be(1);
@@ -285,10 +276,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "818727");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
@@ -429,10 +417,7 @@ namespace IdentityServer4.IntegrationTests.Clients
 
             payload.Should().Contain("client_extra", "extra_claim");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");
@@ -475,10 +460,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("client_id", "client.dynamic");
             payload.Should().Contain("client_extra", "extra_claim");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = payload["scope"] as JArray;
             scopes.First().ToString().Should().Be("api1");

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ResourceOwnerClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ResourceOwnerClient.cs
@@ -62,10 +62,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "88421113");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var scopes = ((JArray)payload["scope"]).Select(x => x.ToString());
             scopes.Count().Should().Be(1);
@@ -103,10 +100,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "88421113");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var amr = payload["amr"] as JArray;
             amr.Count().Should().Be(1);
@@ -155,10 +149,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "88421113");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var amr = payload["amr"] as JArray;
             amr.Count().Should().Be(1);
@@ -199,10 +190,7 @@ namespace IdentityServer4.IntegrationTests.Clients
             payload.Should().Contain("sub", "88421113");
             payload.Should().Contain("idp", "local");
 
-            var audiences = ((JArray)payload["aud"]).Select(x => x.ToString());
-            audiences.Count().Should().Be(2);
-            audiences.Should().Contain("https://idsvr4/resources");
-            audiences.Should().Contain("api");
+            payload["aud"].Should().Be("api");
 
             var amr = payload["amr"] as JArray;
             amr.Count().Should().Be(1);

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/Setup/Clients.cs
@@ -32,7 +32,7 @@ namespace IdentityServer4.IntegrationTests.Clients
 
                     AllowedScopes =
                     {
-                        "api1", "api2"
+                        "api1", "api2", "other_api"
                     }
                 },
                 new Client

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/Setup/Scopes.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/Setup/Scopes.cs
@@ -27,7 +27,7 @@ namespace IdentityServer4.IntegrationTests.Clients
                 new ApiResource
                 {
                     Name = "api",
-                    ApiSecrets = 
+                    ApiSecrets =
                     {
                         new Secret("secret".Sha256())
                     },
@@ -51,7 +51,8 @@ namespace IdentityServer4.IntegrationTests.Clients
                             UserClaims = { "role" }
                         }
                     }
-                }
+                },
+                new ApiResource("other_api")
             };
         }
     }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
@@ -181,14 +181,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Introspection
 
             var values = introspectionResponse.Json.ToObject<Dictionary<string, object>>();
 
-            values["aud"].GetType().Name.Should().Be("JArray");
-
-            var audiences = ((JArray)values["aud"]);
-            foreach (var aud in audiences)
-            {
-                aud.Type.Should().Be(JTokenType.String);
-            }
-
+            values["aud"].GetType().Name.Should().Be("String");
             values["iss"].GetType().Name.Should().Be("String");
             values["nbf"].GetType().Name.Should().Be("Int64");
             values["exp"].GetType().Name.Should().Be("Int64");
@@ -227,14 +220,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Introspection
 
             var values = introspectionResponse.Json.ToObject<Dictionary<string, object>>();
 
-            values["aud"].GetType().Name.Should().Be("JArray");
-
-            var audiences = ((JArray)values["aud"]);
-            foreach (var aud in audiences)
-            {
-                aud.Type.Should().Be(JTokenType.String);
-            }
-
+            values["aud"].GetType().Name.Should().Be("String");
             values["iss"].GetType().Name.Should().Be("String");
             values["nbf"].GetType().Name.Should().Be("Int64");
             values["exp"].GetType().Name.Should().Be("Int64");
@@ -249,7 +235,52 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Introspection
 
         [Fact]
         [Trait("Category", Category)]
-        public async Task Response_data_should_be_valid_using_multiple_scopes()
+        public async Task Response_data_should_be_valid_using_multiple_scopes_multiple_audiences()
+        {
+            var tokenResponse = await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+            {
+                Address = TokenEndpoint,
+                ClientId = "client1",
+                ClientSecret = "secret",
+
+                Scope = "api2 api3-a api3-b",
+            });
+
+            tokenResponse.IsError.Should().BeFalse();
+
+            var introspectionResponse = await _client.IntrospectTokenAsync(new TokenIntrospectionRequest
+            {
+                Address = IntrospectionEndpoint,
+                ClientId = "api3",
+                ClientSecret = "secret",
+
+                Token = tokenResponse.AccessToken
+            });
+
+            var values = introspectionResponse.Json.ToObject<Dictionary<string, object>>();
+
+            values["aud"].GetType().Name.Should().Be("JArray");
+
+            var audiences = ((JArray)values["aud"]);
+            foreach (var aud in audiences)
+            {
+                aud.Type.Should().Be(JTokenType.String);
+            }
+
+            values["iss"].GetType().Name.Should().Be("String");
+            values["nbf"].GetType().Name.Should().Be("Int64");
+            values["exp"].GetType().Name.Should().Be("Int64");
+            values["client_id"].GetType().Name.Should().Be("String");
+            values["active"].GetType().Name.Should().Be("Boolean");
+            values["scope"].GetType().Name.Should().Be("String");
+
+            var scopes = values["scope"].ToString();
+            scopes.Should().Be("api3-a api3-b");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task Response_data_should_be_valid_using_multiple_scopes_single_audience()
         {
             var tokenResponse = await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
             {
@@ -273,14 +304,7 @@ namespace IdentityServer4.IntegrationTests.Endpoints.Introspection
 
             var values = introspectionResponse.Json.ToObject<Dictionary<string, object>>();
 
-            values["aud"].GetType().Name.Should().Be("JArray");
-
-            var audiences = ((JArray)values["aud"]);
-            foreach(var aud in audiences)
-            {
-                aud.Type.Should().Be(JTokenType.String);
-            }
-
+            values["aud"].GetType().Name.Should().Be("String");
             values["iss"].GetType().Name.Should().Be("String"); 
             values["nbf"].GetType().Name.Should().Be("Int64"); 
             values["exp"].GetType().Name.Should().Be("Int64"); 

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
@@ -201,23 +201,6 @@ namespace IdentityServer4.UnitTests.Validation
 
         [Fact]
         [Trait("Category", Category)]
-        public async Task JWT_Token_invalid_Audience()
-        {
-            var signer = Factory.CreateDefaultTokenCreator();
-            var token = TokenFactory.CreateAccessToken(new Client { ClientId = "roclient" }, "valid", 600, "read", "write");
-            token.Audiences.Clear();
-            token.Audiences.Add("invalid");
-            var jwt = await signer.CreateTokenAsync(token);
-
-            var validator = Factory.CreateTokenValidator(null);
-            var result = await validator.ValidateAccessTokenAsync(jwt);
-
-            result.IsError.Should().BeTrue();
-            result.Error.Should().Be(OidcConstants.ProtectedResourceErrors.InvalidToken);
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
         public async Task Valid_AccessToken_but_Client_not_active()
         {
             var store = Factory.CreateReferenceTokenStore();

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -121,7 +121,10 @@ namespace IdentityServer4.UnitTests.Validation
         {
             return new DefaultTokenCreationService(
                 new StubClock(),
-                new DefaultKeyMaterialService(new IValidationKeysStore[] { }, new DefaultSigningCredentialsStore(TestCert.LoadSigningCredentials())), TestLogger.Create<DefaultTokenCreationService>());
+                new DefaultKeyMaterialService(new IValidationKeysStore[] { },
+                new DefaultSigningCredentialsStore(TestCert.LoadSigningCredentials())),
+                TestIdentityServerOptions.Create(),
+                TestLogger.Create<DefaultTokenCreationService>());
         }
 
         public static DeviceAuthorizationRequestValidator CreateDeviceAuthorizationRequestValidator(


### PR DESCRIPTION
...this would also allow removing the `../resources` audience.

TODO: 

* [x] check typ in the built-in token validator.
* [x] make token type value configurable on `IdentityServerOptions`
* [x] remove the old resources audience?