### PR TITLE
Correct launchSettings.json link to point to API project

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -139,7 +139,7 @@ Then add it to the solution by running the following commands::
     cd ..
     dotnet sln add .\src\Api\Api.csproj
 
-Configure the API application to run on ``http://localhost:5001`` only. You can do this by editing the `launchSettings.json <https://github.com/IdentityServer/IdentityServer4/blob/master/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Properties/launchSettings.json>`_ file inside the Properties folder. Change the application URL setting to be::
+Configure the API application to run on ``http://localhost:5001`` only. You can do this by editing the `launchSettings.json <https://github.com/IdentityServer/IdentityServer4/blob/master/samples/Quickstarts/1_ClientCredentials/src/Api/Properties/launchSettings.json>`_ file inside the Properties folder. Change the application URL setting to be::
 
     "applicationUrl": "http://localhost:5001"
 


### PR DESCRIPTION
The link to view the code for launchSettings.json points to the file in the IdentityServer project - but should be referring to file in the API project instead.

**What issue does this PR address?**
Minor issue in the docs


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ Yes ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ No - docs change only ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
None