### PR TITLE
EF Core 3.0 Performance Fix

### DIFF
--- a/src/EntityFramework.Storage/src/Stores/ClientStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/ClientStore.cs
@@ -56,18 +56,19 @@ namespace IdentityServer4.EntityFramework.Stores
                 .Take(1);
 
             var client = baseQuery.FirstOrDefault();
+            if (client == null) return Task.FromResult<Client>(null);
 
-            baseQuery.Include(x => x.AllowedGrantTypes).SelectMany(c => c.AllowedGrantTypes).Load();
-            baseQuery.Include(x => x.RedirectUris).SelectMany(c => c.RedirectUris).Load();
-            baseQuery.Include(x => x.PostLogoutRedirectUris).SelectMany(c => c.PostLogoutRedirectUris).Load();
-            baseQuery.Include(x => x.AllowedScopes).SelectMany(c => c.AllowedScopes).Load();
-            baseQuery.Include(x => x.ClientSecrets).SelectMany(c => c.ClientSecrets).Load();
-            baseQuery.Include(x => x.Claims).SelectMany(c => c.Claims).Load();
-            baseQuery.Include(x => x.IdentityProviderRestrictions).SelectMany(c => c.IdentityProviderRestrictions).Load();
             baseQuery.Include(x => x.AllowedCorsOrigins).SelectMany(c => c.AllowedCorsOrigins).Load();
+            baseQuery.Include(x => x.AllowedGrantTypes).SelectMany(c => c.AllowedGrantTypes).Load();
+            baseQuery.Include(x => x.AllowedScopes).SelectMany(c => c.AllowedScopes).Load();
+            baseQuery.Include(x => x.Claims).SelectMany(c => c.Claims).Load();
+            baseQuery.Include(x => x.ClientSecrets).SelectMany(c => c.ClientSecrets).Load();
+            baseQuery.Include(x => x.IdentityProviderRestrictions).SelectMany(c => c.IdentityProviderRestrictions).Load();
+            baseQuery.Include(x => x.PostLogoutRedirectUris).SelectMany(c => c.PostLogoutRedirectUris).Load();
             baseQuery.Include(x => x.Properties).SelectMany(c => c.Properties).Load();
+            baseQuery.Include(x => x.RedirectUris).SelectMany(c => c.RedirectUris).Load();
 
-            var model = client?.ToModel();
+            var model = client.ToModel();
 
             Logger.LogDebug("{clientId} found in database: {clientIdFound}", clientId, model != null);
 

--- a/src/EntityFramework.Storage/src/Stores/ClientStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/ClientStore.cs
@@ -51,18 +51,22 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </returns>
         public virtual Task<Client> FindClientByIdAsync(string clientId)
         {
-            var client = Context.Clients
-                .Include(x => x.AllowedGrantTypes)
-                .Include(x => x.RedirectUris)
-                .Include(x => x.PostLogoutRedirectUris)
-                .Include(x => x.AllowedScopes)
-                .Include(x => x.ClientSecrets)
-                .Include(x => x.Claims)
-                .Include(x => x.IdentityProviderRestrictions)
-                .Include(x => x.AllowedCorsOrigins)
-                .Include(x => x.Properties)
-                .AsNoTracking()
-                .FirstOrDefault(x => x.ClientId == clientId);
+            IQueryable<Entities.Client> baseQuery = Context.Clients
+                .Where(x => x.ClientId == clientId)
+                .Take(1);
+
+            var client = baseQuery.FirstOrDefault();
+
+            baseQuery.Include(x => x.AllowedGrantTypes).SelectMany(c => c.AllowedGrantTypes).Load();
+            baseQuery.Include(x => x.RedirectUris).SelectMany(c => c.RedirectUris).Load();
+            baseQuery.Include(x => x.PostLogoutRedirectUris).SelectMany(c => c.PostLogoutRedirectUris).Load();
+            baseQuery.Include(x => x.AllowedScopes).SelectMany(c => c.AllowedScopes).Load();
+            baseQuery.Include(x => x.ClientSecrets).SelectMany(c => c.ClientSecrets).Load();
+            baseQuery.Include(x => x.Claims).SelectMany(c => c.Claims).Load();
+            baseQuery.Include(x => x.IdentityProviderRestrictions).SelectMany(c => c.IdentityProviderRestrictions).Load();
+            baseQuery.Include(x => x.AllowedCorsOrigins).SelectMany(c => c.AllowedCorsOrigins).Load();
+            baseQuery.Include(x => x.Properties).SelectMany(c => c.Properties).Load();
+
             var model = client?.ToModel();
 
             Logger.LogDebug("{clientId} found in database: {clientIdFound}", clientId, model != null);

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -26,6 +27,17 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
                 {
                     context.Database.EnsureCreated();
                 }
+            }
+        }
+
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
+        public async Task FindClientByIdAsync_WhenClientDoesNotExist_ExpectNull(DbContextOptions<ConfigurationDbContext> options)
+        {
+            using (var context = new ConfigurationDbContext(options, StoreOptions))
+            {
+                var store = new ClientStore(context, FakeLogger<ClientStore>.Create());
+                var client = await store.FindClientByIdAsync(Guid.NewGuid().ToString());
+                client.Should().BeNull();
             }
         }
 

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
@@ -3,6 +3,7 @@
 
 
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.EntityFramework.Mappers;
@@ -11,6 +12,7 @@ using IdentityServer4.EntityFramework.Stores;
 using IdentityServer4.Models;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
+using Xunit.Sdk;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
 {
@@ -28,7 +30,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindClientByIdAsync_WhenClientExists_ExpectClientRetured(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindClientByIdAsync_WhenClientExists_ExpectClientRetured(DbContextOptions<ConfigurationDbContext> options)
         {
             var testClient = new Client
             {
@@ -46,14 +48,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ClientStore(context, FakeLogger<ClientStore>.Create());
-                client = store.FindClientByIdAsync(testClient.ClientId).Result;
+                client = await store.FindClientByIdAsync(testClient.ClientId);
             }
 
             Assert.NotNull(client);
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindClientByIdAsync_WhenClientExists_ExpectClientPropertiesRetured(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindClientByIdAsync_WhenClientExists_ExpectClientPropertiesRetured(DbContextOptions<ConfigurationDbContext> options)
         {
             var testClient = new Client
             {
@@ -76,7 +78,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ClientStore(context, FakeLogger<ClientStore>.Create());
-                client = store.FindClientByIdAsync(testClient.ClientId).Result;
+                client = await store.FindClientByIdAsync(testClient.ClientId);
             }
 
             client.Properties.Should().NotBeNull();
@@ -85,6 +87,64 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             client.Properties.ContainsKey("foo2").Should().BeTrue();
             client.Properties["foo1"].Should().Be("bar1");
             client.Properties["foo2"].Should().Be("bar2");
+        }
+
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
+        public async Task FindClientByIdAsync_WhenClientsExistWithManyRelations_ExpectClientReturnedInUnderFiveSeconds(DbContextOptions<ConfigurationDbContext> options)
+        {
+            var testClient = new Client
+            {
+                ClientId = "test_client_with_uris",
+                ClientName = "Test client with URIs",
+                AllowedScopes = {"openid", "profile", "api1"},
+                AllowedGrantTypes = GrantTypes.CodeAndClientCredentials
+            };
+
+            for (int i = 0; i < 50; i++)
+            {
+                testClient.RedirectUris.Add($"https://localhost/{i}");
+                testClient.PostLogoutRedirectUris.Add($"https://localhost/{i}");
+                testClient.AllowedCorsOrigins.Add($"https://localhost:{i}");
+            }
+
+            using (var context = new ConfigurationDbContext(options, StoreOptions))
+            {
+                context.Clients.Add(testClient.ToEntity());
+
+                for (int i = 0; i < 50; i++)
+                {
+                    context.Clients.Add(new Client
+                    {
+                        ClientId = testClient.ClientId + i,
+                        ClientName = testClient.ClientName,
+                        AllowedScopes = testClient.AllowedScopes,
+                        AllowedGrantTypes = testClient.AllowedGrantTypes,
+                        RedirectUris = testClient.RedirectUris,
+                        PostLogoutRedirectUris = testClient.PostLogoutRedirectUris,
+                        AllowedCorsOrigins = testClient.AllowedCorsOrigins,
+                    }.ToEntity());
+                }
+
+                context.SaveChanges();
+            }
+            
+            using (var context = new ConfigurationDbContext(options, StoreOptions))
+            {
+                var store = new ClientStore(context, FakeLogger<ClientStore>.Create());
+
+                const int timeout = 5000;
+                var task = Task.Run(() => store.FindClientByIdAsync(testClient.ClientId));
+
+                if (await Task.WhenAny(task, Task.Delay(timeout)) == task)
+                {
+                    var client = task.Result;
+                    client.Should().BeEquivalentTo(testClient);
+                }
+                else
+                {
+                    throw new TestTimeoutException(timeout);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
- Addresses performance issue in the EF implementation of `FindByClientIdAsync`, as raised by #3718
- Test duration went from 10-11 seconds to 100 milliseconds
- Other `ClientStoreTests` updated for null condition and to test all collections (not just client properties)

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)