### PR TITLE
Fix logger category name for BackChannelLogoutHttpClient

### DIFF
--- a/src/IdentityServer4/src/Services/Default/BackChannelLogoutHttpClient.cs
+++ b/src/IdentityServer4/src/Services/Default/BackChannelLogoutHttpClient.cs
@@ -16,14 +16,14 @@ namespace IdentityServer4.Services
     public class BackChannelLogoutHttpClient
     {
         private readonly HttpClient _client;
-        private readonly ILogger<JwtRequestUriHttpClient> _logger;
+        private readonly ILogger<BackChannelLogoutHttpClient> _logger;
 
         /// <summary>
         /// Constructor for BackChannelLogoutHttpClient.
         /// </summary>
         /// <param name="client"></param>
         /// <param name="logger"></param>
-        public BackChannelLogoutHttpClient(HttpClient client, ILogger<JwtRequestUriHttpClient> logger)
+        public BackChannelLogoutHttpClient(HttpClient client, ILogger<BackChannelLogoutHttpClient> logger)
         {
             _client = client;
             _logger = logger;


### PR DESCRIPTION
**What issue does this PR address?**
Logging category name mistake.

**Does this PR introduce a breaking change?**
No impact other than changing logging category name.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
