### PR TITLE
Make cnf part of Token model

### DIFF
--- a/src/IdentityServer4/host/Host.Local.csproj
+++ b/src/IdentityServer4/host/Host.Local.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" />
+    
     <ProjectReference Include="..\src\IdentityServer4.Local.csproj" />
   </ItemGroup>
 </Project>

--- a/src/IdentityServer4/src/Services/Default/DefaultClaimsService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultClaimsService.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 
 namespace IdentityServer4.Services
 {
@@ -31,21 +30,14 @@ namespace IdentityServer4.Services
         protected readonly IProfileService Profile;
 
         /// <summary>
-        /// The HTTP context accessor
-        /// </summary>
-        protected readonly IHttpContextAccessor ContextAccessor;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="DefaultClaimsService"/> class.
         /// </summary>
         /// <param name="profile">The profile service</param>
-        /// <param name="contextAccessor">The HTTP context accessor</param>
         /// <param name="logger">The logger</param>
-        public DefaultClaimsService(IProfileService profile, IHttpContextAccessor contextAccessor, ILogger<DefaultClaimsService> logger)
+        public DefaultClaimsService(IProfileService profile, ILogger<DefaultClaimsService> logger)
         {
             Logger = logger;
             Profile = profile;
-            ContextAccessor = contextAccessor;
         }
 
         /// <summary>
@@ -133,23 +125,6 @@ namespace IdentityServer4.Services
                 Logger.LogDebug("Client {clientId} is impersonating {impersonatedClientId}", request.Client.ClientId, request.ClientId);
             }
 
-            // add cnf if present
-            if (request.Confirmation.IsPresent())
-            {
-                outputClaims.Add(new Claim(JwtClaimTypes.Confirmation, request.Confirmation, IdentityServerConstants.ClaimValueTypes.Json));
-            }
-            else
-            {
-                if (request.Options.MutualTls.AlwaysEmitConfirmationClaim)
-                {
-                    var clientCertificate = await ContextAccessor.HttpContext.Connection.GetClientCertificateAsync();
-                    if (clientCertificate != null)
-                    {
-                        outputClaims.Add(new Claim(JwtClaimTypes.Confirmation, clientCertificate.CreateThumbprintCnf(), IdentityServerConstants.ClaimValueTypes.Json));
-                    }
-                }
-            }
-
             // check for client claims
             if (request.ClientClaims != null && request.ClientClaims.Any())
             {
@@ -168,7 +143,7 @@ namespace IdentityServer4.Services
                     }
                 }
             }
-
+            
             // add scopes
             foreach (var scope in resources.IdentityResources)
             {

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
@@ -51,7 +51,7 @@ namespace IdentityServer.UnitTests.Services.Default
                 }
             }.CreatePrincipal();
 
-            _subject = new DefaultClaimsService(_mockMockProfileService, new HttpContextAccessor(), TestLogger.Create<DefaultClaimsService>());
+            _subject = new DefaultClaimsService(_mockMockProfileService, TestLogger.Create<DefaultClaimsService>());
 
             _validatedRequest = new ValidatedRequest();
             _validatedRequest.Options = new IdentityServerOptions();

--- a/src/Storage/src/Models/Token.cs
+++ b/src/Storage/src/Models/Token.cs
@@ -37,6 +37,11 @@ namespace IdentityServer4.Models
         public ICollection<string> AllowedSigningAlgorithms { get; set; } = new HashSet<string>();
 
         /// <summary>
+        /// Specifies the confirmation method of the token. This value, if set, will become the cnf claim.
+        /// </summary>
+        public string Confirmation { get; set; }
+
+        /// <summary>
         /// Gets or sets the audiences.
         /// </summary>
         /// <value>


### PR DESCRIPTION
Confirmation method is integral part of token - so it belongs to token model.