### PR TITLE
Cache the CheckSessionResult Script string

### DIFF
--- a/src/IdentityServer4/src/Endpoints/Results/CheckSessionResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/CheckSessionResult.cs
@@ -23,6 +23,9 @@ namespace IdentityServer4.Endpoints.Results
         }
 
         private IdentityServerOptions _options;
+        private static volatile string FormattedHtml;
+        private static readonly object Lock = new object();
+        private static volatile string LastCheckSessionCookieName;
 
         private void Init(HttpContext context)
         {
@@ -45,7 +48,18 @@ namespace IdentityServer4.Endpoints.Results
         }
         private string GetHtml(string cookieName)
         {
-            return Html.Replace("{cookieName}", cookieName);
+            if (cookieName != LastCheckSessionCookieName)
+            {
+                lock (Lock)
+                {
+                    if (cookieName != LastCheckSessionCookieName)
+                    {
+                        FormattedHtml = Html.Replace("{cookieName}", cookieName);
+                        LastCheckSessionCookieName = cookieName;
+                    }
+                }
+            }
+            return FormattedHtml;
         }
 
         private const string Html = @"

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
@@ -74,5 +74,21 @@ namespace IdentityServer4.UnitTests.Endpoints.Results
             _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("script-src 'sha256-ZT3q7lL9GXNGhPTB1Vvrvds2xw/kOV0zoeok2tiV23I='");
             _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();
         }
+
+        [Theory]
+        [InlineData("foobar")]
+        [InlineData("morefoobar")]
+
+        public async Task can_change_cached_cookiename(string cookieName)
+        {
+            _options.Authentication.CheckSessionCookieName = cookieName;
+            await _subject.ExecuteAsync(_context);
+            _context.Response.Body.Seek(0, SeekOrigin.Begin);
+            using (var rdr = new StreamReader(_context.Response.Body))
+            {
+                var html = rdr.ReadToEnd();
+                html.Should().Contain($"<script id='cookie-name' type='application/json'>{cookieName}</script>");
+            }
+        }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Reduces the allocations in CheckSessionResult by chaching the formatted string.
The script string shows up consistently as the largest string (~11k chars, 24k bytes) in my memorydumps, because the cookieName is replaced for each CheckSessionResult again.
I don't think that the cookieName is changed that often during runtime (if at all), so I cache the formatted string in a variable with checks via double locking.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
