### PR TITLE
Fix failing build for release/3.1.x branch under .net Core 3.1 (#4221)

### DIFF
--- a/src/AspNetIdentity/host/Host.csproj
+++ b/src/AspNetIdentity/host/Host.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFramework/host/Host.csproj
+++ b/src/EntityFramework/host/Host.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IdentityServer4/host/Host.csproj
+++ b/src/IdentityServer4/host/Host.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
 
     <ProjectReference Include="..\src\IdentityServer4.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Added required package reference to three projects to allow build.ps1 script to complete successfully under .Net Core 3.1

See #4221 