### PR TITLE
Fix UserLoginFailureEvent raised with interactive=true in resource owner grant flow

### DIFF
--- a/src/IdentityServer4/src/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/TokenRequestValidator.cs
@@ -814,7 +814,7 @@ namespace IdentityServer4.Validation
 
         private Task RaiseFailedResourceOwnerAuthenticationEventAsync(string userName, string error, string clientId)
         {
-            return _events.RaiseAsync(new UserLoginFailureEvent(userName, error, clientId: clientId));
+            return _events.RaiseAsync(new UserLoginFailureEvent(userName, error, interactive: false, clientId: clientId));
         }
     }
 }

--- a/src/IdentityServer4/src/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/TokenRequestValidator.cs
@@ -809,7 +809,7 @@ namespace IdentityServer4.Validation
 
         private Task RaiseSuccessfulResourceOwnerAuthenticationEventAsync(string userName, string subjectId, string clientId)
         {
-            return _events.RaiseAsync(new UserLoginSuccessEvent(userName, subjectId, null, false, clientId));
+            return _events.RaiseAsync(new UserLoginSuccessEvent(userName, subjectId, null, interactive: false, clientId));
         }
 
         private Task RaiseFailedResourceOwnerAuthenticationEventAsync(string userName, string error, string clientId)


### PR DESCRIPTION
**What issue does this PR address?**
Fixes #4172. `UserLoginFailureEvent` is incorrectly raised with interactive=true in resource owner grant flow processing in `TokenRequestValidator`.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
