### PR TITLE
use just .NET Core 3.0 SDK for CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,11 +8,6 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
   - task: UseDotNet@2
-    displayName: 'Install .NET Core 2.x SDK'
-    inputs:
-      packageType: 'sdk'
-      version: '2.x'
-  - task: UseDotNet@2
     displayName: 'Install .NET Core 3.x SDK'
     inputs:
       packageType: 'sdk'
@@ -28,11 +23,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 2.x SDK'
-    inputs:
-      packageType: 'sdk'
-      version: '2.x'
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3.x SDK'
     inputs:

--- a/src/AspNetIdentity/build/build.csproj
+++ b/src/AspNetIdentity/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!--build related-->
-    <PackageReference Include="MinVer" Version="1.1.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="2.0.0-alpha.2" PrivateAssets="All" />
     <PackageReference Update="SimpleExec" Version="6.1.0-beta.1" />
     <PackageReference Update="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />

--- a/src/EntityFramework.Storage/build/build.csproj
+++ b/src/EntityFramework.Storage/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFramework/build/build.csproj
+++ b/src/EntityFramework/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IdentityServer4/build/build.csproj
+++ b/src/IdentityServer4/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**What issue does this PR address?**

In `master`, an extra step [was introduced](https://github.com/IdentityServer/IdentityServer4/pull/3490) to install the .NET Core 2.x SDK during the CI build because MinVer 1.x requires a .NET Core 2.x SDK to be present on the machine.

Starting with MinVer 2.0.0 (currently alpha 2), a .NET Core 2.x SDK is no longer required.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**

- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- ~Unit Tests for the changes have been added (for bug fixes / features)~ - _n/a_
