### PR TITLE
Remove outdated project from Community Docs

### DIFF
--- a/docs/quickstarts/community.rst
+++ b/docs/quickstarts/community.rst
@@ -31,11 +31,6 @@ Exchanging external tokens from Facebook, Google and Twitter
 
 https://github.com/waqaskhan540/IdentityServerExternalAuth
 
-ASP.NET Core MVC RazorPages template for IdentityServer4 Quickstart UI
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-`Razor Pages based QuickStart sample <https://github.com/IdentityServer4Contrib/IdentityServer4.Contrib.Templates.RazorPages>`_ by `Martin Fletcher <https://github.com/martinfletcher>`_.
-
 
 .NET Core and ASP.NET Core "Platform" scenario
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
**What issue does this PR address?**
Razor pages community project has no content and is no longer active.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
