### PR TITLE
Update calling token endpoint example.

### DIFF
--- a/docs/topics/extension_grants.rst
+++ b/docs/topics/extension_grants.rst
@@ -126,16 +126,25 @@ In API 1 you can now construct the HTTP payload yourself, or use the *IdentityMo
 
     public async Task<TokenResponse> DelegateAsync(string userToken)
     {
-        var payload = new
-        {
-            token = userToken
-        };
-
-        // create token client
-        var client = new TokenClient(disco.TokenEndpoint, "api1.client", "secret");
+        var client = _httpClientFactory.CreateClient();
+        // or 
+        // var client = new HttpClient();
 
         // send custom grant to token endpoint, return response
-        return await client.RequestCustomGrantAsync("delegation", "api2", payload);
+        return await client.RequestTokenAsync(new TokenRequest
+        {
+            Address = disco.TokenEndpoint,
+            GrantType = "delegation",
+
+            ClientId = "api1.client",
+            ClientSecret = "secret",
+
+            Parameters =
+            {
+                { "scope", "api2" },
+                { "token", userToken}
+            }                
+        });
     }
 
 The ``TokenResponse.AccessToken`` will now contain the delegation access token.


### PR DESCRIPTION
IdentityModel library no longer exposes RequestCustomGrantAsync.

**What issue does this PR address?**
Fixes an example in documentation. Complies with current API.

**Does this PR introduce a breaking change?**
Does not. This is a fix to user documentation.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
