### PR TITLE
Fix the name of logout context class in sign-out doc

### DIFF
--- a/docs/topics/signout.rst
+++ b/docs/topics/signout.rst
@@ -53,7 +53,7 @@ Processing at the end session endpoint might require some temporary state to be 
 This state might be of use to the logout page, and the identifier for the state is passed via a `logoutId` parameter to the logout page.
 
 The ``GetLogoutContextAsync`` API on the :ref:`interaction service <refInteractionService>` can be used to load the state.
-Of interest on the ``ShowSignoutPrompt`` is the ``ShowSignoutPrompt`` which indicates if the request for sign-out has been authenticated, and therefore it's safe to not prompt the user for sign-out.
+Of interest on the ``LogoutRequest`` model context class is the ``ShowSignoutPrompt`` which indicates if the request for sign-out has been authenticated, and therefore it's safe to not prompt the user for sign-out.
 
 By default this state is managed as a protected data structure passed via the `logoutId` value.
 If you wish to use some other persistence between the end session endpoint and the logout page, then you can implement ``IMessageStore<LogoutMessage>`` and register the implementation in DI.


### PR DESCRIPTION
**What issue does this PR address?**
A small issue in documentation.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
