### PR TITLE
Session Cookies need to be LAX

### DIFF
--- a/src/IdentityServer4/src/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
@@ -31,7 +31,7 @@ namespace IdentityServer4.Configuration
                 options.ExpireTimeSpan = _idsrv.Authentication.CookieLifetime;
                 options.Cookie.Name = IdentityServerConstants.DefaultCookieAuthenticationScheme;
                 options.Cookie.IsEssential = true;
-                options.Cookie.SameSite = SameSiteMode.None;
+                options.Cookie.SameSite = SameSiteMode.Lax;
 
                 options.LoginPath = ExtractLocalUrl(_idsrv.UserInteraction.LoginUrl);
                 options.LogoutPath = ExtractLocalUrl(_idsrv.UserInteraction.LogoutUrl);

--- a/src/IdentityServer4/src/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultUserSession.cs
@@ -260,7 +260,7 @@ namespace IdentityServer4.Services
                 Secure = secure,
                 Path = path,
                 IsEssential = true,
-                SameSite = SameSiteMode.None
+                SameSite = SameSiteMode.Lax
             };
 
             return options;


### PR DESCRIPTION
Cookies are not being saved on a redirect, an easy way to see this is in postman.

To replicate problem get latest code and run this in the database first (IdentityServer4-master\samples\Quickstarts\4_EntityFramework)

INSERT [dbo].[ClientRedirectUris] ([RedirectUri], [ClientId]) VALUES (N'http://localhost:5002/', 1)
INSERT [dbo].[ClientGrantTypes] ([GrantType], [ClientId]) VALUES (N'authorization_code', 1)
INSERT [dbo].[ClientScopes] ([Scope], [ClientId]) VALUES (N'profile', 1)
INSERT [dbo].[ClientScopes] ([Scope], [ClientId]) VALUES (N'openid', 1)
update [Clients] set [AllowOfflineAccess] = 1 where [Id] = 1

Within postman
1) Create a new request
2) Click the Authorization tab
3) Change type to 'OAuth 2.0'
4) Click 'Get New Access Token'
5) Complete as follows
Call back URL: http://localhost:5002/
Auth URL: http://localhost:5000/connect/authorize
Access Token URL: http://localhost:5000/connect/token
Client ID: client
Client Secret: secret
Scope: api1 openid profile offline_access
State: <leave blank>

6) Then press 'Request Token'
7) Enter 'bob' & 'bob' without this change the page will simply reload and do nothing, if the cookies are changed it will work correctly.

Does not introduce breaking change as far as I can tell.