### PR TITLE
Update child property loading

### DIFF
--- a/src/EntityFramework.Storage/src/DbContexts/ConfigurationDbContext.cs
+++ b/src/EntityFramework.Storage/src/DbContexts/ConfigurationDbContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 using System;
 using System.Threading.Tasks;
 using IdentityServer4.EntityFramework.Entities;
@@ -9,6 +8,7 @@ using IdentityServer4.EntityFramework.Extensions;
 using IdentityServer4.EntityFramework.Interfaces;
 using IdentityServer4.EntityFramework.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace IdentityServer4.EntityFramework.DbContexts
 {
@@ -60,6 +60,7 @@ namespace IdentityServer4.EntityFramework.DbContexts
         /// The clients.
         /// </value>
         public DbSet<Client> Clients { get; set; }
+
         /// <summary>
         /// Gets or sets the identity resources.
         /// </summary>
@@ -67,6 +68,7 @@ namespace IdentityServer4.EntityFramework.DbContexts
         /// The identity resources.
         /// </value>
         public DbSet<IdentityResource> IdentityResources { get; set; }
+
         /// <summary>
         /// Gets or sets the API resources.
         /// </summary>
@@ -74,6 +76,18 @@ namespace IdentityServer4.EntityFramework.DbContexts
         /// The API resources.
         /// </value>
         public DbSet<ApiResource> ApiResources { get; set; }
+
+        /// <summary>
+        ///     Gets an <see cref="T:Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry`1" /> for the given entity. The entry provides
+        ///     access to change tracking information and operations for the entity.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of the entity. </typeparam>
+        /// <param name="entity"> The entity to get the entry for. </param>
+        /// <returns> The entry for the given entity. </returns>
+        public EntityEntry Entry<TEntity>(TEntity entity) where TEntity : class
+        {
+            return base.Entry<TEntity>(entity);
+        }
 
         /// <summary>
         /// Saves the changes.

--- a/src/EntityFramework.Storage/src/Interfaces/IConfigurationDbContext.cs
+++ b/src/EntityFramework.Storage/src/Interfaces/IConfigurationDbContext.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 using System;
 using System.Threading.Tasks;
 using IdentityServer4.EntityFramework.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace IdentityServer4.EntityFramework.Interfaces
 {
@@ -22,7 +22,7 @@ namespace IdentityServer4.EntityFramework.Interfaces
         /// The clients.
         /// </value>
         DbSet<Client> Clients { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the identity resources.
         /// </summary>
@@ -30,7 +30,7 @@ namespace IdentityServer4.EntityFramework.Interfaces
         /// The identity resources.
         /// </value>
         DbSet<IdentityResource> IdentityResources { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the API resources.
         /// </summary>
@@ -44,11 +44,20 @@ namespace IdentityServer4.EntityFramework.Interfaces
         /// </summary>
         /// <returns></returns>
         int SaveChanges();
-        
+
         /// <summary>
         /// Saves the changes.
         /// </summary>
         /// <returns></returns>
         Task<int> SaveChangesAsync();
+
+        /// <summary>
+        ///     Gets an <see cref="T:Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry`1" /> for the given entity. The entry provides
+        ///     access to change tracking information and operations for the entity.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of the entity. </typeparam>
+        /// <param name="entity"> The entity to get the entry for. </param>
+        /// <returns> The entry for the given entity. </returns>
+        EntityEntry Entry<TEntity>(TEntity entity) where TEntity : class;
     }
 }

--- a/src/EntityFramework.Storage/src/Stores/ClientStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/ClientStore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -51,27 +50,30 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </returns>
         public virtual async Task<Client> FindClientByIdAsync(string clientId)
         {
-            IQueryable<Entities.Client> baseQuery = Context.Clients
-                .Where(x => x.ClientId == clientId)
-                .Take(1);
+            var exists = await Context.Clients
+                .CountAsync(x => x.ClientId == clientId);
+
+            if (exists != 1) return null;
+
+            var baseQuery = Context.Clients.AsTracking()
+                .Where(x => x.ClientId == clientId);
 
             var client = await baseQuery.FirstOrDefaultAsync();
+
             if (client == null) return null;
 
-            await baseQuery.Include(x => x.AllowedCorsOrigins).SelectMany(c => c.AllowedCorsOrigins).LoadAsync();
-            await baseQuery.Include(x => x.AllowedGrantTypes).SelectMany(c => c.AllowedGrantTypes).LoadAsync();
-            await baseQuery.Include(x => x.AllowedScopes).SelectMany(c => c.AllowedScopes).LoadAsync();
-            await baseQuery.Include(x => x.Claims).SelectMany(c => c.Claims).LoadAsync();
-            await baseQuery.Include(x => x.ClientSecrets).SelectMany(c => c.ClientSecrets).LoadAsync();
-            await baseQuery.Include(x => x.IdentityProviderRestrictions).SelectMany(c => c.IdentityProviderRestrictions).LoadAsync();
-            await baseQuery.Include(x => x.PostLogoutRedirectUris).SelectMany(c => c.PostLogoutRedirectUris).LoadAsync();
-            await baseQuery.Include(x => x.Properties).SelectMany(c => c.Properties).LoadAsync();
-            await baseQuery.Include(x => x.RedirectUris).SelectMany(c => c.RedirectUris).LoadAsync();
+            await Context.Entry(client).Collection("AllowedCorsOrigins").LoadAsync();
+            await Context.Entry(client).Collection("AllowedGrantTypes").LoadAsync();
+            await Context.Entry(client).Collection("AllowedScopes").LoadAsync();
+            await Context.Entry(client).Collection("Claims").LoadAsync();
+            await Context.Entry(client).Collection("ClientSecrets").LoadAsync();
+            await Context.Entry(client).Collection("IdentityProviderRestrictions").LoadAsync();
+            await Context.Entry(client).Collection("PostLogoutRedirectUris").LoadAsync();
+            await Context.Entry(client).Collection("Properties").LoadAsync();
+            await Context.Entry(client).Collection("RedirectUris").LoadAsync();
 
             var model = client.ToModel();
-
             Logger.LogDebug("{clientId} found in database: {clientIdFound}", clientId, model != null);
-
             return model;
         }
     }


### PR DESCRIPTION
**What issue does this PR address?**
When using PostgreSQL provider for entity framework, none of the child properties will get loaded using the previous Include extension. Following the instructions in https://docs.microsoft.com/en-us/ef/core/querying/related-data#explicit-loading , explicitly defining the entry as Tracking and then loading the collection individually avoids a large JOIN query and satisfies the needs of this method in terms of data and performance

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
No changes were made that warranted a test.