### PR TITLE
Features/grants enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,4 @@ workspace.xml
 
 src/IdentityServer4/host/identityserver.db
 src/IdentityServer4/host/tempkey.jwk
+src/EntityFramework/host/tempkey.jwk

--- a/src/EntityFramework.Storage/src/DbContexts/ConfigurationDbContext.cs
+++ b/src/EntityFramework.Storage/src/DbContexts/ConfigurationDbContext.cs
@@ -3,7 +3,6 @@
 
 
 using System;
-using System.Threading.Tasks;
 using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.EntityFramework.Extensions;
 using IdentityServer4.EntityFramework.Interfaces;

--- a/src/EntityFramework.Storage/src/Entities/ApiResource.cs
+++ b/src/EntityFramework.Storage/src/Entities/ApiResource.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace IdentityServer4.EntityFramework.Entities
 {

--- a/src/EntityFramework.Storage/src/Stores/DeviceFlowStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/DeviceFlowStore.cs
@@ -3,7 +3,6 @@
 
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using IdentityModel;
 using IdentityServer4.EntityFramework.Entities;

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
 using IdentityServer4.EntityFramework.DbContexts;

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.EntityFramework.Mappers;
 using IdentityServer4.EntityFramework.Options;
@@ -13,6 +14,7 @@ using IdentityServer4.EntityFramework.Stores;
 using IdentityServer4.Models;
 using IdentityServer4.Stores;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 using Xunit;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
@@ -28,14 +30,15 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             }
         }
 
-        private static PersistedGrant CreateTestObject()
+        private static PersistedGrant CreateTestObject(string sub = null, string clientId = null, string sid = null, string type = null)
         {
             return new PersistedGrant
             {
                 Key = Guid.NewGuid().ToString(),
-                Type = "authorization_code",
-                ClientId = Guid.NewGuid().ToString(),
-                SubjectId = Guid.NewGuid().ToString(),
+                Type = type ?? "authorization_code",
+                ClientId = clientId ?? Guid.NewGuid().ToString(),
+                SubjectId = sub ?? Guid.NewGuid().ToString(),
+                SessionId = sid ?? Guid.NewGuid().ToString(),
                 CreationTime = new DateTime(2016, 08, 01),
                 Expiration = new DateTime(2016, 08, 31),
                 Data = Guid.NewGuid().ToString()
@@ -82,7 +85,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public async Task GetAsync_WithSubAndTypeAndPersistedGrantExists_ExpectPersistedGrantReturned(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task GetAllAsync_WithSubAndTypeAndPersistedGrantExists_ExpectPersistedGrantReturned(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
@@ -101,6 +104,85 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
 
             Assert.NotNull(foundPersistedGrants);
             Assert.NotEmpty(foundPersistedGrants);
+        }
+
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
+        public async Task GetAllAsync_Should_Filter(DbContextOptions<PersistedGrantDbContext> options)
+        {
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s1", type: "t1").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s1", type: "t2").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s2", type: "t1").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s2", type: "t2").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s1", type: "t1").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s1", type: "t2").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s2", type: "t1").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s2", type: "t2").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c3", sid: "s3", type: "t3").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject().ToEntity());
+                context.SaveChanges();
+            }
+
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1"
+                })).ToList().Count.Should().Be(9);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub2"
+                })).ToList().Count.Should().Be(0);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c1"
+                })).ToList().Count.Should().Be(4);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c2"
+                })).ToList().Count.Should().Be(4);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c3"
+                })).ToList().Count.Should().Be(1);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c4"
+                })).ToList().Count.Should().Be(0);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c1",
+                    SessionId = "s1"
+                })).ToList().Count.Should().Be(2);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c3",
+                    SessionId = "s1"
+                })).ToList().Count.Should().Be(0);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c1",
+                    SessionId = "s1",
+                    Type = "t1"
+                })).ToList().Count.Should().Be(1);
+                (await store.GetAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c1",
+                    SessionId = "s1",
+                    Type = "t3"
+                })).ToList().Count.Should().Be(0);
+            }
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
@@ -128,7 +210,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public async Task RemoveAsync_WhenSubIdAndClientIdOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task RemoveAllAsync_WhenSubIdAndClientIdOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
@@ -141,7 +223,10 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                await store.RemoveAllAsync(new PersistedGrantFilter { SubjectId = persistedGrant.SubjectId, ClientId = persistedGrant.ClientId });
+                await store.RemoveAllAsync(new PersistedGrantFilter { 
+                    SubjectId = persistedGrant.SubjectId, 
+                    ClientId = persistedGrant.ClientId 
+                });
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -152,7 +237,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public async Task RemoveAsync_WhenSubIdClientIdAndTypeOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task RemoveAllAsync_WhenSubIdClientIdAndTypeOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
@@ -165,13 +250,174 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                await store.RemoveAllAsync(new PersistedGrantFilter { SubjectId = persistedGrant.SubjectId, ClientId = persistedGrant.ClientId, Type = persistedGrant.Type });
+                await store.RemoveAllAsync(new PersistedGrantFilter { 
+                    SubjectId = persistedGrant.SubjectId, 
+                    ClientId = persistedGrant.ClientId, 
+                    Type = persistedGrant.Type });
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var foundGrant = context.PersistedGrants.FirstOrDefault(x => x.Key == persistedGrant.Key);
                 Assert.Null(foundGrant);
+            }
+        }
+
+
+        [Theory, MemberData(nameof(TestDatabaseProviders))]
+        public async Task RemoveAllAsync_Should_Filter(DbContextOptions<PersistedGrantDbContext> options)
+        {
+            void PopulateDb()
+            {
+                using (var context = new PersistedGrantDbContext(options, StoreOptions))
+                {
+                    context.PersistedGrants.RemoveRange(context.PersistedGrants.ToArray());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s1", type: "t1").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s1", type: "t2").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s2", type: "t1").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s2", type: "t2").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s1", type: "t1").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s1", type: "t2").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s2", type: "t1").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s2", type: "t2").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c3", sid: "s3", type: "t3").ToEntity());
+                    context.PersistedGrants.Add(CreateTestObject().ToEntity());
+                    context.SaveChanges();
+                }
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1"
+                });
+                context.PersistedGrants.Count().Should().Be(1);
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub2"
+                });
+                context.PersistedGrants.Count().Should().Be(10);
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1", ClientId = "c1"
+                });
+                context.PersistedGrants.Count().Should().Be(6);
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c2"
+                });
+                context.PersistedGrants.Count().Should().Be(6);
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c3"
+                });
+                context.PersistedGrants.Count().Should().Be(9);
+            }
+
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c4"
+                });
+                context.PersistedGrants.Count().Should().Be(10);
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c1", 
+                    SessionId = "s1"
+                });
+                context.PersistedGrants.Count().Should().Be(8);
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c3",
+                    SessionId = "s1"
+                });
+                context.PersistedGrants.Count().Should().Be(10);
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c1",
+                    SessionId = "s1", 
+                    Type = "t1"
+                });
+                context.PersistedGrants.Count().Should().Be(9);
+            }
+
+            PopulateDb();
+            using (var context = new PersistedGrantDbContext(options, StoreOptions))
+            {
+                var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
+
+                await store.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "c1",
+                    SessionId = "s1",
+                    Type = "t3"
+                });
+                context.PersistedGrants.Count().Should().Be(10);
             }
         }
 

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -11,6 +11,7 @@ using IdentityServer4.EntityFramework.Mappers;
 using IdentityServer4.EntityFramework.Options;
 using IdentityServer4.EntityFramework.Stores;
 using IdentityServer4.Models;
+using IdentityServer4.Stores;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -95,7 +96,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                foundPersistedGrants = (await store.GetAllAsync(persistedGrant.SubjectId)).ToList();
+                foundPersistedGrants = (await store.GetAllAsync(new PersistedGrantFilter { SubjectId = persistedGrant.SubjectId })).ToList();
             }
 
             Assert.NotNull(foundPersistedGrants);
@@ -140,7 +141,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                await store.RemoveAllAsync(persistedGrant.SubjectId, persistedGrant.ClientId);
+                await store.RemoveAllAsync(new PersistedGrantFilter { SubjectId = persistedGrant.SubjectId, ClientId = persistedGrant.ClientId });
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -164,7 +165,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                await store.RemoveAllAsync(persistedGrant.SubjectId, persistedGrant.ClientId, persistedGrant.Type);
+                await store.RemoveAllAsync(new PersistedGrantFilter { SubjectId = persistedGrant.SubjectId, ClientId = persistedGrant.ClientId, Type = persistedGrant.Type });
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ResourceStoreTests.cs
@@ -12,7 +12,6 @@ using IdentityServer4.EntityFramework.Mappers;
 using IdentityServer4.EntityFramework.Options;
 using IdentityServer4.EntityFramework.Stores;
 using IdentityServer4.Models;
-using IdentityServer4.Stores;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 

--- a/src/EntityFramework.Storage/test/IntegrationTests/TokenCleanup/TokenCleanupTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/TokenCleanup/TokenCleanupTests.cs
@@ -12,7 +12,6 @@ using IdentityServer4.Stores;
 using IdentityServer4.Test;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.TokenCleanup

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/ApiResourceMappersTests.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/ApiResourceMappersTests.cs
@@ -5,7 +5,6 @@
 using System.Linq;
 using FluentAssertions;
 using IdentityServer4.EntityFramework.Mappers;
-using IdentityServer4.Models;
 using Xunit;
 using ApiResource = IdentityServer4.Models.ApiResource;
 

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/IdentityResourcesMappersTests.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/IdentityResourcesMappersTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using System.Linq;
-using FluentAssertions;
 using IdentityServer4.EntityFramework.Mappers;
 using IdentityServer4.Models;
 using Xunit;

--- a/src/EntityFramework/migrations/SqlServer/Configuration/Clients.cs
+++ b/src/EntityFramework/migrations/SqlServer/Configuration/Clients.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4;
 using IdentityServer4.Models;
 using System.Collections.Generic;
-using static IdentityServer4.IdentityServerConstants;
 
 namespace Host.Configuration
 {

--- a/src/EntityFramework/migrations/SqlServer/Configuration/ClientsConsole.cs
+++ b/src/EntityFramework/migrations/SqlServer/Configuration/ClientsConsole.cs
@@ -26,7 +26,18 @@ namespace Host.Configuration
                     ClientId = "client",
                     ClientSecrets = {new Secret("secret".Sha256())},
                     AllowedGrantTypes = GrantTypes.ClientCredentials,
-                    AllowedScopes = { "feature1", "feature2", IdentityServerConstants.LocalApi.ScopeName}
+                    AllowedScopes = { "scope1", "scope2", IdentityServerConstants.LocalApi.ScopeName}
+                },
+                
+                ///////////////////////////////////////////
+                // Console Structured Scope Sample
+                //////////////////////////////////////////
+                new Client
+                {
+                    ClientId = "parameterized.client",
+                    ClientSecrets = {new Secret("secret".Sha256())},
+                    AllowedGrantTypes = GrantTypes.ClientCredentials,
+                    AllowedScopes = { "transaction" }
                 },
 
                 ///////////////////////////////////////////
@@ -46,9 +57,10 @@ namespace Host.Configuration
                             Type = IdentityServerConstants.SecretTypes.X509CertificateThumbprint
                         },
                     },
+                    
                     AccessTokenType = AccessTokenType.Jwt,
                     AllowedGrantTypes = GrantTypes.ClientCredentials,
-                    AllowedScopes = { "feature1", "feature2" }
+                    AllowedScopes = { "scope1", "scope2" }
                 },
 
                 ///////////////////////////////////////////
@@ -72,8 +84,9 @@ namespace Host.Configuration
                                 "{'e':'AQAB','kid':'ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA','kty':'RSA','n':'wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw'}"
                         }
                     },
+                    
                     AllowedGrantTypes = GrantTypes.ClientCredentials,
-                    AllowedScopes = { "feature1", "feature2" }
+                    AllowedScopes = { "scope1", "scope2" }
                 },
 
                 ///////////////////////////////////////////
@@ -84,7 +97,7 @@ namespace Host.Configuration
                     ClientId = "client.custom",
                     ClientSecrets = {new Secret("secret".Sha256())},
                     AllowedGrantTypes = {"custom", "custom.nosubject"},
-                    AllowedScopes = { "feature1", "feature2" }
+                    AllowedScopes = { "scope1", "scope2" }
                 },
 
                 ///////////////////////////////////////////
@@ -100,7 +113,7 @@ namespace Host.Configuration
                     {
                         IdentityServerConstants.StandardScopes.OpenId,
                         "custom.profile",
-                        "feature1", "feature2"
+                        "scope1", "scope2"
                     }
                 },
 
@@ -117,7 +130,7 @@ namespace Host.Configuration
                     {
                         IdentityServerConstants.StandardScopes.OpenId,
                         IdentityServerConstants.StandardScopes.Email,
-                        "feature1", "feature2"
+                        "scope1", "scope2"
                     }
                 },
 
@@ -138,7 +151,7 @@ namespace Host.Configuration
                         IdentityServerConstants.StandardScopes.OpenId,
                         IdentityServerConstants.StandardScopes.Profile,
                         IdentityServerConstants.StandardScopes.Email,
-                        "feature1", "feature2"
+                        "scope1", "scope2"
                     }
                 },
                 ///////////////////////////////////////////
@@ -160,7 +173,7 @@ namespace Host.Configuration
                         IdentityServerConstants.StandardScopes.OpenId,
                         IdentityServerConstants.StandardScopes.Profile,
                         IdentityServerConstants.StandardScopes.Email,
-                        "feature1", "feature2"
+                        "scope1", "scope2"
                     }
                 },
 
@@ -173,7 +186,7 @@ namespace Host.Configuration
                     ClientId = "roclient.reference",
                     ClientSecrets = {new Secret("secret".Sha256())},
                     AllowedGrantTypes = GrantTypes.ResourceOwnerPassword,
-                    AllowedScopes = {"feature1", "feature2"},
+                    AllowedScopes = {"scope1", "scope2"},
                     AccessTokenType = AccessTokenType.Reference
                 },
                 
@@ -190,14 +203,12 @@ namespace Host.Configuration
 
                     AllowOfflineAccess = true,
 
-                    AllowedCorsOrigins = { "http://localhost:5001" }, // JS test client only
-
                     AllowedScopes =
                     {
                         IdentityServerConstants.StandardScopes.OpenId,
                         IdentityServerConstants.StandardScopes.Profile,
                         IdentityServerConstants.StandardScopes.Email,
-                        "feature1", "feature2"
+                        "scope1", "scope2"
                     }
                 }
             };

--- a/src/EntityFramework/migrations/SqlServer/Configuration/ClientsWeb.cs
+++ b/src/EntityFramework/migrations/SqlServer/Configuration/ClientsWeb.cs
@@ -9,6 +9,16 @@ namespace Host.Configuration
 {
     public static class ClientsWeb
     {
+        static string[] allowedScopes = 
+        {
+            IdentityServerConstants.StandardScopes.OpenId,
+            IdentityServerConstants.StandardScopes.Profile,
+            IdentityServerConstants.StandardScopes.Email,
+            "scope1", 
+            "scope2",
+            "transaction"
+        };
+        
         public static IEnumerable<Client> Get()
         {
             return new List<Client>
@@ -36,13 +46,7 @@ namespace Host.Configuration
                     PostLogoutRedirectUris = { "https://localhost:44300/index.html" },
                     AllowedCorsOrigins = { "https://localhost:44300" },
 
-                    AllowedScopes =
-                    {
-                        IdentityServerConstants.StandardScopes.OpenId,
-                        IdentityServerConstants.StandardScopes.Profile,
-                        IdentityServerConstants.StandardScopes.Email,
-                        "feature1", "feature2"
-                    }
+                    AllowedScopes = allowedScopes
                 },
                 
                 ///////////////////////////////////////////
@@ -68,13 +72,7 @@ namespace Host.Configuration
 
                     AllowOfflineAccess = true,
 
-                    AllowedScopes =
-                    {
-                        IdentityServerConstants.StandardScopes.OpenId,
-                        IdentityServerConstants.StandardScopes.Profile,
-                        IdentityServerConstants.StandardScopes.Email,
-                        "feature1", "feature2"
-                    }
+                    AllowedScopes = allowedScopes
                 },
                 
                 ///////////////////////////////////////////
@@ -100,14 +98,7 @@ namespace Host.Configuration
 
                     AllowOfflineAccess = true,
 
-                    AllowedScopes =
-                    {
-                        IdentityServerConstants.StandardScopes.OpenId,
-                        IdentityServerConstants.StandardScopes.Profile,
-                        IdentityServerConstants.StandardScopes.Email,
-                        "feature1", "feature2", 
-                        "transaction"
-                    }
+                    AllowedScopes = allowedScopes
                 },
                 
                 ///////////////////////////////////////////
@@ -133,13 +124,7 @@ namespace Host.Configuration
 
                     AllowOfflineAccess = true,
 
-                    AllowedScopes =
-                    {
-                        IdentityServerConstants.StandardScopes.OpenId,
-                        IdentityServerConstants.StandardScopes.Profile,
-                        IdentityServerConstants.StandardScopes.Email,
-                        "feature1", "feature2"
-                    }
+                    AllowedScopes = allowedScopes
                 }
             };
         }

--- a/src/EntityFramework/migrations/SqlServer/Configuration/Resources.cs
+++ b/src/EntityFramework/migrations/SqlServer/Configuration/Resources.cs
@@ -11,7 +11,8 @@ namespace Host.Configuration
 {
     public class Resources
     {
-        public static IEnumerable<IdentityResource> IdentityResources =
+        // identity resources represent identity data about a user that can be requested via the scope parameter (OpenID Connect)
+        public static readonly IEnumerable<IdentityResource> IdentityResources =
             new[]
             {
                 // some standard scopes from the OIDC spec
@@ -23,24 +24,41 @@ namespace Host.Configuration
                 new IdentityResource("custom.profile", new[] { JwtClaimTypes.Name, JwtClaimTypes.Email, "location" })
             };
 
-        public static IEnumerable<ApiResource> ApiResources = new[]
+        // API scopes represent values that describe scope of access and can be requested by the scope parameter (OAuth)
+        public static readonly IEnumerable<ApiScope> ApiScopes =
+            new[]
+            {
+                // local feature
+                new ApiScope(LocalApi.ScopeName),
+
+                // some generic scopes
+                new ApiScope("scope1"),
+                new ApiScope("scope2"), 
+                new ApiScope("scope3"),
+                new ApiScope("shared.scope"),
+
+                // used as a dynamic scope
+                new ApiScope("transaction")
+            };
+
+        // API resources are more formal representation of a resource with processing rules and their scopes (if any)
+        public static readonly IEnumerable<ApiResource> ApiResources = 
+            new[]
             {
                 // simple version with ctor
-                new ApiResource("api1", "Some API 1")
+                new ApiResource("resource1", "Resource 1")
                 {
-                    //// this is needed for introspection when using reference tokens
-                    //ApiSecrets = { new Secret("secret".Sha256()) },
+                    // this is needed for introspection when using reference tokens
+                    ApiSecrets = { new Secret("secret".Sha256()) },
 
                     //AllowedSigningAlgorithms = { "RS256", "ES256" }
 
-                    Scopes = { "feature1" }
+                    Scopes = { "scope1", "shared.scope" }
                 },
                 
                 // expanded version if more control is needed
-                new ApiResource
+                new ApiResource("resource2", "Resource 2")
                 {
-                    Name = "api2",
-
                     ApiSecrets =
                     {
                         new Secret("secret".Sha256())
@@ -54,20 +72,7 @@ namespace Host.Configuration
                         JwtClaimTypes.Email
                     },
 
-                    Scopes = { "feature2", "feature3" }
-                }
-            };
-
-        public static IEnumerable<ApiScope> ApiScopes = new[]
-            {
-                // local API
-                new ApiScope(LocalApi.ScopeName),
-                new ApiScope("feature1"),
-                new ApiScope("feature2"),
-                new ApiScope("feature3"),
-                new ApiScope
-                {
-                    Name = "transaction"
+                    Scopes = { "scope2", "shared.scope" }
                 }
             };
     }

--- a/src/IdentityServer4/host/Configuration/Clients.cs
+++ b/src/IdentityServer4/host/Configuration/Clients.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4;
 using IdentityServer4.Models;
 using System.Collections.Generic;
-using static IdentityServer4.IdentityServerConstants;
 
 namespace Host.Configuration
 {

--- a/src/IdentityServer4/host/Extensions/HostProfileService.cs
+++ b/src/IdentityServer4/host/Extensions/HostProfileService.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using IdentityServer4.Models;
-using IdentityServer4.Services;
 using IdentityServer4.Test;
 using Microsoft.Extensions.Logging;
 

--- a/src/IdentityServer4/host/Quickstart/Consent/ConsentController.cs
+++ b/src/IdentityServer4/host/Quickstart/Consent/ConsentController.cs
@@ -5,7 +5,6 @@
 using IdentityServer4.Events;
 using IdentityServer4.Models;
 using IdentityServer4.Services;
-using IdentityServer4.Stores;
 using IdentityServer4.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/IdentityServer4/host/Quickstart/Extensions.cs
+++ b/src/IdentityServer4/host/Quickstart/Extensions.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Threading.Tasks;
 using IdentityServer4.Models;
-using IdentityServer4.Stores;
 using Microsoft.AspNetCore.Mvc;
 
 namespace IdentityServer4.Quickstart.UI

--- a/src/IdentityServer4/host/Startup.cs
+++ b/src/IdentityServer4/host/Startup.cs
@@ -21,7 +21,6 @@ using System.Threading.Tasks;
 using Host.Extensions;
 using Microsoft.AspNetCore.Authentication.Certificate;
 using Microsoft.AspNetCore.HttpOverrides;
-using IdentityServer4.Validation;
 
 namespace Host
 {

--- a/src/IdentityServer4/src/Configuration/CryptoHelper.cs
+++ b/src/IdentityServer4/src/Configuration/CryptoHelper.cs
@@ -1,10 +1,7 @@
 ﻿using IdentityModel;
 using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Linq;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -7,7 +7,6 @@ using IdentityServer4.Services;
 using IdentityServer4.Stores;
 using IdentityServer4.Validation;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Http;
 using System;
 using System.Net.Http;
 using IdentityServer4;

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Crypto.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Crypto.cs
@@ -11,7 +11,6 @@ using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using JsonWebKey = Microsoft.IdentityModel.Tokens.JsonWebKey;
 

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
@@ -4,7 +4,6 @@
 
 using IdentityServer4.Extensions;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/IdentityServer4/src/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/AuthorizeResult.cs
@@ -16,7 +16,6 @@ using IdentityServer4.Stores;
 using IdentityServer4.ResponseHandling;
 using Microsoft.AspNetCore.Authentication;
 using System.Text.Encodings.Web;
-using System.Linq;
 
 namespace IdentityServer4.Endpoints.Results
 {

--- a/src/IdentityServer4/src/Endpoints/Results/ConsentPageResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/ConsentPageResult.cs
@@ -12,7 +12,6 @@ using IdentityServer4.Validation;
 using IdentityServer4.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using IdentityServer4.Stores;
-using System.Collections.Specialized;
 using IdentityServer4.Models;
 
 namespace IdentityServer4.Endpoints.Results

--- a/src/IdentityServer4/src/Endpoints/Results/LoginPageResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/LoginPageResult.cs
@@ -13,7 +13,6 @@ using IdentityServer4.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using IdentityServer4.Stores;
 using IdentityServer4.Models;
-using System.Collections.Specialized;
 
 namespace IdentityServer4.Endpoints.Results
 {

--- a/src/IdentityServer4/src/Models/DeviceFlowAuthorizationRequest.cs
+++ b/src/IdentityServer4/src/Models/DeviceFlowAuthorizationRequest.cs
@@ -3,7 +3,6 @@
 
 
 using IdentityServer4.Validation;
-using System.Collections.Generic;
 
 namespace IdentityServer4.Models
 {

--- a/src/IdentityServer4/src/Models/Messages/AuthorizationRequest.cs
+++ b/src/IdentityServer4/src/Models/Messages/AuthorizationRequest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Extensions;
 using IdentityServer4.Validation;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/src/IdentityServer4/src/Services/Default/DefaultDeviceFlowInteractionService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultDeviceFlowInteractionService.cs
@@ -3,7 +3,6 @@
 
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using IdentityServer4.Models;
 using IdentityServer4.Stores;

--- a/src/IdentityServer4/src/Services/Default/DefaultIdentityServerInteractionService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultIdentityServerInteractionService.cs
@@ -188,11 +188,8 @@ namespace IdentityServer4.Services
             if (user != null)
             {
                 var subject = user.GetSubjectId();
-                var clients = await _userSession.GetClientListAsync();
-                foreach (var client in clients)
-                {
-                    await _grants.RemoveAllGrantsAsync(subject, client);
-                }
+                var sessionId = await _userSession.GetSessionIdAsync();
+                await _grants.RemoveAllGrantsAsync(subject, sessionId: sessionId);
             }
         }
     }

--- a/src/IdentityServer4/src/Services/Default/DefaultPersistedGrantService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultPersistedGrantService.cs
@@ -40,6 +40,8 @@ namespace IdentityServer4.Services
         /// <inheritdoc/>
         public async Task<IEnumerable<Grant>> GetAllGrantsAsync(string subjectId)
         {
+            if (String.IsNullOrWhiteSpace(subjectId)) throw new ArgumentNullException(nameof(subjectId));
+            
             var grants = (await _store.GetAllAsync(new PersistedGrantFilter { SubjectId = subjectId })).ToArray();
 
             try
@@ -145,11 +147,14 @@ namespace IdentityServer4.Services
         }
 
         /// <inheritdoc/>
-        public Task RemoveAllGrantsAsync(string subjectId, string clientId, string sessionId = null)
+        public Task RemoveAllGrantsAsync(string subjectId, string clientId = null, string sessionId = null)
         {
+            if (String.IsNullOrWhiteSpace(subjectId)) throw new ArgumentNullException(nameof(subjectId));
+
             return _store.RemoveAllAsync(new PersistedGrantFilter {
                 SubjectId = subjectId,
-                ClientId = clientId
+                ClientId = clientId,
+                SessionId = sessionId
             });
         }
     }

--- a/src/IdentityServer4/src/Services/Default/DefaultPersistedGrantService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultPersistedGrantService.cs
@@ -37,14 +37,10 @@ namespace IdentityServer4.Services
             _logger = logger;
         }
 
-        /// <summary>
-        /// Gets all grants for a given subject ID.
-        /// </summary>
-        /// <param name="subjectId">The subject identifier.</param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public async Task<IEnumerable<Grant>> GetAllGrantsAsync(string subjectId)
         {
-            var grants = (await _store.GetAllAsync(subjectId)).ToArray();
+            var grants = (await _store.GetAllAsync(new PersistedGrantFilter { SubjectId = subjectId })).ToArray();
 
             try
             {
@@ -148,15 +144,13 @@ namespace IdentityServer4.Services
             return list;
         }
 
-        /// <summary>
-        /// Removes all grants for a given subject id and client id combination.
-        /// </summary>
-        /// <param name="subjectId">The subject identifier.</param>
-        /// <param name="clientId">The client identifier.</param>
-        /// <returns></returns>
-        public Task RemoveAllGrantsAsync(string subjectId, string clientId)
+        /// <inheritdoc/>
+        public Task RemoveAllGrantsAsync(string subjectId, string clientId, string sessionId = null)
         {
-            return _store.RemoveAllAsync(subjectId, clientId);
+            return _store.RemoveAllAsync(new PersistedGrantFilter {
+                SubjectId = subjectId,
+                ClientId = clientId
+            });
         }
     }
 }

--- a/src/IdentityServer4/src/Services/IPersistedGrantService.cs
+++ b/src/IdentityServer4/src/Services/IPersistedGrantService.cs
@@ -25,7 +25,8 @@ namespace IdentityServer4.Services
         /// </summary>
         /// <param name="subjectId">The subject identifier.</param>
         /// <param name="clientId">The client identifier.</param>
+        /// <param name="sessionId">The sesion id (optional).</param>
         /// <returns></returns>
-        Task RemoveAllGrantsAsync(string subjectId, string clientId);
+        Task RemoveAllGrantsAsync(string subjectId, string clientId, string sessionId = null);
     }
 }

--- a/src/IdentityServer4/src/Services/IPersistedGrantService.cs
+++ b/src/IdentityServer4/src/Services/IPersistedGrantService.cs
@@ -21,12 +21,12 @@ namespace IdentityServer4.Services
         Task<IEnumerable<Grant>> GetAllGrantsAsync(string subjectId);
 
         /// <summary>
-        /// Removes all grants for a given subject id and client id combination.
+        /// Removes all grants for a given subject id, and optionally client id and session id combination.
         /// </summary>
         /// <param name="subjectId">The subject identifier.</param>
-        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientId">The client identifier (optional).</param>
         /// <param name="sessionId">The sesion id (optional).</param>
         /// <returns></returns>
-        Task RemoveAllGrantsAsync(string subjectId, string clientId, string sessionId = null);
+        Task RemoveAllGrantsAsync(string subjectId, string clientId = null, string sessionId = null);
     }
 }

--- a/src/IdentityServer4/src/Stores/Default/DefaultGrantStore.cs
+++ b/src/IdentityServer4/src/Stores/Default/DefaultGrantStore.cs
@@ -196,7 +196,12 @@ namespace IdentityServer4.Stores
         /// <returns></returns>
         protected virtual async Task RemoveAllAsync(string subjectId, string clientId)
         {
-            await Store.RemoveAllAsync(subjectId, clientId, GrantType);
+            await Store.RemoveAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = subjectId,
+                ClientId = clientId,
+                Type = GrantType
+            });
         }
     }
 }

--- a/src/IdentityServer4/src/Stores/Default/DistributedCacheAuthorizationParametersMessageStore.cs
+++ b/src/IdentityServer4/src/Stores/Default/DistributedCacheAuthorizationParametersMessageStore.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Threading.Tasks;
 using IdentityModel;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/src/Stores/Default/QueryStringAuthorizationParametersMessageStore.cs
+++ b/src/IdentityServer4/src/Stores/Default/QueryStringAuthorizationParametersMessageStore.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using IdentityServer4.Models;
 using System.Threading.Tasks;
-using System.Collections.Specialized;
 using IdentityServer4.Extensions;
 
 namespace IdentityServer4.Stores

--- a/src/IdentityServer4/src/Stores/IAuthorizationParametersMessageStore.cs
+++ b/src/IdentityServer4/src/Stores/IAuthorizationParametersMessageStore.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using IdentityServer4.Models;
-using System.Collections.Specialized;
 using System.Threading.Tasks;
 
 namespace IdentityServer4.Stores

--- a/src/IdentityServer4/src/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Common/MockPersistedGrantService.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Common/MockPersistedGrantService.cs
@@ -20,7 +20,7 @@ namespace IdentityServer.UnitTests.Common
             return Task.FromResult(GetAllGrantsResult ?? Enumerable.Empty<Grant>());
         }
 
-        public Task RemoveAllGrantsAsync(string subjectId, string clientId)
+        public Task RemoveAllGrantsAsync(string subjectId, string clientId, string sessionId = null)
         {
             RemoveAllGrantsWasCalled = true;
             return Task.CompletedTask;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/JwtPayloadCreationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/JwtPayloadCreationTests.cs
@@ -9,7 +9,6 @@ using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace IdentityServer.UnitTests.Extensions

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultPersistedGrantServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultPersistedGrantServiceTests.cs
@@ -393,6 +393,322 @@ namespace IdentityServer.UnitTests.Services.Default
             (await _codes.GetAuthorizationCodeAsync(handle8)).Should().NotBeNull();
             (await _codes.GetAuthorizationCodeAsync(handle9)).Should().NotBeNull();
         }
+        [Fact]
+        public async Task RemoveAllGrantsAsync_should_filter_on_session_id()
+        {
+            {
+                var handle1 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client1",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle2 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client2",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle3 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client3",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session3"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+
+                await _subject.RemoveAllGrantsAsync("123");
+
+                (await _refreshTokens.GetRefreshTokenAsync(handle1)).Should().BeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle2)).Should().BeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle3)).Should().BeNull();
+                await _refreshTokens.RemoveRefreshTokenAsync(handle1);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle2);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle3);
+            }
+            {
+                var handle1 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client1",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle2 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client2",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle3 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client3",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session3"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+
+                await _subject.RemoveAllGrantsAsync("123", "client1");
+
+                (await _refreshTokens.GetRefreshTokenAsync(handle1)).Should().BeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle2)).Should().NotBeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle3)).Should().NotBeNull();
+                await _refreshTokens.RemoveRefreshTokenAsync(handle1);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle2);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle3);
+            }
+            {
+                var handle1 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client1",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle2 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client2",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle3 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client3",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle4 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client1",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session2"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                await _subject.RemoveAllGrantsAsync("123", "client1", "session1");
+
+                (await _refreshTokens.GetRefreshTokenAsync(handle1)).Should().BeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle2)).Should().NotBeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle3)).Should().NotBeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle4)).Should().NotBeNull();
+                await _refreshTokens.RemoveRefreshTokenAsync(handle1);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle2);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle3);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle4);
+            }
+            {
+                var handle1 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client1",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle2 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client2",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle3 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client3",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session1"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                var handle4 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
+                {
+                    CreationTime = DateTime.UtcNow,
+                    Lifetime = 10,
+                    AccessToken = new Token
+                    {
+                        ClientId = "client1",
+                        Audiences = { "aud" },
+                        CreationTime = DateTime.UtcNow,
+                        Type = "type",
+                        Claims = new List<Claim>
+                        {
+                            new Claim("sub", "123"),
+                            new Claim("sid", "session2"),
+                            new Claim("scope", "baz")
+                        }
+                    },
+                    Version = 1
+                });
+                await _subject.RemoveAllGrantsAsync("123", sessionId:"session1");
+
+                (await _refreshTokens.GetRefreshTokenAsync(handle1)).Should().BeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle2)).Should().BeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle3)).Should().BeNull();
+                (await _refreshTokens.GetRefreshTokenAsync(handle4)).Should().NotBeNull();
+                await _refreshTokens.RemoveRefreshTokenAsync(handle1);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle2);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle3);
+                await _refreshTokens.RemoveRefreshTokenAsync(handle4);
+            }
+        }
 
         [Fact]
         public async Task GetAllGrantsAsync_should_aggregate_correctly()

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Stores/InMemoryPersistedGrantStoreTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Stores/InMemoryPersistedGrantStoreTests.cs
@@ -1,7 +1,5 @@
 ﻿using IdentityServer4.Models;
 using IdentityServer4.Stores;
-using System;
-using System.Collections.Generic;
 using Xunit;
 using FluentAssertions;
 using System.Threading.Tasks;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Stores/InMemoryPersistedGrantStoreTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Stores/InMemoryPersistedGrantStoreTests.cs
@@ -1,0 +1,537 @@
+﻿using IdentityServer4.Models;
+using IdentityServer4.Stores;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using FluentAssertions;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace IdentityServer.UnitTests.Stores
+{
+    public class InMemoryPersistedGrantStoreTests
+    {
+        InMemoryPersistedGrantStore _subject;
+
+        public InMemoryPersistedGrantStoreTests()
+        {
+            _subject = new InMemoryPersistedGrantStore();
+        }
+
+        [Fact]
+        public async Task Store_should_persist_value()
+        {
+            {
+                var item = await _subject.GetAsync("key1");
+                item.Should().BeNull();
+            }
+
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key1" });
+
+            {
+                var item = await _subject.GetAsync("key1");
+                item.Should().NotBeNull();
+            }
+        }
+
+        [Fact]
+        public async Task GetAll_should_filter()
+        {
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key1", SubjectId = "sub1", ClientId = "client1", SessionId = "session1" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key2", SubjectId = "sub1", ClientId = "client2", SessionId = "session1" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key3", SubjectId = "sub1", ClientId = "client1", SessionId = "session2" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key4", SubjectId = "sub1", ClientId = "client3", SessionId = "session2" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key5", SubjectId = "sub1", ClientId = "client4", SessionId = "session3" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key6", SubjectId = "sub1", ClientId = "client4", SessionId = "session4" });
+
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key7", SubjectId = "sub2", ClientId = "client4", SessionId = "session4" });
+
+
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key1", "key2", "key3", "key4", "key5", "key6" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub2"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key7" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub3"
+            }))
+            .Select(x => x.Key).Should().BeEmpty();
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client1"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key1", "key3" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client2"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key2" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client3"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key4" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client4"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key5", "key6" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client5"
+            }))
+            .Select(x => x.Key).Should().BeEmpty();
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub2",
+                ClientId = "client1"
+            }))
+            .Select(x => x.Key).Should().BeEmpty();
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub2",
+                ClientId = "client4"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key7" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub3",
+                ClientId = "client1"
+            }))
+            .Select(x => x.Key).Should().BeEmpty();
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client1",
+                SessionId = "session1"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key1" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client1",
+                SessionId = "session2"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key3" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client1",
+                SessionId = "session3"
+            }))
+            .Select(x => x.Key).Should().BeEmpty();
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client2",
+                SessionId = "session1"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key2" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client2",
+                SessionId = "session2"
+            }))
+            .Select(x => x.Key).Should().BeEmpty();
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub1",
+                ClientId = "client4",
+                SessionId = "session4"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key6" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub2",
+                ClientId = "client4",
+                SessionId = "session4"
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo(new[] { "key7" });
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub2",
+                ClientId = "client4",
+                SessionId = "session1"
+            }))
+            .Select(x => x.Key).Should().BeEmpty();
+
+            (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                SubjectId = "sub2",
+                ClientId = "client4",
+                SessionId = "session5"
+            }))
+            .Select(x => x.Key).Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task RemoveAll_should_filter()
+        {
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1"
+                });
+                (await _subject.GetAsync("key1")).Should().BeNull();
+                (await _subject.GetAsync("key2")).Should().BeNull();
+                (await _subject.GetAsync("key3")).Should().BeNull();
+                (await _subject.GetAsync("key4")).Should().BeNull();
+                (await _subject.GetAsync("key5")).Should().BeNull();
+                (await _subject.GetAsync("key6")).Should().BeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub2"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().BeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub3"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client1"
+                });
+                (await _subject.GetAsync("key1")).Should().BeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().BeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client2"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().BeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client3"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().BeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client4"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().BeNull();
+                (await _subject.GetAsync("key6")).Should().BeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client5"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub2",
+                    ClientId = "client1"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client4"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().BeNull();
+                (await _subject.GetAsync("key6")).Should().BeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub3",
+                    ClientId = "client1"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client1",
+                    SessionId = "session1"
+                });
+                (await _subject.GetAsync("key1")).Should().BeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client1",
+                    SessionId = "session2"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().BeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client1",
+                    SessionId = "session3"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client2",
+                    SessionId = "session1"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().BeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client2",
+                    SessionId = "session2"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub1",
+                    ClientId = "client4",
+                    SessionId = "session4"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().BeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub2",
+                    ClientId = "client4",
+                    SessionId = "session4"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().BeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub2",
+                    ClientId = "client4",
+                    SessionId = "session1"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub2",
+                    ClientId = "client4",
+                    SessionId = "session5"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+            {
+                await Populate();
+                await _subject.RemoveAllAsync(new PersistedGrantFilter
+                {
+                    SubjectId = "sub3",
+                    ClientId = "client1",
+                    SessionId = "session1"
+                });
+                (await _subject.GetAsync("key1")).Should().NotBeNull();
+                (await _subject.GetAsync("key2")).Should().NotBeNull();
+                (await _subject.GetAsync("key3")).Should().NotBeNull();
+                (await _subject.GetAsync("key4")).Should().NotBeNull();
+                (await _subject.GetAsync("key5")).Should().NotBeNull();
+                (await _subject.GetAsync("key6")).Should().NotBeNull();
+                (await _subject.GetAsync("key7")).Should().NotBeNull();
+            }
+        }
+
+        private async Task Populate()
+        {
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key1", SubjectId = "sub1", ClientId = "client1", SessionId = "session1" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key2", SubjectId = "sub1", ClientId = "client2", SessionId = "session1" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key3", SubjectId = "sub1", ClientId = "client1", SessionId = "session2" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key4", SubjectId = "sub1", ClientId = "client3", SessionId = "session2" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key5", SubjectId = "sub1", ClientId = "client4", SessionId = "session3" });
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key6", SubjectId = "sub1", ClientId = "client4", SessionId = "session4" });
+
+            await _subject.StoreAsync(new PersistedGrant() { Key = "key7", SubjectId = "sub2", ClientId = "client4", SessionId = "session4" });
+        }
+    }
+}

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -18,10 +18,7 @@ using IdentityServer4.Models;
 using IdentityServer4.Services;
 using IdentityServer4.Stores;
 using IdentityServer4.Validation;
-using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
 

--- a/src/Storage/src/Extensions/IEnumerableExtensions.cs
+++ b/src/Storage/src/Extensions/IEnumerableExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Storage/src/Extensions/PersistedGrantFilterExtensions.cs
+++ b/src/Storage/src/Extensions/PersistedGrantFilterExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using IdentityServer4.Stores;
+using System;
+
+namespace IdentityServer4.Extensions
+{
+    /// <summary>
+    /// Extensions for PersistedGrantFilter.
+    /// </summary>
+    public static class PersistedGrantFilterExtensions
+    {
+        /// <summary>
+        /// Validates the PersistedGrantFilter and throws if invalid.
+        /// </summary>
+        /// <param name="filter"></param>
+        public static void Validate(this PersistedGrantFilter filter)
+        {
+            if (filter == null) throw new ArgumentNullException(nameof(filter));
+
+            if (String.IsNullOrWhiteSpace(filter.ClientId) &&
+                String.IsNullOrWhiteSpace(filter.SessionId) &&
+                String.IsNullOrWhiteSpace(filter.SubjectId) &&
+                String.IsNullOrWhiteSpace(filter.Type))
+            {
+                throw new ArgumentException("No filter values set.", nameof(filter));
+            }
+        }
+    }
+}

--- a/src/Storage/src/Models/Client.cs
+++ b/src/Storage/src/Models/Client.cs
@@ -3,10 +3,8 @@
 
 
 using System.Collections.Generic;
-using System.Security.Claims;
 using System.Linq;
 using System;
-using IdentityModel;
 using System.Collections;
 using System.Diagnostics;
 

--- a/src/Storage/src/Models/Resource.cs
+++ b/src/Storage/src/Models/Resource.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Extensions;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/src/Storage/src/Stores/IPersistedGrantStore.cs
+++ b/src/Storage/src/Stores/IPersistedGrantStore.cs
@@ -28,11 +28,11 @@ namespace IdentityServer4.Stores
         Task<PersistedGrant> GetAsync(string key);
 
         /// <summary>
-        /// Gets all grants for a given subject id.
+        /// Gets all grants based on the filter.
         /// </summary>
-        /// <param name="subjectId">The subject identifier.</param>
+        /// <param name="filter">The filter.</param>
         /// <returns></returns>
-        Task<IEnumerable<PersistedGrant>> GetAllAsync(string subjectId);
+        Task<IEnumerable<PersistedGrant>> GetAllAsync(PersistedGrantFilter filter);
 
         /// <summary>
         /// Removes the grant by key.
@@ -42,20 +42,10 @@ namespace IdentityServer4.Stores
         Task RemoveAsync(string key);
 
         /// <summary>
-        /// Removes all grants for a given subject id and client id combination.
+        /// Removes all grants based on the filter.
         /// </summary>
-        /// <param name="subjectId">The subject identifier.</param>
-        /// <param name="clientId">The client identifier.</param>
+        /// <param name="filter">The filter.</param>
         /// <returns></returns>
-        Task RemoveAllAsync(string subjectId, string clientId);
-
-        /// <summary>
-        /// Removes all grants of a give type for a given subject id and client id combination.
-        /// </summary>
-        /// <param name="subjectId">The subject identifier.</param>
-        /// <param name="clientId">The client identifier.</param>
-        /// <param name="type">The type.</param>
-        /// <returns></returns>
-        Task RemoveAllAsync(string subjectId, string clientId, string type);
+        Task RemoveAllAsync(PersistedGrantFilter filter);
     }
 }

--- a/src/Storage/src/Stores/PersistedGrantFilter.cs
+++ b/src/Storage/src/Stores/PersistedGrantFilter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+namespace IdentityServer4.Stores
+{
+    /// <summary>
+    /// Represents a filter used when accessing the persisted grants store. 
+    /// Setting multiple properties is interpreted as a logical 'AND' to further filter the query.
+    /// At least one value must be supplied.
+    /// </summary>
+    public class PersistedGrantFilter
+    {
+        /// <summary>
+        /// Subject id of the user.
+        /// </summary>
+        public string SubjectId { get; set; }
+        
+        /// <summary>
+        /// Session id used for the grant.
+        /// </summary>
+        public string SessionId { get; set; }
+        
+        /// <summary>
+        /// Client id the grant was issued to.
+        /// </summary>
+        public string ClientId { get; set; }
+        
+        /// <summary>
+        /// The type of grant.
+        /// </summary>
+        public string Type { get; set; }
+    }
+}

--- a/src/Storage/src/Stores/PersistedGrantFilter.cs
+++ b/src/Storage/src/Stores/PersistedGrantFilter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 namespace IdentityServer4.Stores
 {
     /// <summary>


### PR DESCRIPTION
Provides enhancements around persisted grants:
* Store GetAll and DeleteAll now accepts a filter object where sub, sid, clientId, and/or type can be used to filter the request
* InMemory and EF implementations updated for the new filter API
* PersistedGrantService updated to use session id in `RevokeTokensForCurrentSessionAsync` which makes more sense than previously. 