### PR TITLE
Add more comments to 'claims' parameter of GrantValidationResult constructor.

### DIFF
--- a/src/IdentityServer4/src/Validation/Models/GrantValidationResult.cs
+++ b/src/IdentityServer4/src/Validation/Models/GrantValidationResult.cs
@@ -77,7 +77,8 @@ namespace IdentityServer4.Validation
         /// <param name="subject">The subject claim used to uniquely identifier the user.</param>
         /// <param name="authenticationMethod">The authentication method which describes the custom grant type.</param>
         /// <param name="claims">Additional claims that will be maintained in the principal. 
-        /// If you want these claims to appear in token, you need to add them explicitly in your custom implementation of <see cref="Services.IProfileService"/> service.</param>
+        /// If you want these claims to appear in token, you need to add them explicitly in your custom implementation of <see cref="Services.IProfileService"/> service.
+        /// Beware as well that these claims won't present in refreshed access token because <see cref="GrantValidationResult"/> is not used in refresh_token flow.</param>
         /// <param name="identityProvider">The identity provider.</param>
         /// <param name="customResponse">The custom response.</param>
         public GrantValidationResult(
@@ -97,7 +98,8 @@ namespace IdentityServer4.Validation
         /// <param name="authenticationMethod">The authentication method which describes the custom grant type.</param>
         /// <param name="authTime">The UTC date/time of authentication.</param>
         /// <param name="claims">Additional claims that will be maintained in the principal.
-        /// If you want these claims to appear in token, you need to add them explicitly in your custom implementation of <see cref="Services.IProfileService"/> service.</param>
+        /// If you want these claims to appear in token, you need to add them explicitly in your custom implementation of <see cref="Services.IProfileService"/> service.
+        /// Beware as well that these claims won't present in refreshed access token because <see cref="GrantValidationResult"/> is not used in refresh_token flow.</param>
         /// <param name="identityProvider">The identity provider.</param>
         /// <param name="customResponse">The custom response.</param>
         public GrantValidationResult(


### PR DESCRIPTION
**What issue does this PR address?**
I still believe `claims` parameter of `GrantValidationResult` is somewhat confusing. It was yet another gotcha for me. When access token is being refreshed no `GrantValidationResult` is involved in the process, and it is the responsibility of `IProfileSevice` to retrieve all required claims.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ +] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ Not Relevant] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
This might seem to be a questionable expansion of the comments, so decide yourself whether it is worth adding it.