### PR TITLE
Some backslashes needed quoting

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -164,7 +164,7 @@ Adding a Nuget Dependency
 -----------------------
 In order for the configuration step to work the nuget package dependency has to be added, run this command in the root directory.
 
-    dotnet add .\src\api\Api.csproj package Microsoft.AspNetCore.Authentication.JwtBearer
+    dotnet add .\\src\\api\\Api.csproj package Microsoft.AspNetCore.Authentication.JwtBearer
 
 Configuration
 -------------


### PR DESCRIPTION
Three backslashes needed quoting, in the current version they disappear.
Easy to spot, but might be confusing.


**Please check if the PR fulfills these requirements**
- [X ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)

