### PR TITLE
Change HttpRequest/Response extension method namespace

### DIFF
--- a/src/IdentityServer4/src/Endpoints/Results/CheckSessionResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/CheckSessionResult.cs
@@ -7,6 +7,7 @@ using IdentityServer4.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using IdentityServer4.Configuration;
+using IdentityServer4.Extensions;
 
 namespace IdentityServer4.Endpoints.Results
 {

--- a/src/IdentityServer4/src/Endpoints/Results/DeviceAuthorizationResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/DeviceAuthorizationResult.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Threading.Tasks;
+using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
 using IdentityServer4.ResponseHandling;
 using Microsoft.AspNetCore.Http;

--- a/src/IdentityServer4/src/Endpoints/Results/DiscoveryDocumentResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/DiscoveryDocumentResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
 using Microsoft.AspNetCore.Http;
 using System;

--- a/src/IdentityServer4/src/Endpoints/Results/IntrospectionResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/IntrospectionResult.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using IdentityServer4.Hosting;
 using Microsoft.AspNetCore.Http;
 using System;
+using IdentityServer4.Extensions;
 
 namespace IdentityServer4.Endpoints.Results
 {

--- a/src/IdentityServer4/src/Endpoints/Results/JsonWebKeysResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/JsonWebKeysResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
 using IdentityServer4.Models;
 using Microsoft.AspNetCore.Http;

--- a/src/IdentityServer4/src/Endpoints/Results/TokenRevocationErrorResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/TokenRevocationErrorResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
 using Microsoft.AspNetCore.Http;
 using System.Net;

--- a/src/IdentityServer4/src/Endpoints/Results/UserInfoResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/UserInfoResult.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
 using Microsoft.AspNetCore.Http;
 

--- a/src/IdentityServer4/src/Extensions/HttpRequestExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/HttpRequestExtensions.cs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using Microsoft.AspNetCore.Http;
 using System.Linq;
 
 #pragma warning disable 1591
 
-namespace Microsoft.AspNetCore.Http
+namespace IdentityServer4.Extensions
 {
     public static class HttpRequestExtensions
     {

--- a/src/IdentityServer4/src/Extensions/HttpResponseExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/HttpResponseExtensions.cs
@@ -2,17 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4;
 using IdentityServer4.Configuration;
-using IdentityServer4.Extensions;
 using IdentityServer4.Models;
+using Microsoft.AspNetCore.Http;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 #pragma warning disable 1591
 
-namespace Microsoft.AspNetCore.Http
+namespace IdentityServer4.Extensions
 {
     public static class HttpResponseExtensions
     {

--- a/src/IdentityServer4/src/Hosting/CorsPolicyProvider.cs
+++ b/src/IdentityServer4/src/Hosting/CorsPolicyProvider.cs
@@ -11,6 +11,7 @@ using IdentityServer4.Configuration;
 using IdentityServer4.Configuration.DependencyInjection;
 using IdentityServer4.Services;
 using Microsoft.Extensions.DependencyInjection;
+using IdentityServer4.Extensions;
 
 namespace IdentityServer4.Hosting
 {

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/HttpRequestExtensionsTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/HttpRequestExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 
 using FluentAssertions;
+using IdentityServer4.Extensions;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 


### PR DESCRIPTION
This is a breaking change - but see

https://github.com/IdentityServer/IdentityServer4/issues/3699