### PR TITLE
Strict redirect uri validator app auth with path

### DIFF
--- a/src/IdentityServer4/src/Validation/Default/StrictRedirectUriValidatorAppAuth.cs
+++ b/src/IdentityServer4/src/Validation/Default/StrictRedirectUriValidatorAppAuth.cs
@@ -98,7 +98,7 @@ namespace IdentityServer4.Validation
             }
 
             string portAsString;
-            int indexOfPathSeparator = parts[2].IndexOfAny(new char[] { '/', '?' });
+            int indexOfPathSeparator = parts[2].IndexOfAny(new char[] { '/', '?', '#' });
             if (indexOfPathSeparator > 0)
             {
                 portAsString = parts[2].Substring(0, indexOfPathSeparator);

--- a/src/IdentityServer4/src/Validation/Default/StrictRedirectUriValidatorAppAuth.cs
+++ b/src/IdentityServer4/src/Validation/Default/StrictRedirectUriValidatorAppAuth.cs
@@ -64,10 +64,23 @@ namespace IdentityServer4.Validation
             return false;
         }
 
-        // check if http://127.0.0.1:random_port is used
+        /// <summary>
+        /// Check if <paramref name="requestedUri"/> is of the form http://127.0.0.1:port/path.
+        /// </summary>
+        /// <param name="requestedUri">The requested URI.</param>
+        /// <returns>
+        /// <c>true</c> if <paramref name="requestedUri"/> is a valid Loopback URI; <c>false</c> otherwise.
+        /// </returns>
         internal bool IsLoopback(string requestedUri)
         {
             _logger.LogDebug("Checking for 127.0.0.1 redirect URI");
+
+            // Validate that the requestedUri is not null or empty.
+            if (string.IsNullOrEmpty(requestedUri))
+            {
+                _logger.LogDebug("'requestedUri' is null or empty");
+                return false;
+            }
 
             var parts = requestedUri.Split(':');
 
@@ -84,9 +97,24 @@ namespace IdentityServer4.Validation
                 return false;
             }
 
-            if (int.TryParse(parts[2], out var port))
+            string portAsString;
+            int indexOfPathSeparator = parts[2].IndexOfAny(new char[] { '/', '?' });
+            if (indexOfPathSeparator > 0)
             {
-                if (port >= 0 && port <= 65536) return true;
+                portAsString = parts[2].Substring(0, indexOfPathSeparator);
+            }
+            else
+            {
+                portAsString = parts[2];
+            }
+
+            // Valid port range is 0 through 65535.
+            if (int.TryParse(portAsString, out var port))
+            {
+                if (port >= 0 && port < 65536)
+                {
+                    return true;
+                }
             }
 
             _logger.LogDebug("invalid port");

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/StrictRedirectUriValidatorAppAuthValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/StrictRedirectUriValidatorAppAuthValidation.cs
@@ -1,0 +1,84 @@
+﻿using FluentAssertions;
+using IdentityServer.UnitTests.Common;
+using IdentityServer4.Models;
+using IdentityServer4.Validation;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Validation
+{
+    public class StrictRedirectUriValidatorAppAuthValidation
+    {
+        private const string Category = "Strict Redirect Uri Validator AppAuth Validation Tests";
+
+        private Client clientWithValidLoopbackRedirectUri = new Client
+        {
+            RequirePkce = true,
+            RedirectUris = new List<string>
+            {
+                "http://127.0.0.1"
+            }
+        };
+
+        private Client clientWithNoRedirectUris = new Client
+        {
+            RequirePkce = true
+        };
+
+        [Theory]
+        [Trait("Category", Category)]
+        [InlineData("http://127.0.0.1")] // This is in the clients redirect URIs
+        [InlineData("http://127.0.0.1:0")]
+        [InlineData("http://127.0.0.1:80")]
+        [InlineData("http://127.0.0.1:65535")]
+        [InlineData("http://127.0.0.1:123/a/b")]
+        [InlineData("http://127.0.0.1:123?q=123")]
+        [InlineData("http://127.0.0.1:443/?q=123")]
+        [InlineData("http://127.0.0.1:443/a/b?q=123")]
+        public async Task Loopback_Redirect_URIs_Should_Be_AllowedAsync(string requestedUri)
+        {
+            var strictRedirectUriValidatorAppAuthValidator = new StrictRedirectUriValidatorAppAuth(TestLogger.Create<StrictRedirectUriValidatorAppAuth>());
+
+            var result = await strictRedirectUriValidatorAppAuthValidator.IsRedirectUriValidAsync(requestedUri, clientWithValidLoopbackRedirectUri);
+
+            result.Should().BeTrue();
+        }
+
+        [Theory]
+        [Trait("Category", Category)]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("http:")]
+        [InlineData("127.0.0.1")]
+        [InlineData("//127.0.0.1")]
+        [InlineData("https://127.0.0.1:123")]
+        [InlineData("http://127.0.0.1:")]
+        [InlineData("http://127.0.0.1:-1")]
+        [InlineData("http://127.0.0.2:65536")]
+        [InlineData("http://127.0.0.1:443a")]
+        [InlineData("http://127.0.0.1:a443")]
+        [InlineData("http://127.0.0.1:443a/")]
+        [InlineData("http://127.0.0.1:443a?")]
+        [InlineData("http://127.0.0.2:443")]
+        public async Task Loopback_Redirect_URIs_Should_Not_Be_AllowedAsync(string requestedUri)
+        {
+            var strictRedirectUriValidatorAppAuthValidator = new StrictRedirectUriValidatorAppAuth(TestLogger.Create<StrictRedirectUriValidatorAppAuth>());
+
+            var result = await strictRedirectUriValidatorAppAuthValidator.IsRedirectUriValidAsync(requestedUri, clientWithValidLoopbackRedirectUri);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task Client_With_No_Redirect_Uris_Should_Not_Be_AllowedAsync()
+        {
+            var strictRedirectUriValidatorAppAuthValidator = new StrictRedirectUriValidatorAppAuth(TestLogger.Create<StrictRedirectUriValidatorAppAuth>());
+
+            var result = await strictRedirectUriValidatorAppAuthValidator.IsRedirectUriValidAsync("http://127.0.0.1", clientWithNoRedirectUris);
+
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/StrictRedirectUriValidatorAppAuthValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/StrictRedirectUriValidatorAppAuthValidation.cs
@@ -36,6 +36,8 @@ namespace IdentityServer.UnitTests.Validation
         [InlineData("http://127.0.0.1:123?q=123")]
         [InlineData("http://127.0.0.1:443/?q=123")]
         [InlineData("http://127.0.0.1:443/a/b?q=123")]
+        [InlineData("http://127.0.0.1:443#abc")]
+        [InlineData("http://127.0.0.1:443/a/b?q=123#abc")]
         public async Task Loopback_Redirect_URIs_Should_Be_AllowedAsync(string requestedUri)
         {
             var strictRedirectUriValidatorAppAuthValidator = new StrictRedirectUriValidatorAppAuth(TestLogger.Create<StrictRedirectUriValidatorAppAuth>());
@@ -61,22 +63,13 @@ namespace IdentityServer.UnitTests.Validation
         [InlineData("http://127.0.0.1:443a/")]
         [InlineData("http://127.0.0.1:443a?")]
         [InlineData("http://127.0.0.2:443")]
+        [InlineData("http://127.0.0.1#abc")]
+        [InlineData("http://127.0.0.1:#abc")]
         public async Task Loopback_Redirect_URIs_Should_Not_Be_AllowedAsync(string requestedUri)
         {
             var strictRedirectUriValidatorAppAuthValidator = new StrictRedirectUriValidatorAppAuth(TestLogger.Create<StrictRedirectUriValidatorAppAuth>());
 
             var result = await strictRedirectUriValidatorAppAuthValidator.IsRedirectUriValidAsync(requestedUri, clientWithValidLoopbackRedirectUri);
-
-            result.Should().BeFalse();
-        }
-
-        [Fact]
-        [Trait("Category", Category)]
-        public async Task Client_With_No_Redirect_Uris_Should_Not_Be_AllowedAsync()
-        {
-            var strictRedirectUriValidatorAppAuthValidator = new StrictRedirectUriValidatorAppAuth(TestLogger.Create<StrictRedirectUriValidatorAppAuth>());
-
-            var result = await strictRedirectUriValidatorAppAuthValidator.IsRedirectUriValidAsync("http://127.0.0.1", clientWithNoRedirectUris);
 
             result.Should().BeFalse();
         }


### PR DESCRIPTION
**What issue does this PR address?**
[#3974](https://github.com/IdentityServer/IdentityServer4/issues/3974)

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [&check; ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ &check;] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
This PR is similar to [this one](https://github.com/IdentityServer/IdentityServer4/pull/3978) but does not use RegEx. It allows for a path in the Loopback address, but does not validate that path. 

I'd like to acknowledge [VictorioBerra](https://github.com/VictorioBerra) - the unit tests added in this PR are based on the unit tests he wrote in [his PR](https://github.com/IdentityServer/IdentityServer4/pull/3978).