### PR TITLE
Check for existing email claim

### DIFF
--- a/src/AspNetIdentity/src/UserClaimsFactory.cs
+++ b/src/AspNetIdentity/src/UserClaimsFactory.cs
@@ -47,7 +47,7 @@ namespace IdentityServer4.AspNetIdentity
                 identity.AddClaim(new Claim(JwtClaimTypes.Name, username));
             }
 
-            if (_userManager.SupportsUserEmail)
+            if (_userManager.SupportsUserEmail && !identity.HasClaim(x => x.Type == JwtClaimTypes.Email))
             {
                 var email = await _userManager.GetEmailAsync(user);
                 if (!String.IsNullOrWhiteSpace(email))


### PR DESCRIPTION
Checks for an already existing "email" claim in the ClaimPrincipal before adding a new second.
This PR suppresses the duplicated email claim in the token.

Fixes #4138

