### PR TITLE
Add option to emit scopes as space separated string in JWT (as opposed to array)

### DIFF
--- a/docs/reference/options.rst
+++ b/docs/reference/options.rst
@@ -12,6 +12,9 @@ IdentityServer Options
 * ``AccessTokenJwtType``
     Specifies the value used for the JWT typ header for access tokens (defaults to ``at+jwt``).
 
+* ``EmitScopesAsSpaceDelimitedStringInJwt``
+    Specifies whether scopes in JWTs are emitted as array or string
+
 * ``EmitLegacyResourceAudienceClaim``
     Emits an ``aud`` claim with the format issuer/resources. That's needed for some older access token validation plumbing. Defaults to false.
 

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -37,6 +37,11 @@ namespace IdentityServer4.Configuration
         public bool EmitLegacyResourceAudienceClaim { get; set; } = false;
 
         /// <summary>
+        /// Specifies whether scopes in JWTs are emitted as array or string
+        /// </summary>
+        public bool EmitScopesAsSpaceDelimitedStringInJwt { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the endpoint configuration.
         /// </summary>
         /// <value>

--- a/src/IdentityServer4/src/Extensions/TokenExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/TokenExtensions.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
+using IdentityServer4.Configuration;
 
 namespace IdentityServer4.Extensions
 {
@@ -25,11 +26,12 @@ namespace IdentityServer4.Extensions
         /// </summary>
         /// <param name="token">The token.</param>
         /// <param name="clock">The clock.</param>
+        /// <param name="options">The options</param>
         /// <param name="logger">The logger.</param>
         /// <returns></returns>
         /// <exception cref="Exception">
         /// </exception>
-        public static JwtPayload CreateJwtPayload(this Token token, ISystemClock clock, ILogger logger)
+        public static JwtPayload CreateJwtPayload(this Token token, ISystemClock clock, IdentityServerOptions options, ILogger logger)
         {
             var payload = new JwtPayload(
                 token.Issuer,
@@ -64,7 +66,15 @@ namespace IdentityServer4.Extensions
             if (!scopeClaims.IsNullOrEmpty())
             {
                 var scopeValues = scopeClaims.Select(x => x.Value).ToArray();
-                payload.Add(JwtClaimTypes.Scope, scopeValues);
+
+                if (options.EmitScopesAsSpaceDelimitedStringInJwt)
+                {
+                    payload.Add(JwtClaimTypes.Scope, string.Join(" ", scopeValues));
+                }
+                else
+                {
+                    payload.Add(JwtClaimTypes.Scope, scopeValues);
+                }
             }
 
             // amr claims

--- a/src/IdentityServer4/src/Services/Default/DefaultTokenCreationService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultTokenCreationService.cs
@@ -122,7 +122,7 @@ namespace IdentityServer4.Services
         /// <returns>The JWT payload</returns>
         protected virtual Task<JwtPayload> CreatePayloadAsync(Token token)
         {
-            var payload = token.CreateJwtPayload(Clock, Logger);
+            var payload = token.CreateJwtPayload(Clock, Options, Logger);
             return Task.FromResult(payload);
         }
 

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/JwtPayloadCreationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/JwtPayloadCreationTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using FluentAssertions;
+using IdentityModel;
+using IdentityServer.UnitTests.Common;
+using IdentityServer4.Configuration;
+using IdentityServer4.Extensions;
+using IdentityServer4.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Extensions
+{
+    public class JwtPayloadCreationTests
+    {
+        private Token _token;
+        
+        public JwtPayloadCreationTests()
+        {
+            var claims = new List<Claim>
+            {
+                new Claim(JwtClaimTypes.Scope, "scope1"),
+                new Claim(JwtClaimTypes.Scope, "scope2"),
+                new Claim(JwtClaimTypes.Scope, "scope3"),
+            };
+            
+            _token = new Token(OidcConstants.TokenTypes.AccessToken)
+            {
+                CreationTime = DateTime.UtcNow,
+                Issuer = "issuer",
+                Lifetime = 60,
+                Claims = claims.Distinct(new ClaimComparer()).ToList(),
+                ClientId = "client"
+            };
+        }
+        
+        [Fact]
+        public void Should_create_scopes_as_array_by_default()
+        {
+            var options = new IdentityServerOptions();
+            var payload = _token.CreateJwtPayload(new SystemClock(), options, TestLogger.Create<JwtPayloadCreationTests>());
+
+            payload.Should().NotBeNull();
+            var scopes = payload.Claims.Where(c => c.Type == JwtClaimTypes.Scope).ToArray();
+            scopes.Count().Should().Be(3);
+            scopes[0].Value.Should().Be("scope1");
+            scopes[1].Value.Should().Be("scope2");
+            scopes[2].Value.Should().Be("scope3");
+        }
+        
+        [Fact]
+        public void Should_create_scopes_as_string()
+        {
+            var options = new IdentityServerOptions
+            {
+                EmitScopesAsSpaceDelimitedStringInJwt = true
+            };
+            
+            var payload = _token.CreateJwtPayload(new SystemClock(), options, TestLogger.Create<JwtPayloadCreationTests>());
+
+            payload.Should().NotBeNull();
+            var scopes = payload.Claims.Where(c => c.Type == JwtClaimTypes.Scope).ToList();
+            scopes.Count().Should().Be(1);
+            scopes.First().Value.Should().Be("scope1 scope2 scope3");
+        }
+    }
+}


### PR DESCRIPTION
to comply with JWT profile.