### PR TITLE
Updated tests for EF Core 3

### DIFF
--- a/src/EntityFramework.Storage/src/Services/CorsPolicyService.cs
+++ b/src/EntityFramework.Storage/src/Services/CorsPolicyService.cs
@@ -45,7 +45,12 @@ namespace IdentityServer4.EntityFramework.Services
             // doing this here and not in the ctor because: https://github.com/aspnet/CORS/issues/105
             var dbContext = _context.HttpContext.RequestServices.GetRequiredService<IConfigurationDbContext>();
 
-            var origins = dbContext.Clients.SelectMany(x => x.AllowedCorsOrigins.Select(y => y.Origin)).AsNoTracking().ToList();
+            var origins = dbContext.Clients
+                .Include(x => x.AllowedCorsOrigins)
+                .AsNoTracking()
+                .ToList()
+                .SelectMany(x => x.AllowedCorsOrigins.Select(y => y.Origin))
+                .ToList();
 
             var distinctOrigins = origins.Where(x => x != null).Distinct();
 

--- a/src/EntityFramework.Storage/test/IntegrationTests/DbContexts/ClientDbContextTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/DbContexts/ClientDbContextTests.cs
@@ -22,7 +22,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
             }
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void CanAddAndDeleteClientScopes(DbContextOptions<ConfigurationDbContext> options)
         {
             using (var db = new ConfigurationDbContext(options, StoreOptions))
@@ -67,7 +67,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
             }
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void CanAddAndDeleteClientRedirectUri(DbContextOptions<ConfigurationDbContext> options)
         {
             using (var db = new ConfigurationDbContext(options, StoreOptions))

--- a/src/EntityFramework.Storage/test/IntegrationTests/IntegrationTest.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/IntegrationTest.cs
@@ -32,7 +32,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
 
                 TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
                 {
-                    DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name),
+                    // DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name),
                     DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name),
                     DatabaseProviderBuilder.BuildLocalDb<TDbContext>(typeof(TClass).Name)
                 };
@@ -41,7 +41,8 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
             {
                 TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
                 {
-                    DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name)
+                    // DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name)
+                    DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name)
                 };
                 Console.WriteLine("Skipping DB integration tests on non-Windows");
             }

--- a/src/EntityFramework.Storage/test/IntegrationTests/Services/CorsPolicyServiceTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Services/CorsPolicyServiceTests.cs
@@ -29,7 +29,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
             }
         }
 
-        [Theory(Skip = "EFCore3 doesn't seem to support SelectMany"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void IsOriginAllowedAsync_WhenOriginIsAllowed_ExpectTrue(DbContextOptions<ConfigurationDbContext> options)
         {
             const string testCorsOrigin = "https://identityserver.io/";
@@ -68,7 +68,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
             Assert.True(result);
         }
 
-        [Theory(Skip = "EFCore3 doesn't seem to support SelectMany"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void IsOriginAllowedAsync_WhenOriginIsNotAllowed_ExpectFalse(DbContextOptions<ConfigurationDbContext> options)
         {
             using (var context = new ConfigurationDbContext(options, StoreOptions))

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
@@ -27,7 +27,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             }
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindClientByIdAsync_WhenClientExists_ExpectClientRetured(DbContextOptions<ConfigurationDbContext> options)
         {
             var testClient = new Client
@@ -52,7 +52,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.NotNull(client);
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindClientByIdAsync_WhenClientExists_ExpectClientPropertiesRetured(DbContextOptions<ConfigurationDbContext> options)
         {
             var testClient = new Client

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/DeviceFlowStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/DeviceFlowStoreTests.cs
@@ -220,7 +220,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             code.Subject.Claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Subject && x.Value == expectedSubject).Should().NotBeNull();
         }
 
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public async Task FindByUserCodeAsync_WhenUserCodeDoesNotExist_ExpectNull(DbContextOptions<PersistedGrantDbContext> options)
         {
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -276,7 +276,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             code.Subject.Claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Subject && x.Value == expectedSubject).Should().NotBeNull();
         }
 
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public async Task FindByDeviceCodeAsync_WhenDeviceCodeDoesNotExist_ExpectNull(DbContextOptions<PersistedGrantDbContext> options)
         {
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -353,7 +353,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             parsedCode.Subject.Claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Subject && x.Value == expectedSubject).Should().NotBeNull();
         }
 
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public async Task RemoveByDeviceCodeAsync_WhenDeviceCodeExists_ExpectDeviceCodeDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var testDeviceCode = $"device_{Guid.NewGuid().ToString()}";
@@ -393,7 +393,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
                 context.DeviceFlowCodes.FirstOrDefault(x => x.UserCode == testUserCode).Should().BeNull();
             }
         }
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public async Task RemoveByDeviceCodeAsync_WhenDeviceCodeDoesNotExists_ExpectSuccess(DbContextOptions<PersistedGrantDbContext> options)
         {
             using (var context = new PersistedGrantDbContext(options, StoreOptions))

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -40,7 +40,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             };
         }
 
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void StoreAsync_WhenPersistedGrantStored_ExpectSuccess(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
@@ -101,7 +101,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.NotEmpty(foundPersistedGrants);
         }
 
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void RemoveAsync_WhenKeyOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
@@ -125,7 +125,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             }
         }
 
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void RemoveAsync_WhenSubIdAndClientIdOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
@@ -149,7 +149,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             }
         }
 
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void RemoveAsync_WhenSubIdClientIdAndTypeOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
@@ -173,7 +173,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             }
         }
 
-        [Theory(Skip = "Strange NRE for InMemory provider"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void Store_should_create_new_record_if_key_does_not_exist(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ResourceStoreTests.cs
@@ -67,7 +67,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             };
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindResourcesAsync_WhenResourcesExist_ExpectResourcesReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var testIdentityResource = CreateIdentityTestResource();
@@ -100,7 +100,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.NotNull(resources.ApiResources.FirstOrDefault(x => x.Name == testApiResource.Name));
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindResourcesAsync_WhenResourcesExist_ExpectOnlyResourcesRequestedReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var testIdentityResource = CreateIdentityTestResource();
@@ -135,7 +135,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.Equal(1, resources.ApiResources.Count);
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void GetAllResources_WhenAllResourcesRequested_ExpectAllResourcesIncludingHidden(DbContextOptions<ConfigurationDbContext> options)
         {
             var visibleIdentityResource = CreateIdentityTestResource();
@@ -171,7 +171,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.Contains(resources.ApiResources, x => !x.Scopes.Any(y => y.ShowInDiscoveryDocument));
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindIdentityResourcesByScopeAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateIdentityTestResource();
@@ -201,7 +201,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.NotEmpty(foundScope.UserClaims);
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindIdentityResourcesByScopeAsync_WhenResourcesExist_ExpectOnlyRequestedReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateIdentityTestResource();
@@ -228,7 +228,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.Equal(1, resources.Count);
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindApiResourceAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateApiTestResource();
@@ -257,7 +257,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.Contains(foundResource.Scopes, x => x.UserClaims.Any());
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindApiResourcesByScopeAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateApiTestResource();
@@ -287,7 +287,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.Contains(resources.First().Scopes, x => x.UserClaims.Any());
         }
 
-        [Theory(Skip = "EfCore3 in-mem db does not support Include"), MemberData(nameof(TestDatabaseProviders))]
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
         public void FindApiResourcesByScopeAsync_WhenMultipleResourcesExist_ExpectOnlyRequestedResourcesReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateApiTestResource();

--- a/src/EntityFramework.Storage/test/IntegrationTests/TokenCleanup/TokenCleanupTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/TokenCleanup/TokenCleanupTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.EntityFramework.DbContexts;
+using IdentityServer4.EntityFramework.Entities;
+using IdentityServer4.EntityFramework.Interfaces;
+using IdentityServer4.EntityFramework.Options;
+using IdentityServer4.EntityFramework.Stores;
+using IdentityServer4.Stores;
+using IdentityServer4.Test;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IdentityServer4.EntityFramework.IntegrationTests.TokenCleanup
+{
+    public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGrantDbContext, OperationalStoreOptions>
+    {
+
+
+        public TokenCleanupTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture) : base(fixture)
+        {
+            foreach (var options in TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<PersistedGrantDbContext>)y)).ToList())
+            {
+                using (var context = new PersistedGrantDbContext(options, StoreOptions))
+                {
+                    context.Database.EnsureCreated();
+                }
+            }
+        }
+
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
+        public async Task RemoveExpiredGrantsAsync_WhenExpiredGrantsExist_ExpectExpiredGrantsRemoved(DbContextOptions<PersistedGrantDbContext> options)
+        {
+            var expiredGrant = new PersistedGrant
+            {
+                Key = Guid.NewGuid().ToString(),
+                ClientId = "app1",
+                Type = "reference",
+                SubjectId = "123",
+                Expiration = DateTime.UtcNow.AddDays(-3),
+                Data = "{!}"
+            };
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.PersistedGrants.Add(expiredGrant);
+                context.SaveChanges();
+            }
+
+            await CreateSut(options).RemoveExpiredGrantsAsync();
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.PersistedGrants.FirstOrDefault(x => x.Key == expiredGrant.Key).Should().BeNull();
+            }
+        }
+
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
+        public async Task RemoveExpiredGrantsAsync_WhenValidGrantsExist_ExpectValidGrantsInDb(DbContextOptions<PersistedGrantDbContext> options)
+        {
+            var validGrant = new PersistedGrant
+            {
+                Key = Guid.NewGuid().ToString(),
+                ClientId = "app1",
+                Type = "reference",
+                SubjectId = "123",
+                Expiration = DateTime.UtcNow.AddDays(3),
+                Data = "{!}"
+            };
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.PersistedGrants.Add(validGrant);
+                context.SaveChanges();
+            }
+
+            await CreateSut(options).RemoveExpiredGrantsAsync();
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.PersistedGrants.FirstOrDefault(x => x.Key == validGrant.Key).Should().NotBeNull();
+            }
+        }
+
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
+        public async Task RemoveExpiredGrantsAsync_WhenExpiredDeviceGrantsExist_ExpectExpiredDeviceGrantsRemoved(DbContextOptions<PersistedGrantDbContext> options)
+        {
+            var expiredGrant = new DeviceFlowCodes
+            {
+                DeviceCode = Guid.NewGuid().ToString(),
+                UserCode = Guid.NewGuid().ToString(),
+                ClientId = "app1",
+                SubjectId = "123",
+                CreationTime = DateTime.UtcNow.AddDays(-4),
+                Expiration = DateTime.UtcNow.AddDays(-3),
+                Data = "{!}"
+            };
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.DeviceFlowCodes.Add(expiredGrant);
+                context.SaveChanges();
+            }
+
+            await CreateSut(options).RemoveExpiredGrantsAsync();
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.DeviceFlowCodes.FirstOrDefault(x => x.DeviceCode == expiredGrant.DeviceCode).Should().BeNull();
+            }
+        }
+
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
+        public async Task RemoveExpiredGrantsAsync_WhenValidDeviceGrantsExist_ExpectValidDeviceGrantsInDb(DbContextOptions<PersistedGrantDbContext> options)
+        {
+            var validGrant = new DeviceFlowCodes
+            {
+                DeviceCode = Guid.NewGuid().ToString(),
+                UserCode = "2468",
+                ClientId = "app1",
+                SubjectId = "123",
+                CreationTime = DateTime.UtcNow.AddDays(-4),
+                Expiration = DateTime.UtcNow.AddDays(3),
+                Data = "{!}"
+            };
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.DeviceFlowCodes.Add(validGrant);
+                context.SaveChanges();
+            }
+
+            await CreateSut(options).RemoveExpiredGrantsAsync();
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.DeviceFlowCodes.FirstOrDefault(x => x.DeviceCode == validGrant.DeviceCode).Should().NotBeNull();
+            }
+        }
+
+        private EntityFramework.TokenCleanup CreateSut(DbContextOptions<PersistedGrantDbContext> options)
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddIdentityServer()
+                .AddTestUsers(new List<TestUser>())
+                .AddInMemoryClients(new List<Models.Client>())
+                .AddInMemoryIdentityResources(new List<Models.IdentityResource>())
+                .AddInMemoryApiResources(new List<Models.ApiResource>());
+
+            services.AddScoped<IPersistedGrantDbContext, PersistedGrantDbContext>(_ =>
+                new PersistedGrantDbContext(options, StoreOptions));
+            services.AddTransient<IPersistedGrantStore, PersistedGrantStore>();
+            services.AddTransient<IDeviceFlowStore, DeviceFlowStore>();
+
+            return new EntityFramework.TokenCleanup(
+                services.BuildServiceProvider(),
+                new NullLogger<EntityFramework.TokenCleanup>(),
+                StoreOptions);
+        }
+    }
+}


### PR DESCRIPTION
- Removed usage of in-memory database until EF Core 3 is ready. Sqlite now used for non-windows
  - https://github.com/aspnet/EntityFrameworkCore/issues/16963
- Made CORS service pull full client record into memory until EF Core 3 is ready
  - https://github.com/IdentityServer/IdentityServer4/issues/3546
- Added integration tests for token cleanup