### PR TITLE
switch to named HTTP clients from factory (instead of typed)

### DIFF
--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -10,6 +10,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http;
 using System;
 using System.Net.Http;
+using IdentityServer4;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -332,7 +334,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IHttpClientBuilder AddBackChannelLogoutHttpClient(this IIdentityServerBuilder builder, Action<HttpClient> configureClient = null)
         {
-            var name = typeof(BackChannelLogoutHttpClient).Name;
+            const string name = IdentityServerConstants.HttpClients.BackChannelLogoutHttpClient;
             IHttpClientBuilder httpBuilder;
 
             if (configureClient != null)
@@ -344,13 +346,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 httpBuilder = builder.Services.AddHttpClient(name);
             }
 
-            httpBuilder.Services.AddTransient<BackChannelLogoutHttpClient>(s =>
+            builder.Services.AddTransient<BackChannelLogoutHttpClient>(s =>
             {
                 var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
                 var httpClient = httpClientFactory.CreateClient(name);
-
-                var typedClientFactory = s.GetRequiredService<ITypedHttpClientFactory<BackChannelLogoutHttpClient>>();
-                return typedClientFactory.CreateClient(httpClient);
+                var loggerFactory = s.GetRequiredService<ILoggerFactory>();
+                
+                return new BackChannelLogoutHttpClient(httpClient, loggerFactory);
             });
 
             return httpBuilder;
@@ -366,7 +368,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IHttpClientBuilder AddJwtRequestUriHttpClient(this IIdentityServerBuilder builder, Action<HttpClient> configureClient = null)
         {
-            var name = typeof(JwtRequestUriHttpClient).Name;
+            const string name = IdentityServerConstants.HttpClients.JwtRequestUriHttpClient;
             IHttpClientBuilder httpBuilder;
 
             if (configureClient != null)
@@ -377,14 +379,14 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 httpBuilder = builder.Services.AddHttpClient(name);
             }
-
-            httpBuilder.Services.AddTransient<JwtRequestUriHttpClient>(s =>
+            
+            builder.Services.AddTransient<JwtRequestUriHttpClient>(s =>
             {
                 var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
                 var httpClient = httpClientFactory.CreateClient(name);
+                var loggerFactory = s.GetRequiredService<ILoggerFactory>();
 
-                var typedClientFactory = s.GetRequiredService<ITypedHttpClientFactory<JwtRequestUriHttpClient>>();
-                return typedClientFactory.CreateClient(httpClient);
+                return new JwtRequestUriHttpClient(httpClient, loggerFactory);
             });
 
             return httpBuilder;

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -175,8 +175,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.AddJwtRequestUriHttpClient();
             builder.AddBackChannelLogoutHttpClient();
-            //builder.Services.AddHttpClient<BackChannelLogoutHttpClient>();
-            //builder.Services.AddHttpClient<JwtRequestUriHttpClient>();
 
             builder.Services.AddTransient<IClientSecretValidator, ClientSecretValidator>();
             builder.Services.AddTransient<IApiSecretValidator, ApiSecretValidator>();

--- a/src/IdentityServer4/src/IdentityServerConstants.cs
+++ b/src/IdentityServer4/src/IdentityServerConstants.cs
@@ -158,5 +158,11 @@ namespace IdentityServer4
         {
             public const string Numeric = "Numeric";
         }
+
+        public static class HttpClients
+        {
+            public const string JwtRequestUriHttpClient = "IdentityServer:JwtRequestUriClient";
+            public const string BackChannelLogoutHttpClient = "IdentityServer:BackChannelLogoutClient";
+        }
     }
 }

--- a/src/IdentityServer4/src/Services/Default/BackChannelLogoutHttpClient.cs
+++ b/src/IdentityServer4/src/Services/Default/BackChannelLogoutHttpClient.cs
@@ -22,11 +22,11 @@ namespace IdentityServer4.Services
         /// Constructor for BackChannelLogoutHttpClient.
         /// </summary>
         /// <param name="client"></param>
-        /// <param name="logger"></param>
-        public BackChannelLogoutHttpClient(HttpClient client, ILogger<BackChannelLogoutHttpClient> logger)
+        /// <param name="loggerFactory"></param>
+        public BackChannelLogoutHttpClient(HttpClient client, ILoggerFactory loggerFactory)
         {
             _client = client;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger<BackChannelLogoutHttpClient>();
         }
 
         /// <summary>

--- a/src/IdentityServer4/src/Services/Default/JwtRequestUriHttpClient.cs
+++ b/src/IdentityServer4/src/Services/Default/JwtRequestUriHttpClient.cs
@@ -21,11 +21,11 @@ namespace IdentityServer4.Services
         /// Constructor for DefaultJwtRequestUriHttpClient.
         /// </summary>
         /// <param name="client"></param>
-        /// <param name="logger"></param>
-        public JwtRequestUriHttpClient(HttpClient client, ILogger<JwtRequestUriHttpClient> logger)
+        /// <param name="loggerFactory"></param>
+        public JwtRequestUriHttpClient(HttpClient client, ILoggerFactory loggerFactory)
         {
             _client = client;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger<JwtRequestUriHttpClient>();
         }
 
         /// <summary>

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -205,7 +205,7 @@ namespace IdentityServer.UnitTests.Validation.Setup
 
             if (jwtRequestUriHttpClient == null)
             {
-                jwtRequestUriHttpClient = new JwtRequestUriHttpClient(new HttpClient(new NetworkHandler(new Exception("no jwt request uri response configured"))), new LoggerFactory().CreateLogger<JwtRequestUriHttpClient>());
+                jwtRequestUriHttpClient = new JwtRequestUriHttpClient(new HttpClient(new NetworkHandler(new Exception("no jwt request uri response configured"))), new LoggerFactory());
             }
 
 


### PR DESCRIPTION
Don't like the typed HTTP clients magic. Our new approach will

* list all names for our clients in `IdentityServerConstants.HttpClients`
* use those names internally when resolving our services from DI

If you want to customize a client, override the client in the factory using the name.