### PR TITLE
Quickstart.UI native client detection heuristic based on client's redirect uri

### DIFF
--- a/src/IdentityServer4/host/Quickstart/Account/AccountController.cs
+++ b/src/IdentityServer4/host/Quickstart/Account/AccountController.cs
@@ -90,9 +90,9 @@ namespace IdentityServer4.Quickstart.UI
                     await _interaction.GrantConsentAsync(context, ConsentResponse.Denied);
 
                     // we can trust model.ReturnUrl since GetAuthorizationContextAsync returned non-null
-                    if (await _clientStore.IsPkceClientAsync(context.ClientId))
+                    if (context.IsNativeClient())
                     {
-                        // if the client is PKCE then we assume it's native, so this change in how to
+                        // The client is native, so this change in how to
                         // return the response is for better UX for the end user.
                         //return View("Redirect", new RedirectViewModel { RedirectUrl = model.ReturnUrl });
 
@@ -138,9 +138,9 @@ namespace IdentityServer4.Quickstart.UI
 
                     if (context != null)
                     {
-                        if (await _clientStore.IsPkceClientAsync(context.ClientId))
+                        if (context.IsNativeClient())
                         {
-                            // if the client is PKCE then we assume it's native, so this change in how to
+                            // The client is native, so this change in how to
                             // return the response is for better UX for the end user.
                             //return View("Redirect", new RedirectViewModel { RedirectUrl = model.ReturnUrl });
                             return this.LoadingPage("Redirect", model.ReturnUrl);

--- a/src/IdentityServer4/host/Quickstart/Account/ExternalController.cs
+++ b/src/IdentityServer4/host/Quickstart/Account/ExternalController.cs
@@ -141,9 +141,9 @@ namespace IdentityServer4.Quickstart.UI
 
             if (context != null)
             {
-                if (await _clientStore.IsPkceClientAsync(context.ClientId))
+                if (context.IsNativeClient())
                 {
-                    // if the client is PKCE then we assume it's native, so this change in how to
+                    // The client is native, so this change in how to
                     // return the response is for better UX for the end user.
                     return this.LoadingPage("Redirect", returnUrl);
                 }

--- a/src/IdentityServer4/host/Quickstart/Consent/ConsentController.cs
+++ b/src/IdentityServer4/host/Quickstart/Consent/ConsentController.cs
@@ -70,9 +70,10 @@ namespace IdentityServer4.Quickstart.UI
 
             if (result.IsRedirect)
             {
-                if (await _clientStore.IsPkceClientAsync(result.ClientId))
+                var context = await _interaction.GetAuthorizationContextAsync(model.ReturnUrl);
+                if (context?.IsNativeClient() == true)
                 {
-                    // if the client is PKCE then we assume it's native, so this change in how to
+                    // The client is native, so this change in how to
                     // return the response is for better UX for the end user.
                     return this.LoadingPage("Redirect", result.RedirectUri);
                 }

--- a/src/IdentityServer4/host/Quickstart/Extensions.cs
+++ b/src/IdentityServer4/host/Quickstart/Extensions.cs
@@ -1,34 +1,23 @@
-using System.Threading.Tasks;
-using IdentityServer4.Stores;
+using System;
+using IdentityServer4.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace IdentityServer4.Quickstart.UI
 {
     public static class Extensions
     {
-        /// <summary>
-        /// Determines whether the client is configured to use PKCE.
-        /// </summary>
-        /// <param name="store">The store.</param>
-        /// <param name="client_id">The client identifier.</param>
-        /// <returns></returns>
-        public static async Task<bool> IsPkceClientAsync(this IClientStore store, string client_id)
-        {
-            if (!string.IsNullOrWhiteSpace(client_id))
-            {
-                var client = await store.FindEnabledClientByIdAsync(client_id);
-                return client?.RequirePkce == true;
-            }
-
-            return false;
-        }
-
         public static IActionResult LoadingPage(this Controller controller, string viewName, string redirectUri)
         {
             controller.HttpContext.Response.StatusCode = 200;
             controller.HttpContext.Response.Headers["Location"] = "";
             
             return controller.View(viewName, new RedirectViewModel { RedirectUrl = redirectUri });
+        }
+
+        public static bool IsNativeClient(this AuthorizationRequest context)
+        {
+            return !context.RedirectUri.StartsWith("https", StringComparison.Ordinal)
+                && !context.RedirectUri.StartsWith("http", StringComparison.Ordinal);
         }
     }
 }


### PR DESCRIPTION
Redirection to a native client uses a loading page instead of an http
redirect. Previously, determination of the type of the client was based on
whether it used PKCE. This PR changes it to be based on the redirect uri. If it
has http or https scheme, an http redirect is used. Otherwise, we assume it's
a native client and use a loading page. This is based on the fact that a
native client should use a private-use uri scheme.

**What issue does this PR address?**
Fixes #3997 

**Does this PR introduce a breaking change?**
Not in IdentityServer itself.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
