### PR TITLE
move logging before removal so the PromptMode is included in the logging

### DIFF
--- a/src/IdentityServer4/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -101,12 +101,12 @@ namespace IdentityServer4.ResponseHandling
             if (request.PromptMode == OidcConstants.PromptModes.Login ||
                 request.PromptMode == OidcConstants.PromptModes.SelectAccount)
             {
+                Logger.LogInformation("Showing login: request contains prompt={0}", request.PromptMode);
+
                 // remove prompt so when we redirect back in from login page
                 // we won't think we need to force a prompt again
                 request.RemovePrompt();
-
-                Logger.LogInformation("Showing login: request contains prompt={0}", request.PromptMode);
-
+                
                 return new InteractionResponse { IsLogin = true };
             }
 


### PR DESCRIPTION
**What issue does this PR address?**
In the AuthorizeInteractionResponseGenerator.ProcessLoginAsync method, the call to the Logger.LogInformation() is done after the prompt mode has been cleared from the request. This leads to "Showing login: request contains prompt=null" showing up in the logs

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
