### PR TITLE
move entirely to netcoreapp3.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,11 +8,6 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
   - task: UseDotNet@2
-    displayName: 'Install .NET Core 2.x SDK'
-    inputs:
-      packageType: 'sdk'
-      version: '2.x'
-  - task: UseDotNet@2
     displayName: 'Install .NET Core 3.x SDK'
     inputs:
       packageType: 'sdk'
@@ -28,11 +23,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 2.x SDK'
-    inputs:
-      packageType: 'sdk'
-      version: '2.x'
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3.x SDK'
     inputs:

--- a/samples/Clients/src/JsOidc/JsOidc.csproj
+++ b/samples/Clients/src/JsOidc/JsOidc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Clients/src/MvcHybridAutomaticRefresh/MvcHybridAutomaticRefresh.csproj
+++ b/samples/Clients/src/MvcHybridAutomaticRefresh/MvcHybridAutomaticRefresh.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/KeyManagement/FileSystem/FileSystemSample.csproj
+++ b/samples/KeyManagement/FileSystem/FileSystemSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/KeyManagement/database/EF/EfSample.csproj
+++ b/samples/KeyManagement/database/EF/EfSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/KeyManagement/database/migrations/migrations.csproj
+++ b/samples/KeyManagement/database/migrations/migrations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/1_ClientCredentials/src/Api/Api.csproj
+++ b/samples/Quickstarts/1_ClientCredentials/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/1_ClientCredentials/src/Client/Client.csproj
+++ b/samples/Quickstarts/1_ClientCredentials/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/IdentityServer.csproj
+++ b/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/IdentityServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/Quickstarts/2_ResourceOwnerPasswords/src/Api/Api.csproj
+++ b/samples/Quickstarts/2_ResourceOwnerPasswords/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/2_ResourceOwnerPasswords/src/Client/Client.csproj
+++ b/samples/Quickstarts/2_ResourceOwnerPasswords/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/2_ResourceOwnerPasswords/src/IdentityServer/IdentityServer.csproj
+++ b/samples/Quickstarts/2_ResourceOwnerPasswords/src/IdentityServer/IdentityServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/Quickstarts/2_ResourceOwnerPasswords/src/ResourceOwnerClient/ResourceOwnerClient.csproj
+++ b/samples/Quickstarts/2_ResourceOwnerPasswords/src/ResourceOwnerClient/ResourceOwnerClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/samples/Quickstarts/3_ImplicitFlowAuthentication/src/Api/Api.csproj
+++ b/samples/Quickstarts/3_ImplicitFlowAuthentication/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/3_ImplicitFlowAuthentication/src/Client/Client.csproj
+++ b/samples/Quickstarts/3_ImplicitFlowAuthentication/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/3_ImplicitFlowAuthentication/src/IdentityServer/IdentityServer.csproj
+++ b/samples/Quickstarts/3_ImplicitFlowAuthentication/src/IdentityServer/IdentityServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/Quickstarts/3_ImplicitFlowAuthentication/src/MvcClient/MvcClient.csproj
+++ b/samples/Quickstarts/3_ImplicitFlowAuthentication/src/MvcClient/MvcClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/3_ImplicitFlowAuthentication/src/ResourceOwnerClient/ResourceOwnerClient.csproj
+++ b/samples/Quickstarts/3_ImplicitFlowAuthentication/src/ResourceOwnerClient/ResourceOwnerClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/Api/Api.csproj
+++ b/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/Client/Client.csproj
+++ b/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/IdentityServer/IdentityServer.csproj
+++ b/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/IdentityServer/IdentityServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/MvcClient/MvcClient.csproj
+++ b/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/MvcClient/MvcClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/ResourceOwnerClient/ResourceOwnerClient.csproj
+++ b/samples/Quickstarts/4_ImplicitFlowAuthenticationWithExternal/src/ResourceOwnerClient/ResourceOwnerClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/Api/Api.csproj
+++ b/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/Client/Client.csproj
+++ b/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/IdentityServer/IdentityServer.csproj
+++ b/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/IdentityServer/IdentityServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/MvcClient/MvcClient.csproj
+++ b/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/MvcClient/MvcClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/ResourceOwnerClient/ResourceOwnerClient.csproj
+++ b/samples/Quickstarts/5_HybridFlowAuthenticationWithApiAccess/src/ResourceOwnerClient/ResourceOwnerClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/6_JavaScriptClient/src/Api/Api.csproj
+++ b/samples/Quickstarts/6_JavaScriptClient/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/6_JavaScriptClient/src/Client/Client.csproj
+++ b/samples/Quickstarts/6_JavaScriptClient/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/6_JavaScriptClient/src/IdentityServer/IdentityServer.csproj
+++ b/samples/Quickstarts/6_JavaScriptClient/src/IdentityServer/IdentityServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/Quickstarts/6_JavaScriptClient/src/JavaScriptClient/JavaScriptClient.csproj
+++ b/samples/Quickstarts/6_JavaScriptClient/src/JavaScriptClient/JavaScriptClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/samples/Quickstarts/6_JavaScriptClient/src/MvcClient/MvcClient.csproj
+++ b/samples/Quickstarts/6_JavaScriptClient/src/MvcClient/MvcClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/6_JavaScriptClient/src/ResourceOwnerClient/ResourceOwnerClient.csproj
+++ b/samples/Quickstarts/6_JavaScriptClient/src/ResourceOwnerClient/ResourceOwnerClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/7_EntityFrameworkStorage/src/Api/Api.csproj
+++ b/samples/Quickstarts/7_EntityFrameworkStorage/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/7_EntityFrameworkStorage/src/Client/Client.csproj
+++ b/samples/Quickstarts/7_EntityFrameworkStorage/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/7_EntityFrameworkStorage/src/IdentityServer/IdentityServer.csproj
+++ b/samples/Quickstarts/7_EntityFrameworkStorage/src/IdentityServer/IdentityServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/Quickstarts/7_EntityFrameworkStorage/src/JavaScriptClient/JavaScriptClient.csproj
+++ b/samples/Quickstarts/7_EntityFrameworkStorage/src/JavaScriptClient/JavaScriptClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/samples/Quickstarts/7_EntityFrameworkStorage/src/MvcClient/MvcClient.csproj
+++ b/samples/Quickstarts/7_EntityFrameworkStorage/src/MvcClient/MvcClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/7_EntityFrameworkStorage/src/ResourceOwnerClient/ResourceOwnerClient.csproj
+++ b/samples/Quickstarts/7_EntityFrameworkStorage/src/ResourceOwnerClient/ResourceOwnerClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/8_AspNetIdentity/src/Api/Api.csproj
+++ b/samples/Quickstarts/8_AspNetIdentity/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/8_AspNetIdentity/src/Client/Client.csproj
+++ b/samples/Quickstarts/8_AspNetIdentity/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/8_AspNetIdentity/src/IdentityServerAspNetIdentity/IdentityServerAspNetIdentity.csproj
+++ b/samples/Quickstarts/8_AspNetIdentity/src/IdentityServerAspNetIdentity/IdentityServerAspNetIdentity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/8_AspNetIdentity/src/JavaScriptClient/JavaScriptClient.csproj
+++ b/samples/Quickstarts/8_AspNetIdentity/src/JavaScriptClient/JavaScriptClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/samples/Quickstarts/8_AspNetIdentity/src/MvcClient/MvcClient.csproj
+++ b/samples/Quickstarts/8_AspNetIdentity/src/MvcClient/MvcClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/8_AspNetIdentity/src/ResourceOwnerClient/ResourceOwnerClient.csproj
+++ b/samples/Quickstarts/8_AspNetIdentity/src/ResourceOwnerClient/ResourceOwnerClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/Api/Api.csproj
+++ b/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/Client/Client.csproj
+++ b/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/IdentityServer/IdentityServer.csproj
+++ b/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/IdentityServer/IdentityServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/JavaScriptClient/JavaScriptClient.csproj
+++ b/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/JavaScriptClient/JavaScriptClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/MvcClient/MvcClient.csproj
+++ b/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/MvcClient/MvcClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/ResourceOwnerClient/ResourceOwnerClient.csproj
+++ b/samples/Quickstarts/9_Combined_AspId_and_EFStorage/src/ResourceOwnerClient/ResourceOwnerClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/AspNetIdentity/build/build.csproj
+++ b/src/AspNetIdentity/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!--build related-->
-    <PackageReference Include="MinVer" Version="1.1.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="2.0.0-alpha.2" PrivateAssets="All" />
     <PackageReference Update="SimpleExec" Version="6.1.0-beta.1" />
     <PackageReference Update="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />

--- a/src/EntityFramework.Storage/build/build.csproj
+++ b/src/EntityFramework.Storage/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFramework/build/build.csproj
+++ b/src/EntityFramework/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IdentityServer4/build/build.csproj
+++ b/src/IdentityServer4/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**What issue does this PR address?**

In `master`, an extra step [was introduced](https://github.com/IdentityServer/IdentityServer4/pull/3490) to install the .NET Core 2.x SDK during the CI build. One of the reasons was that MinVer 1.x requires a .NET Core 2.x SDK to be present on the machine.

Starting with MinVer 2.0.0 (currently alpha 2), a .NET Core 2.x SDK is no longer required.

However, a number of projects in the solution (e.g. many samples) are still using `netcoreapp2.x` so it wasn't just MinVer that required a .NET Core 2.x SDK to be present. I've upgraded all remaining projects from `netcoreapp2.x` to `netcoreapp3.0`, but I'm not sure if that has any unintended consequences.

**Does this PR introduce a breaking change?**

I'm not entirely sure. The upgrade of all remaining projects from `netcoreapp2.x` to `netcoreapp3.0` would need to be examined.

**Please check if the PR fulfills these requirements**

- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- ~Unit Tests for the changes have been added (for bug fixes / features)~ - _n/a_
