### PR TITLE
make TokenCleanupInterval more realistic

### DIFF
--- a/docs/reference/ef.rst
+++ b/docs/reference/ef.rst
@@ -80,7 +80,7 @@ To use the operational store support, use the ``AddOperationalStore`` extension 
 
                 // this enables automatic token cleanup. this is optional.
                 options.EnableTokenCleanup = true;
-                options.TokenCleanupInterval = 30; // interval in seconds
+                options.TokenCleanupInterval = 3600; // interval in seconds (default is 3600)
             });
     }
 


### PR DESCRIPTION
TokenCleanupInterval of 30 seconds seams a bit extreme to me.  Wouldn't it be better to show the default of 3600 and let them decide if they want to set it down from there?

**What issue does this PR address?**

None being lazy with documentation

**Does this PR introduce a breaking change?**

none 


**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
