### PR TITLE
Feature: Support for (bespoke) userland csp rules

### DIFF
--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/CspOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/CspOptions.cs
@@ -17,6 +17,21 @@ namespace IdentityServer4.Configuration
         public CspLevel Level { get; set; } = CspLevel.Two;
 
         /// <summary>
+        /// Gets or sets own 'default-src' rules.
+        /// </summary>
+        public string DefaultSrc { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets own 'script-src' rules.
+        /// </summary>
+        public string ScriptSrc { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets own 'style-src' rules.
+        /// </summary>
+        public string StyleSrc { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets a value indicating whether the deprected X-Content-Security-Policy header should be added.
         /// </summary>
         public bool AddDeprecatedHeader { get; set; } = true;

--- a/src/IdentityServer4/src/Extensions/HttpResponseExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/HttpResponseExtensions.cs
@@ -87,7 +87,9 @@ namespace IdentityServer4.Extensions
         public static void AddScriptCspHeaders(this HttpResponse response, CspOptions options, string hash)
         {
             var csp1part = options.Level == CspLevel.One ? "'unsafe-inline' " : string.Empty;
-            var cspHeader = $"default-src 'none'; script-src {csp1part}'{hash}'";
+            var userDefaultSrc = string.IsNullOrEmpty(options.DefaultSrc) ? string.Empty : $" {options.DefaultSrc}";
+            var userScriptSrc = string.IsNullOrEmpty(options.ScriptSrc) ? string.Empty : $" {options.ScriptSrc}";
+            var cspHeader = $"default-src 'none'{userDefaultSrc}; script-src {csp1part}'{hash}'{userScriptSrc}";
 
             AddCspHeaders(response.Headers, options, cspHeader);
         }
@@ -95,7 +97,9 @@ namespace IdentityServer4.Extensions
         public static void AddStyleCspHeaders(this HttpResponse response, CspOptions options, string hash, string frameSources)
         {
             var csp1part = options.Level == CspLevel.One ? "'unsafe-inline' " : string.Empty;
-            var cspHeader = $"default-src 'none'; style-src {csp1part}'{hash}'";
+            var userDefaultSrc = string.IsNullOrEmpty(options.DefaultSrc) ? string.Empty : $" {options.DefaultSrc}";
+            var userStyleCsp = string.IsNullOrEmpty(options.StyleSrc) ? string.Empty : $" {options.StyleSrc}";
+            var cspHeader = $"default-src 'none'{userDefaultSrc}; style-src {csp1part}'{hash}'{userStyleCsp}";
 
             if (!string.IsNullOrEmpty(frameSources))
             {

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/HttpResponseExtensionsTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/HttpResponseExtensionsTests.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Configuration;
+using IdentityServer4.Extensions;
+using IdentityServer4.Models;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace IdentityServer4.UnitTests.Extensions
+{
+    public class HttpResponseExtensionsTests
+    {
+        [Fact]
+        public void AddScriptCspHeaders_default()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions();
+            httpResponse.AddScriptCspHeaders(
+                cspOptions,
+                "bar"
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; script-src 'bar'"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        [Fact]
+        public void AddScriptCspHeaders_with_csp_level_1()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions {Level = CspLevel.One};
+            httpResponse.AddScriptCspHeaders(
+                cspOptions,
+                "bar"
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; script-src 'unsafe-inline' 'bar'"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        [Fact]
+        public void AddScriptCspHeaders_without_deprecated_header()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions {AddDeprecatedHeader = false};
+            httpResponse.AddScriptCspHeaders(
+                cspOptions,
+                "bar"
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; script-src 'bar'"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddScriptCspHeaders_with_user_default_src()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions {DefaultSrc = "data:"};
+            httpResponse.AddScriptCspHeaders(
+                cspOptions,
+                "bar"
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none' data:; script-src 'bar'"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        [Fact]
+        public void AddScriptCspHeaders_with_user_script_src()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions {ScriptSrc = "data:"};
+            httpResponse.AddScriptCspHeaders(
+                cspOptions,
+                "bar"
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; script-src 'bar' data:"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        [Fact]
+        public void AddStyleCspHeaders_default()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions();
+            httpResponse.AddStyleCspHeaders(
+                cspOptions,
+                "bar",
+                null
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; style-src 'bar'"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        [Fact]
+        public void AddStyleCspHeaders_with_csp_level_1()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions {Level = CspLevel.One};
+            httpResponse.AddStyleCspHeaders(
+                cspOptions,
+                "bar",
+                null
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; style-src 'unsafe-inline' 'bar'"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        [Fact]
+        public void AddStyleCspHeaders_with_frame_src()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions();
+            httpResponse.AddStyleCspHeaders(
+                cspOptions,
+                "bar",
+                "baz"
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; style-src 'bar'; frame-src baz"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        [Fact]
+        public void AddStyleCspHeaders_without_deprecated_header()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions {AddDeprecatedHeader = false};
+            httpResponse.AddStyleCspHeaders(
+                cspOptions,
+                "bar",
+                null
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; style-src 'bar'"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddStyleCspHeaders_with_user_default_src()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions {DefaultSrc = "data:"};
+            httpResponse.AddStyleCspHeaders(
+                cspOptions,
+                "bar",
+                null
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none' data:; style-src 'bar'"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        [Fact]
+        public void AddStyleCspHeaders_with_user_style_src()
+        {
+            var httpResponse = new HttpResponseMock();
+
+            var cspOptions = new CspOptions {StyleSrc = "data:"};
+            httpResponse.AddStyleCspHeaders(
+                cspOptions,
+                "bar",
+                null
+            );
+
+            httpResponse.Headers["Content-Security-Policy"].Should().Contain(
+                "default-src 'none'; style-src 'bar' data:"
+            );
+            httpResponse.Headers["X-Content-Security-Policy"].Should().Contain(
+                httpResponse.Headers["Content-Security-Policy"]
+            );
+        }
+
+        class HttpResponseMock : HttpResponse
+        {
+            public override void OnCompleted(Func<object, Task> callback, object state)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void OnStarting(Func<object, Task> callback, object state)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Redirect(string location, bool permanent)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Stream Body { get; set; }
+            public override long? ContentLength { get; set; }
+            public override string ContentType { get; set; }
+            public override IResponseCookies Cookies { get; }
+            public override bool HasStarted { get; }
+            public override IHeaderDictionary Headers { get; } = new HeaderDictionary();
+            public override HttpContext HttpContext { get; }
+            public override int StatusCode { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
It allows configuration of userland CSP rules (e.g. `data:`)

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes/features)

**Other Information**:
This PR introduces the following configuration options:
```cs
AddIdentityServer(options =>
{
    options.Csp.DefaultSrc = "; font-src data:"; // add rules "default-src 'none'; font-src data:; style-src ..."
    options.Csp.ScriptSrc= "data:"; // add rules "default-src 'none'; script-src ... data:"
    options.Csp.StyleSrc= "data:"; // add rules "default-src 'none'; style-src ... data:"
});
```
which allows whitelisting e.g. a bit malfunction browser extensions which can't operate with CSP well, and in development environment produces a lot of mess in browser log.