### PR TITLE
Add bare minimum to run on endpoint routing

### DIFF
--- a/src/IdentityServer4/host/Startup.cs
+++ b/src/IdentityServer4/host/Startup.cs
@@ -96,12 +96,13 @@ namespace Host
 
             app.UseRouting();
             app.UseMiddleware<Logging.RequestLoggerMiddleware>();
-            app.UseIdentityServer();
 
+            app.UseCors();
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapIdentityServer();
                 endpoints.MapDefaultControllerRoute();
             });
         }

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IIdentityServerBuilder AddDefaultEndpoints(this IIdentityServerBuilder builder)
         {
             builder.Services.AddTransient<IEndpointRouter, EndpointRouter>();
+            builder.Services.TryAddSingleton<IdentityServerEndpointDataSource>();
 
             builder.AddEndpoint<AuthorizeCallbackEndpoint>(EndpointNames.Authorize, ProtocolRoutePaths.AuthorizeCallback.EnsureLeadingSlash());
             builder.AddEndpoint<AuthorizeEndpoint>(EndpointNames.Authorize, ProtocolRoutePaths.Authorize.EnsureLeadingSlash());

--- a/src/IdentityServer4/src/Configuration/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/IdentityServer4/src/Configuration/IdentityServerApplicationBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns></returns>
         public static IApplicationBuilder UseIdentityServer(this IApplicationBuilder app, IdentityServerMiddlewareOptions options = null)
         {
-            app.Validate();
+            app.ApplicationServices.Validate();
 
             app.UseMiddleware<BaseUrlMiddleware>();
 
@@ -47,15 +47,15 @@ namespace Microsoft.AspNetCore.Builder
             return app;
         }
 
-        internal static void Validate(this IApplicationBuilder app)
+        internal static void Validate(this IServiceProvider provider)
         {
-            var loggerFactory = app.ApplicationServices.GetService(typeof(ILoggerFactory)) as ILoggerFactory;
+            var loggerFactory = provider.GetService(typeof(ILoggerFactory)) as ILoggerFactory;
             if (loggerFactory == null) throw new ArgumentNullException(nameof(loggerFactory));
 
             var logger = loggerFactory.CreateLogger("IdentityServer4.Startup");
             logger.LogInformation("Starting IdentityServer4 version {version}", typeof(IdentityServerApplicationBuilderExtensions).Assembly.GetName().Version.ToString());
 
-            var scopeFactory = app.ApplicationServices.GetService<IServiceScopeFactory>();
+            var scopeFactory = provider.GetService<IServiceScopeFactory>();
 
             using (var scope = scopeFactory.CreateScope())
             {

--- a/src/IdentityServer4/src/Configuration/IdentityServerEndpointDataSource.cs
+++ b/src/IdentityServer4/src/Configuration/IdentityServerEndpointDataSource.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Threading;
+using IdentityServer4.Extensions;
+using IdentityServer4.Hosting;
+using IdentityServer4.Services;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Endpoint = Microsoft.AspNetCore.Http.Endpoint;
+
+namespace IdentityServer4.Configuration
+{
+    internal class IdentityServerEndpointDataSource : EndpointDataSource
+    {
+        private readonly IdentityServerOptions _options;
+
+        private readonly RequestDelegate _requestDelegate;
+
+        private readonly IReadOnlyList<Endpoint> _endpoints;
+
+        public IdentityServerEndpointDataSource(IEnumerable<IdentityServer4.Hosting.Endpoint> endpoints, IdentityServerOptions options)
+        {
+            _options = options;
+            _requestDelegate = CreateRequestDelegate(options);
+            _endpoints = ConvertEndpoints(endpoints);
+        }
+
+        public override IReadOnlyList<Endpoint> Endpoints => _endpoints;
+
+        public override IChangeToken GetChangeToken() => new CancellationChangeToken(CancellationToken.None);
+
+        private IReadOnlyList<Endpoint> ConvertEndpoints(IEnumerable<IdentityServer4.Hosting.Endpoint> endpoints)
+        {
+            var result = new List<Endpoint>();
+
+            foreach (var endpoint in endpoints)
+            {
+                if (!_options.Endpoints.IsEndpointEnabled(endpoint))
+                {
+                    continue; // We don't even add disabled endpoints to the collection.
+                }
+
+                var pattern = RoutePatternFactory.Parse(endpoint.Path);
+
+                var builder = new RouteEndpointBuilder(_requestDelegate, pattern, order: 0) { DisplayName = endpoint.Name };
+
+                builder.Metadata.Add(new RouteNameMetadata(endpoint.Name));
+                builder.Metadata.Add(new EndpointNameMetadata(endpoint.Name));
+                builder.Metadata.Add(new IdentityServerEndpointMetadata(endpoint));
+                builder.Metadata.Add(new EnableCorsAttribute(_options.Cors.CorsPolicyName));
+
+                // TODO: Add HTTP method metadata.
+                // builder.Metadata.Add(new HttpMethodMetadata(endpoint.Methods));
+
+                result.Add(builder.Build());
+            }
+
+            return result;
+        }
+
+        private static RequestDelegate CreateRequestDelegate(IdentityServerOptions options)
+        {
+            return context =>
+            {
+                BaseUrlMiddleware.Handle(context, options);
+
+                var session = context.RequestServices.GetRequiredService<IUserSession>();
+                var events = context.RequestServices.GetRequiredService<IEventService>();
+                var logger = context.RequestServices.GetRequiredService<ILogger<IdentityServer4.Hosting.Endpoint>>();
+
+                return IdentityServerMiddleware.Handle(context, session, events, logger, null, GetHandler);
+            };
+        }
+
+        private static IEndpointHandler GetHandler(HttpContext context)
+        {
+            var endpoint = context.GetEndpoint();
+            var metadata = endpoint.Metadata.GetMetadata<IdentityServerEndpointMetadata>().Endpoint;
+            return context.RequestServices.GetService(metadata.Handler) as IEndpointHandler;
+        }
+    }
+}

--- a/src/IdentityServer4/src/Configuration/IdentityServerEndpointMetadata.cs
+++ b/src/IdentityServer4/src/Configuration/IdentityServerEndpointMetadata.cs
@@ -1,0 +1,12 @@
+namespace IdentityServer4.Configuration
+{
+    internal class IdentityServerEndpointMetadata
+    {
+        public IdentityServerEndpointMetadata(Hosting.Endpoint endpoint)
+        {
+            Endpoint = endpoint;
+        }
+
+        public Hosting.Endpoint Endpoint { get; }
+    }
+}

--- a/src/IdentityServer4/src/Configuration/IdentityServerEndpointRouteBuilderExtensions.cs
+++ b/src/IdentityServer4/src/Configuration/IdentityServerEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using IdentityServer4.Configuration;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Routing extension methods for adding IdentityServer
+    /// </summary>
+    public static class IdentityServerEndpointRouteBuilderExtensions
+    {
+        /// <summary>
+        /// Adds endpoints for IdentityServer to the <see cref="IEndpointRouteBuilder"/>.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/>.</param>
+        public static void MapIdentityServer(this IEndpointRouteBuilder endpoints)
+        {
+            endpoints.ServiceProvider.Validate();
+
+            var dataSource = endpoints.DataSources.OfType<IdentityServerEndpointDataSource>().FirstOrDefault();
+            if (dataSource is null)
+            {
+                dataSource = endpoints.ServiceProvider.GetRequiredService<IdentityServerEndpointDataSource>();
+                endpoints.DataSources.Add(dataSource);
+            }
+        }
+    }
+}

--- a/src/IdentityServer4/src/Hosting/BaseUrlMiddleware.cs
+++ b/src/IdentityServer4/src/Hosting/BaseUrlMiddleware.cs
@@ -24,16 +24,22 @@ namespace IdentityServer4.Hosting
 
         public async Task Invoke(HttpContext context)
         {
+            Handle(context, _options);
+
+            await _next(context);
+        }
+
+        internal static void Handle(HttpContext context, IdentityServerOptions options)
+        {
             var request = context.Request;
 
-            if (_options.PublicOrigin.IsPresent())
+            if (options.PublicOrigin.IsPresent())
             {
-                context.SetIdentityServerOrigin(_options.PublicOrigin);
+                context.SetIdentityServerOrigin(options.PublicOrigin);
             }
 
             context.SetIdentityServerBasePath(request.PathBase.Value.RemoveTrailingSlash());
 
-            await _next(context);
         }
     }
 }

--- a/src/IdentityServer4/src/Hosting/IdentityServerMiddleware.cs
+++ b/src/IdentityServer4/src/Hosting/IdentityServerMiddleware.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
+using IdentityServer4.Configuration;
 
 namespace IdentityServer4.Hosting
 {
@@ -38,7 +39,21 @@ namespace IdentityServer4.Hosting
         /// <param name="session">The user session.</param>
         /// <param name="events">The event service.</param>
         /// <returns></returns>
-        public async Task Invoke(HttpContext context, IEndpointRouter router, IUserSession session, IEventService events)
+        public Task Invoke(HttpContext context, IEndpointRouter router, IUserSession session, IEventService events)
+        {
+            var endpoint = context.GetEndpoint();
+            var metadata = endpoint?.Metadata.GetMetadata<IdentityServerEndpointMetadata>();
+
+            if (metadata is null)
+            {
+                // We only handle the request in the middleware if there's no IdentityServer endpoint resolved.'
+                return Handle(context, session, events, _logger, _next, router.Find);
+            }
+
+            return _next(context);
+        }
+
+        internal static async Task Handle(HttpContext context, IUserSession session, IEventService events, ILogger logger, RequestDelegate next, Func<HttpContext, IEndpointHandler> getEndpoint)
         {
             // this will check the authentication session and from it emit the check session
             // cookie needed from JS-based signout clients.
@@ -46,16 +61,17 @@ namespace IdentityServer4.Hosting
 
             try
             {
-                var endpoint = router.Find(context);
+                var endpoint = getEndpoint(context);
                 if (endpoint != null)
                 {
-                    _logger.LogInformation("Invoking IdentityServer endpoint: {endpointType} for {url}", endpoint.GetType().FullName, context.Request.Path.ToString());
+                    logger.LogInformation("Invoking IdentityServer endpoint: {endpointType} for {url}", endpoint.GetType().FullName, context.Request.Path.ToString());
 
                     var result = await endpoint.ProcessAsync(context);
 
                     if (result != null)
                     {
-                        _logger.LogTrace("Invoking result: {type}", result.GetType().FullName);
+                        logger.LogTrace("Invoking result: {type}", result.GetType().FullName);
+
                         await result.ExecuteAsync(context);
                     }
 
@@ -65,11 +81,14 @@ namespace IdentityServer4.Hosting
             catch (Exception ex)
             {
                 await events.RaiseAsync(new UnhandledExceptionEvent(ex));
-                _logger.LogCritical(ex, "Unhandled exception: {exception}", ex.Message);
+                logger.LogCritical(ex, "Unhandled exception: {exception}", ex.Message);
                 throw;
             }
 
-            await _next(context);
+            if (next != null)
+            {
+                await next.Invoke(context);
+            }
         }
     }
 }


### PR DESCRIPTION
This will allow users to use either endpoint routing (by using `MapIdentityServer`) or regular middleware (by calling `UseIdentityServer`).

I've tried to keep this free from breaking changes, but it's still missing some stuff. I guess we should determine how far we're willing to go with breaking changes and what the migration story should be.