### PR TITLE
identify the builds for each solution in the logs

### DIFF
--- a/src/AspNetIdentity/build/Program.cs
+++ b/src/AspNetIdentity/build/Program.cs
@@ -9,6 +9,7 @@ namespace build
 {
     class Program
     {
+        private const string Prefix = "AspNetIdentity";
         private const bool RequireTests = false;
 
         private const string ArtifactsDir = "artifacts";
@@ -29,7 +30,7 @@ namespace build
                 {
                     var solution = Directory.GetFiles(".", "*.sln", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"build {solution} -c Release");
+                    Run("dotnet", $"build {solution} -c Release", echoPrefix: Prefix);
 
                     if (sign.HasValue())
                     {
@@ -45,7 +46,7 @@ namespace build
 
                         foreach (var test in tests)
                         {
-                            Run("dotnet", $"test {test} -c Release --no-build");
+                            Run("dotnet", $"test {test} -c Release --no-build", echoPrefix: Prefix);
                         }    
                     }
                     catch (System.IO.DirectoryNotFoundException ex)
@@ -61,7 +62,7 @@ namespace build
                 {
                     var project = Directory.GetFiles("./src", "*.csproj", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build");
+                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build", echoPrefix: Prefix);
                     
                     if (sign.HasValue())
                     {
@@ -73,7 +74,7 @@ namespace build
 
 
                 Target("default", DependsOn(Test, Pack));
-                RunTargetsAndExit(app.RemainingArguments);
+                RunTargetsAndExit(app.RemainingArguments, logPrefix: Prefix);
             });
 
             app.Execute(args);

--- a/src/AspNetIdentity/build/build.csproj
+++ b/src/AspNetIdentity/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.3.0" />
+    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,8 +11,8 @@
   <ItemGroup>
     <!--build related-->
     <PackageReference Include="MinVer" Version="1.1.0" PrivateAssets="All" />
-    <PackageReference Update="SimpleExec" Version="6.0.0" />
-    <PackageReference Update="BullsEye" Version="2.4.0" />
+    <PackageReference Update="SimpleExec" Version="6.1.0-beta.1" />
+    <PackageReference Update="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.3.3" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19324-01" PrivateAssets="All" />
 

--- a/src/EntityFramework.Storage/build/Program.cs
+++ b/src/EntityFramework.Storage/build/Program.cs
@@ -9,6 +9,7 @@ namespace build
 {
     class Program
     {
+        private const string Prefix = "EntityFramework.Storage";
         private const bool RequireTests = true;
 
         private const string ArtifactsDir = "artifacts";
@@ -29,7 +30,7 @@ namespace build
                 {
                     var solution = Directory.GetFiles(".", "*.sln", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"build {solution} -c Release");
+                    Run("dotnet", $"build {solution} -c Release", echoPrefix: Prefix);
 
                     if (sign.HasValue())
                     {
@@ -45,7 +46,7 @@ namespace build
 
                         foreach (var test in tests)
                         {
-                            Run("dotnet", $"test {test} -c Release --no-build");
+                            Run("dotnet", $"test {test} -c Release --no-build", echoPrefix: Prefix);
                         }    
                     }
                     catch (System.IO.DirectoryNotFoundException ex)
@@ -61,7 +62,7 @@ namespace build
                 {
                     var project = Directory.GetFiles("./src", "*.csproj", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build");
+                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build", echoPrefix: Prefix);
                     
                     if (sign.HasValue())
                     {
@@ -73,7 +74,7 @@ namespace build
 
 
                 Target("default", DependsOn(Test, Pack));
-                RunTargetsAndExit(app.RemainingArguments);
+                RunTargetsAndExit(app.RemainingArguments, logPrefix: Prefix);
             });
 
             app.Execute(args);

--- a/src/EntityFramework.Storage/build/build.csproj
+++ b/src/EntityFramework.Storage/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.3.0" />
+    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>

--- a/src/EntityFramework/build/Program.cs
+++ b/src/EntityFramework/build/Program.cs
@@ -9,6 +9,7 @@ namespace build
 {
     class Program
     {
+        private const string Prefix = "EntityFramework";
         private const bool RequireTests = false;
 
         private const string ArtifactsDir = "artifacts";
@@ -29,7 +30,7 @@ namespace build
                 {
                     var solution = Directory.GetFiles(".", "*.sln", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"build {solution} -c Release");
+                    Run("dotnet", $"build {solution} -c Release", echoPrefix: Prefix);
 
                     if (sign.HasValue())
                     {
@@ -45,7 +46,7 @@ namespace build
 
                         foreach (var test in tests)
                         {
-                            Run("dotnet", $"test {test} -c Release --no-build");
+                            Run("dotnet", $"test {test} -c Release --no-build", echoPrefix: Prefix);
                         }    
                     }
                     catch (System.IO.DirectoryNotFoundException ex)
@@ -61,7 +62,7 @@ namespace build
                 {
                     var project = Directory.GetFiles("./src", "*.csproj", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build");
+                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build", echoPrefix: Prefix);
                     
                     if (sign.HasValue())
                     {
@@ -73,7 +74,7 @@ namespace build
 
 
                 Target("default", DependsOn(Test, Pack));
-                RunTargetsAndExit(app.RemainingArguments);
+                RunTargetsAndExit(app.RemainingArguments, logPrefix: Prefix);
             });
 
             app.Execute(args);

--- a/src/EntityFramework/build/build.csproj
+++ b/src/EntityFramework/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.3.0" />
+    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>

--- a/src/IdentityServer4/build/Program.cs
+++ b/src/IdentityServer4/build/Program.cs
@@ -9,6 +9,7 @@ namespace build
 {
     class Program
     {
+        private const string Prefix = "IdentityServer4";
         private const bool RequireTests = true;
 
         private const string ArtifactsDir = "artifacts";
@@ -29,7 +30,7 @@ namespace build
                 {
                     var solution = Directory.GetFiles(".", "*.sln", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"build {solution} -c Release");
+                    Run("dotnet", $"build {solution} -c Release", echoPrefix: Prefix);
 
                     if (sign.HasValue())
                     {
@@ -45,7 +46,7 @@ namespace build
 
                         foreach (var test in tests)
                         {
-                            Run("dotnet", $"test {test} -c Release --no-build");
+                            Run("dotnet", $"test {test} -c Release --no-build", echoPrefix: Prefix);
                         }    
                     }
                     catch (System.IO.DirectoryNotFoundException ex)
@@ -61,7 +62,7 @@ namespace build
                 {
                     var project = Directory.GetFiles("./src", "*.csproj", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build");
+                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build", echoPrefix: Prefix);
                     
                     if (sign.HasValue())
                     {
@@ -73,7 +74,7 @@ namespace build
 
 
                 Target("default", DependsOn(Test, Pack));
-                RunTargetsAndExit(app.RemainingArguments);
+                RunTargetsAndExit(app.RemainingArguments, logPrefix: Prefix);
             });
 
             app.Execute(args);

--- a/src/IdentityServer4/build/build.csproj
+++ b/src/IdentityServer4/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.3.0" />
+    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>

--- a/src/Storage/build/Program.cs
+++ b/src/Storage/build/Program.cs
@@ -9,6 +9,7 @@ namespace build
 {
     class Program
     {
+        private const string Prefix = "Storage";
         private const bool RequireTests = false;
 
         private const string ArtifactsDir = "artifacts";
@@ -29,7 +30,7 @@ namespace build
                 {
                     var solution = Directory.GetFiles(".", "*.sln", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"build {solution} -c Release");
+                    Run("dotnet", $"build {solution} -c Release", echoPrefix: Prefix);
 
                     if (sign.HasValue())
                     {
@@ -45,7 +46,7 @@ namespace build
 
                         foreach (var test in tests)
                         {
-                            Run("dotnet", $"test {test} -c Release --no-build");
+                            Run("dotnet", $"test {test} -c Release --no-build", echoPrefix: Prefix);
                         }    
                     }
                     catch (System.IO.DirectoryNotFoundException ex)
@@ -61,7 +62,7 @@ namespace build
                 {
                     var project = Directory.GetFiles("./src", "*.csproj", SearchOption.TopDirectoryOnly).First();
 
-                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build");
+                    Run("dotnet", $"pack {project} -c Release -o ./{ArtifactsDir} --no-build", echoPrefix: Prefix);
                     
                     if (sign.HasValue())
                     {
@@ -73,7 +74,7 @@ namespace build
 
 
                 Target("default", DependsOn(Test, Pack));
-                RunTargetsAndExit(app.RemainingArguments);
+                RunTargetsAndExit(app.RemainingArguments, logPrefix: Prefix);
             });
 
             app.Execute(args);

--- a/src/Storage/build/build.csproj
+++ b/src/Storage/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.3.0" />
+    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>


### PR DESCRIPTION
**What issue does this PR address?**

It's difficult to tell which solution each part of the build log applies to.

(The new version of Bullseye also comes with other things like a timing and outcome summary.)

### Before

![image](https://user-images.githubusercontent.com/677704/64113262-b56ff780-cd81-11e9-9ef4-a680c109a5f3.png)

### After

![image](https://user-images.githubusercontent.com/677704/64113714-e6046100-cd82-11e9-945a-996a0036c7aa.png)

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- ~Unit Tests for the changes have been added (for bug fixes / features)~

**Other information**:
