### PR TITLE
Microsoft.AspNetCore.Authentication.Abstractions nuget package deleted

### DIFF
--- a/src/EntityFramework.Storage/src/IdentityServer4.EntityFramework.Storage.csproj
+++ b/src/EntityFramework.Storage/src/IdentityServer4.EntityFramework.Storage.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="IdentityServer4.Storage" />
     <PackageReference Include="AutoMapper" Version="8.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" />
 
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />

--- a/src/Storage/src/IdentityServer4.Storage.csproj
+++ b/src/Storage/src/IdentityServer4.Storage.csproj
@@ -26,8 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" />
-
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
**What issue does this PR address?**
With this PR, I'm just deleted the unused Microsoft.AspNetCore.Authentication.Abstractions nuget package from IdentityServer4.Storage project.
Resolves #3580 

**Does this PR introduce a breaking change?**
No. I'm just deleted the unused nuget package from IdentityServer4.Storage project.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
