### PR TITLE
update Bullseye and SimpleExec to RC1

### DIFF
--- a/src/AspNetIdentity/build/build.csproj
+++ b/src/AspNetIdentity/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
+    <PackageReference Include="Bullseye" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,8 +11,8 @@
   <ItemGroup>
     <!--build related-->
     <PackageReference Include="MinVer" Version="2.0.0-rc.1" PrivateAssets="All" />
-    <PackageReference Update="SimpleExec" Version="6.1.0-beta.1" />
-    <PackageReference Update="Bullseye" Version="3.0.0-beta.3" />
+    <PackageReference Update="SimpleExec" Version="6.1.0-rc.1" />
+    <PackageReference Update="Bullseye" Version="3.0.0-rc.1" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
 

--- a/src/EntityFramework.Storage/build/build.csproj
+++ b/src/EntityFramework.Storage/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
+    <PackageReference Include="Bullseye" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>

--- a/src/EntityFramework/build/build.csproj
+++ b/src/EntityFramework/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
+    <PackageReference Include="Bullseye" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>

--- a/src/IdentityServer4/build/build.csproj
+++ b/src/IdentityServer4/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
+    <PackageReference Include="Bullseye" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>

--- a/src/Storage/build/build.csproj
+++ b/src/Storage/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
+    <PackageReference Include="Bullseye" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="SimpleExec" />
   </ItemGroup>


### PR DESCRIPTION
**What issue does this PR address?**

Updates Bullseye from 3.0.0-beta.3 to 3.0.0-rc.1 and SimpleExec from 6.1.0-beta.1 to 6.1.0-rc.1.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)

**Other information**:

Thanks for testing the betas. 🙂 