### PR TITLE
Add option to set SameSite mode for internal cookies

### DIFF
--- a/docs/reference/options.rst
+++ b/docs/reference/options.rst
@@ -39,7 +39,10 @@ Authentication
     The authentication cookie lifetime (only effective if the IdentityServer-provided cookie handler is used).
 
 * ``CookieSlidingExpiration``
-    Specified if the cookie should be sliding or not (only effective if the IdentityServer-provided cookie handler is used).
+    Specifies if the cookie should be sliding or not (only effective if the IdentityServer-provided cookie handler is used).
+
+* ``CookieSameSiteMode``
+    Specifies the SameSite mode for the internal cookies.
 
 * ``RequireAuthenticatedUserForSignOutMessage``
     Indicates if user must be authenticated to accept parameters to end session endpoint. Defaults to false.

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
@@ -31,7 +31,7 @@ namespace IdentityServer4.Configuration
                 options.ExpireTimeSpan = _idsrv.Authentication.CookieLifetime;
                 options.Cookie.Name = IdentityServerConstants.DefaultCookieAuthenticationScheme;
                 options.Cookie.IsEssential = true;
-                options.Cookie.SameSite = SameSiteMode.None;
+                options.Cookie.SameSite = _idsrv.Authentication.CookieSameSiteMode;
 
                 options.LoginPath = ExtractLocalUrl(_idsrv.UserInteraction.LoginUrl);
                 options.LogoutPath = ExtractLocalUrl(_idsrv.UserInteraction.LogoutUrl);
@@ -51,7 +51,7 @@ namespace IdentityServer4.Configuration
                 // so we need to make those cookies issued without same-site, thus the browser will
                 // hold onto them and send on the next redirect to the callback page.
                 // see: https://brockallen.com/2019/01/11/same-site-cookies-asp-net-core-and-external-authentication-providers/
-                options.Cookie.SameSite = SameSiteMode.None;
+                options.Cookie.SameSite = _idsrv.Authentication.CookieSameSiteMode;
             }
         }
 

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using Microsoft.AspNetCore.Http;
 
 namespace IdentityServer4.Configuration
 {
@@ -26,6 +27,11 @@ namespace IdentityServer4.Configuration
         /// Specified if the cookie should be sliding or not (only effective if the built-in cookie middleware is used)
         /// </summary>
         public bool CookieSlidingExpiration { get; set; } = false;
+        
+        /// <summary>
+        /// Specifies the SameSite mode for the internal authentication and temp cookie
+        /// </summary>
+        public SameSiteMode CookieSameSiteMode { get; set; } = SameSiteMode.None;
 
         /// <summary>
         /// Indicates if user must be authenticated to accept parameters to end session endpoint. Defaults to false.


### PR DESCRIPTION
If no cross-site scenario is present, setting to Lax improves security.