### PR TITLE
Replace GetApis() with GetApiResources()

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -55,9 +55,9 @@ Defining an API Resource
 ^^^^^^^^^^^^^^^^^^^^^^^^
 An API is a resource in your system that you want to protect. Resource definitions can be loaded in many ways, the template you used to create the project above shows how to use a "code as configuration" approach.
 
-Open the project that we just created above in your favorite editor.  Find the `Config.cs <https://github.com/IdentityServer/IdentityServer4/blob/master/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Config.cs>`_ file you can find a method called ``GetApis``, define the API as follows::
+Open the project that we just created above in your favorite editor.  Find the `Config.cs <https://github.com/IdentityServer/IdentityServer4/blob/master/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Config.cs>`_ file you can find a method called ``GetApiResources``, define the API as follows::
 
-    public static IEnumerable<ApiResource> GetApis()
+    public static IEnumerable<ApiResource> GetApiResources()
     {
         return new List<ApiResource>
         {
@@ -118,7 +118,7 @@ Loading the resource and client definitions happens in `Startup.cs <https://gith
     {
         var builder = services.AddIdentityServer()
             .AddInMemoryIdentityResources(Config.GetIdentityResources())
-            .AddInMemoryApiResources(Config.GetApis())
+            .AddInMemoryApiResources(Config.GetApiResources())
             .AddInMemoryClients(Config.GetClients());
 
         // omitted for brevity


### PR DESCRIPTION
**What issue does this PR address?**
GetApiResources() is consistently called GetApis() in this tutorial, which is confusing in a starter guide. The second part of the tutorial also calls it as GetApiResources() which creates an error when someone follows the guide continously.

**Does this PR introduce a breaking change?**
No, it's only a change in the starter guide.

**Please check if the PR fulfills these requirements**
- ✓ The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- ✕ - Not needed - Unit Tests for the changes have been added (for bug fixes / features)