### PR TITLE
Adding the nuget package dependency

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -160,6 +160,12 @@ Add a new class called ``IdentityController``::
 
 This controller will be used later to test the authorization requirement, as well as visualize the claims identity through the eyes of the API.
 
+Adding a Nuget Dependency
+-----------------------
+In order for the configuration step to work the nuget package dependency has to be added, run this command in the root directory.
+
+    dotnet add .\src\api\Api.csproj package Microsoft.AspNetCore.Authentication.JwtBearer
+
 Configuration
 -------------
 The last step is to add the authentication services to DI (dependency injection) and the authentication middleware to the pipeline.
@@ -199,7 +205,6 @@ Update `Startup` to look like this::
             });
         }
     }
-
 
 * ``AddAuthentication`` adds the authentication services to DI and configures ``Bearer`` as the default scheme. 
 * ``UseAuthentication`` adds the authentication middleware to the pipeline so authentication will be performed automatically on every call into the host.


### PR DESCRIPTION
Had to add the nuget package instruction, otherwise it won't work. Not sure down there is the best spot for the instruction though

**What issue does this PR address?**

A Missing instruction

**Does this PR introduce a breaking change?**

It's just text, so probably not.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

Adding instruction to enable building the tutorial.  Text should be reviewed =]
