### PR TITLE
Updated cache expiration to use current time

### DIFF
--- a/src/IdentityServer4/src/Services/Default/DistributedDeviceFlowThrottlingService.cs
+++ b/src/IdentityServer4/src/Services/Default/DistributedDeviceFlowThrottlingService.cs
@@ -51,7 +51,7 @@ namespace IdentityServer4.Services
             if (deviceCode == null) throw new ArgumentNullException(nameof(deviceCode));
             
             var key = _keyPrefix + deviceCode;
-            var options = new DistributedCacheEntryOptions {AbsoluteExpiration = details.CreationTime.AddSeconds(details.Lifetime)};
+            var options = new DistributedCacheEntryOptions {AbsoluteExpiration = _clock.UtcNow.AddSeconds(details.Lifetime)};
 
             var lastSeenAsString = await _cache.GetStringAsync(key);
 


### PR DESCRIPTION
**What issue does this PR address?**
Addresses race condition reported in #3860

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)