### PR TITLE
Update code snippet from 1_client_credentials.rst

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -272,10 +272,10 @@ Calling the API
 To send the access token to the API you typically use the HTTP Authorization header. This is done using the ``SetBearerToken`` extension method::
 
     // call api
-    var client = new HttpClient();
-    client.SetBearerToken(tokenResponse.AccessToken);
+    var apiClient = new HttpClient();
+    apiClient.SetBearerToken(tokenResponse.AccessToken);
 
-    var response = await client.GetAsync("http://localhost:5001/identity");
+    var response = await apiClient.GetAsync("http://localhost:5001/identity");
     if (!response.IsSuccessStatusCode)
     {
         Console.WriteLine(response.StatusCode);


### PR DESCRIPTION
In the "call api" code snippet the the variable "client" was reused, when it should have been set to "apiClient".

**What issue does this PR address?**
Typo in documentation

**Does this PR introduce a breaking change?**
N/A

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
