### PR TITLE
enhancements to add logout notification service as first class service

### DIFF
--- a/samples/Clients/src/MvcHybridBackChannel/Controllers/LogoutController.cs
+++ b/samples/Clients/src/MvcHybridBackChannel/Controllers/LogoutController.cs
@@ -76,15 +76,17 @@ namespace MvcHybrid.Controllers
             var keys = new List<SecurityKey>();
             foreach (var webKey in disco.KeySet.Keys)
             {
-                var e = Base64Url.Decode(webKey.E);
-                var n = Base64Url.Decode(webKey.N);
-
-                var key = new RsaSecurityKey(new RSAParameters { Exponent = e, Modulus = n })
+                if (webKey.Kty == "RSA")
                 {
-                    KeyId = webKey.Kid
-                };
+                    var e = Base64Url.Decode(webKey.E);
+                    var n = Base64Url.Decode(webKey.N);
 
-                keys.Add(key);
+                    var key = new RsaSecurityKey(new RSAParameters { Exponent = e, Modulus = n })
+                    {
+                        KeyId = webKey.Kid
+                    };
+                    keys.Add(key);
+                }
             }
 
             var parameters = new TokenValidationParameters

--- a/samples/Clients/src/MvcHybridBackChannel/Controllers/LogoutController.cs
+++ b/samples/Clients/src/MvcHybridBackChannel/Controllers/LogoutController.cs
@@ -76,17 +76,18 @@ namespace MvcHybrid.Controllers
             var keys = new List<SecurityKey>();
             foreach (var webKey in disco.KeySet.Keys)
             {
-                if (webKey.Kty == "RSA")
+                var key = new JsonWebKey()
                 {
-                    var e = Base64Url.Decode(webKey.E);
-                    var n = Base64Url.Decode(webKey.N);
-
-                    var key = new RsaSecurityKey(new RSAParameters { Exponent = e, Modulus = n })
-                    {
-                        KeyId = webKey.Kid
-                    };
-                    keys.Add(key);
-                }
+                    Kty = webKey.Kty,
+                    Alg = webKey.Alg,
+                    Kid = webKey.Kid,
+                    X = webKey.X,
+                    Y = webKey.Y,
+                    Crv = webKey.Crv,
+                    E = webKey.E,
+                    N = webKey.N,
+                };
+                keys.Add(key);
             }
 
             var parameters = new TokenValidationParameters

--- a/samples/Clients/src/MvcHybridBackChannel/Properties/launchSettings.json
+++ b/samples/Clients/src/MvcHybridBackChannel/Properties/launchSettings.json
@@ -3,10 +3,10 @@
     "Host": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:44303",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "https://localhost:44303"
     }
   }
 }

--- a/src/IdentityServer4/host/Configuration/ClientsWeb.cs
+++ b/src/IdentityServer4/host/Configuration/ClientsWeb.cs
@@ -119,7 +119,7 @@ namespace Host.Configuration
                     RequirePkce = false,
 
                     RedirectUris = { "https://localhost:44303/signin-oidc" },
-                    BackChannelLogoutUri = "http://localhost:44303/logout",
+                    BackChannelLogoutUri = "https://localhost:44303/logout",
                     PostLogoutRedirectUris = { "https://localhost:44303/signout-callback-oidc" },
 
                     AllowOfflineAccess = true,

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -360,13 +360,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 httpBuilder = builder.Services.AddHttpClient(name);
             }
 
-            builder.Services.AddTransient<BackChannelLogoutHttpClient>(s =>
+            builder.Services.AddTransient<IBackChannelLogoutHttpClient>(s =>
             {
                 var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
                 var httpClient = httpClientFactory.CreateClient(name);
                 var loggerFactory = s.GetRequiredService<ILoggerFactory>();
                 
-                return new BackChannelLogoutHttpClient(httpClient, loggerFactory);
+                return new DefaultBackChannelLogoutHttpClient(httpClient, loggerFactory);
             });
 
             return httpBuilder;

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -357,7 +357,10 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             else
             {
-                httpBuilder = builder.Services.AddHttpClient(name);
+                httpBuilder = builder.Services.AddHttpClient(name)
+                    .ConfigureHttpClient(client => {
+                        client.Timeout = TimeSpan.FromSeconds(IdentityServerConstants.HttpClients.DefaultTimeoutSeconds);
+                    });
             }
 
             builder.Services.AddTransient<IBackChannelLogoutHttpClient>(s =>
@@ -391,9 +394,12 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             else
             {
-                httpBuilder = builder.Services.AddHttpClient(name);
+                httpBuilder = builder.Services.AddHttpClient(name)
+                    .ConfigureHttpClient(client => {
+                        client.Timeout = TimeSpan.FromSeconds(IdentityServerConstants.HttpClients.DefaultTimeoutSeconds);
+                    });
             }
-            
+
             builder.Services.AddTransient<JwtRequestUriHttpClient>(s =>
             {
                 var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddTransient<IProfileService, DefaultProfileService>();
             builder.Services.TryAddTransient<IConsentMessageStore, ConsentMessageStore>();
             builder.Services.TryAddTransient<IMessageStore<LogoutMessage>, ProtectedDataMessageStore<LogoutMessage>>();
-            builder.Services.TryAddTransient<IMessageStore<EndSession>, ProtectedDataMessageStore<EndSession>>();
+            builder.Services.TryAddTransient<IMessageStore<LogoutNotificationContext>, ProtectedDataMessageStore<LogoutNotificationContext>>();
             builder.Services.TryAddTransient<IMessageStore<ErrorMessage>, ProtectedDataMessageStore<ErrorMessage>>();
             builder.Services.TryAddTransient<IIdentityServerInteractionService, DefaultIdentityServerInteractionService>();
             builder.Services.TryAddTransient<IDeviceFlowInteractionService, DefaultDeviceFlowInteractionService>();
@@ -170,6 +170,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddTransient<IEventSink, DefaultEventSink>();
             builder.Services.TryAddTransient<IUserCodeService, DefaultUserCodeService>();
             builder.Services.TryAddTransient<IUserCodeGenerator, NumericUserCodeGenerator>();
+            builder.Services.TryAddTransient<ILogoutNotificationService, LogoutNotificationService>();
             builder.Services.TryAddTransient<IBackChannelLogoutService, DefaultBackChannelLogoutService>();
             builder.Services.TryAddTransient<IResourceValidator, ResourceValidator>();
 

--- a/src/IdentityServer4/src/Endpoints/EndSessionCallbackEndpoint.cs
+++ b/src/IdentityServer4/src/Endpoints/EndSessionCallbackEndpoint.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
-using IdentityServer4.Services;
 using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -16,16 +15,13 @@ namespace IdentityServer4.Endpoints
     internal class EndSessionCallbackEndpoint : IEndpointHandler
     {
         private readonly IEndSessionRequestValidator _endSessionRequestValidator;
-        private readonly ILogoutNotificationService _logoutNotificationService;
         private readonly ILogger _logger;
 
         public EndSessionCallbackEndpoint(
             IEndSessionRequestValidator endSessionRequestValidator,
-            ILogoutNotificationService logoutNotificationService,
             ILogger<EndSessionCallbackEndpoint> logger)
         {
             _endSessionRequestValidator = endSessionRequestValidator;
-            _logoutNotificationService = logoutNotificationService;
             _logger = logger;
         }
 
@@ -45,13 +41,12 @@ namespace IdentityServer4.Endpoints
             if (!result.IsError)
             {
                 _logger.LogInformation("Successful signout callback.");
-
-                var frontChannel = await _logoutNotificationService.GetFrontChannelLogoutNotificationsUrlsAsync(result.LogoutContext);
-                await _logoutNotificationService.SendBackChannelLogoutNotificationsAsync(result.LogoutContext);
-                return new EndSessionCallbackResult(result, frontChannel);
             }
-
-            _logger.LogError("Error validating signout callback: {error}", result.Error);
+            else
+            {
+                _logger.LogError("Error validating signout callback: {error}", result.Error);
+            }
+            
             return new EndSessionCallbackResult(result);
         }
     }

--- a/src/IdentityServer4/src/Endpoints/EndSessionCallbackEndpoint.cs
+++ b/src/IdentityServer4/src/Endpoints/EndSessionCallbackEndpoint.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using System;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using IdentityServer4.Endpoints.Results;
@@ -18,16 +16,16 @@ namespace IdentityServer4.Endpoints
     internal class EndSessionCallbackEndpoint : IEndpointHandler
     {
         private readonly IEndSessionRequestValidator _endSessionRequestValidator;
-        private readonly IBackChannelLogoutService _backChannelClient;
+        private readonly ILogoutNotificationService _logoutNotificationService;
         private readonly ILogger _logger;
 
         public EndSessionCallbackEndpoint(
             IEndSessionRequestValidator endSessionRequestValidator,
-            IBackChannelLogoutService backChannelClient,
+            ILogoutNotificationService logoutNotificationService,
             ILogger<EndSessionCallbackEndpoint> logger)
         {
             _endSessionRequestValidator = endSessionRequestValidator;
-            _backChannelClient = backChannelClient;
+            _logoutNotificationService = logoutNotificationService;
             _logger = logger;
         }
 
@@ -44,49 +42,17 @@ namespace IdentityServer4.Endpoints
             var parameters = context.Request.Query.AsNameValueCollection();
             var result = await _endSessionRequestValidator.ValidateCallbackAsync(parameters);
 
-            if (result.IsError == false)
+            if (!result.IsError)
             {
                 _logger.LogInformation("Successful signout callback.");
 
-                if (result.FrontChannelLogoutUrls?.Any() == true)
-                {
-                    _logger.LogDebug("Client front-channel iframe urls: {urls}", result.FrontChannelLogoutUrls);
-                }
-                else
-                {
-                    _logger.LogDebug("No client front-channel iframe urls");
-                }
-
-                if (result.BackChannelLogouts?.Any() == true)
-                {
-
-                    _logger.LogDebug("Client back-channel iframe urls: {urls}", result.BackChannelLogouts.Select(x=>x.LogoutUri));
-                }
-                else
-                {
-                    _logger.LogDebug("No client back-channel iframe urls");
-                }
-
-                await InvokeBackChannelClientsAsync(result);
+                var frontChannel = await _logoutNotificationService.GetFrontChannelLogoutNotificationsUrlsAsync(result.LogoutContext);
+                await _logoutNotificationService.SendBackChannelLogoutNotificationsAsync(result.LogoutContext);
+                return new EndSessionCallbackResult(result, frontChannel);
             }
 
+            _logger.LogError("Error validating signout callback: {error}", result.Error);
             return new EndSessionCallbackResult(result);
-        }
-
-        private async Task InvokeBackChannelClientsAsync(EndSessionCallbackValidationResult result)
-        {
-            if (result.BackChannelLogouts?.Any() == true)
-            {
-                // best-effort, and async to not block the response to the browser
-                try
-                {
-                    await _backChannelClient.SendLogoutNotificationsAsync(result.BackChannelLogouts);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error calling backchannel sign-out urls");
-                }
-            }
         }
     }
 }

--- a/src/IdentityServer4/src/Endpoints/Results/EndSessionCallbackResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/EndSessionCallbackResult.cs
@@ -19,19 +19,16 @@ namespace IdentityServer4.Endpoints.Results
     internal class EndSessionCallbackResult : IEndpointResult
     {
         private readonly EndSessionCallbackValidationResult _result;
-        private readonly IEnumerable<string> _urls;
 
-        public EndSessionCallbackResult(EndSessionCallbackValidationResult result, IEnumerable<string> urls = null)
+        public EndSessionCallbackResult(EndSessionCallbackValidationResult result)
         {
             _result = result ?? throw new ArgumentNullException(nameof(result));
-            _urls = urls;
         }
 
         internal EndSessionCallbackResult(
             EndSessionCallbackValidationResult result,
-            IEnumerable<string> urls,
             IdentityServerOptions options)
-            : this(result, urls)
+            : this(result)
         {
             _options = options;
         }
@@ -47,7 +44,7 @@ namespace IdentityServer4.Endpoints.Results
         {
             Init(context);
 
-            if (_result?.IsError == true)
+            if (_result.IsError)
             {
                 context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
             }
@@ -66,7 +63,7 @@ namespace IdentityServer4.Endpoints.Results
             if (_options.Authentication.RequireCspFrameSrcForSignout)
             {
                 string frameSources = null;
-                var origins = _urls?.Select(x => x.GetOrigin());
+                var origins = _result.FrontChannelLogoutUrls?.Select(x => x.GetOrigin());
                 if (origins != null && origins.Any())
                 {
                     frameSources = origins.Distinct().Aggregate((x, y) => $"{x} {y}");
@@ -81,9 +78,9 @@ namespace IdentityServer4.Endpoints.Results
         {
             string framesHtml = null;
 
-            if (_urls?.Any() == true)
+            if (_result.FrontChannelLogoutUrls != null && _result.FrontChannelLogoutUrls.Any())
             {
-                var frameUrls = _urls.Select(url => $"<iframe src='{url}'></iframe>");
+                var frameUrls = _result.FrontChannelLogoutUrls.Select(url => $"<iframe src='{url}'></iframe>");
                 framesHtml = frameUrls.Aggregate((x, y) => x + y);
             }
 

--- a/src/IdentityServer4/src/Extensions/HttpContextExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/HttpContextExtensions.cs
@@ -159,7 +159,7 @@ namespace IdentityServer4.Extensions
             var user = await userSession.GetUserAsync();
             var currentSubId = user?.GetSubjectId();
 
-            EndSession endSessionMsg = null;
+            LogoutNotificationContext endSessionMsg = null;
 
             // if we have a logout message, then that take precedence over the current user
             if (logoutMessage?.ClientIds?.Any() == true)
@@ -173,7 +173,7 @@ namespace IdentityServer4.Extensions
                     clientIds = clientIds.Distinct();
                 }
 
-                endSessionMsg = new EndSession
+                endSessionMsg = new LogoutNotificationContext
                 {
                     SubjectId = logoutMessage.SubjectId,
                     SessionId = logoutMessage.SessionId,
@@ -186,7 +186,7 @@ namespace IdentityServer4.Extensions
                 var clientIds = await userSession.GetClientListAsync();
                 if (clientIds.Any())
                 {
-                    endSessionMsg = new EndSession
+                    endSessionMsg = new LogoutNotificationContext
                     {
                         SubjectId = currentSubId,
                         SessionId = await userSession.GetSessionIdAsync(),
@@ -198,9 +198,9 @@ namespace IdentityServer4.Extensions
             if (endSessionMsg != null)
             {
                 var clock = context.RequestServices.GetRequiredService<ISystemClock>();
-                var msg = new Message<EndSession>(endSessionMsg, clock.UtcNow.UtcDateTime);
+                var msg = new Message<LogoutNotificationContext>(endSessionMsg, clock.UtcNow.UtcDateTime);
 
-                var endSessionMessageStore = context.RequestServices.GetRequiredService<IMessageStore<EndSession>>();
+                var endSessionMessageStore = context.RequestServices.GetRequiredService<IMessageStore<LogoutNotificationContext>>();
                 var id = await endSessionMessageStore.WriteAsync(msg);
 
                 var signoutIframeUrl = context.GetIdentityServerBaseUrl().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.EndSessionCallback;

--- a/src/IdentityServer4/src/Extensions/IUserSessionExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/IUserSessionExtensions.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using IdentityServer4.Extensions;
+using IdentityServer4.Models;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.Services
+{
+    /// <summary>
+    /// Extension for IUserSession.
+    /// </summary>
+    public static class IUserSessionExtensions
+    {
+        /// <summary>
+        /// Creates a LogoutNotificationContext for the current user session.
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<LogoutNotificationContext> GetLogoutNotificationContext(this IUserSession session)
+        {
+            var clientIds = await session.GetClientListAsync();
+
+            if (clientIds.Any())
+            {
+                var user = await session.GetUserAsync();
+                var sub = user.GetSubjectId();
+                var sid = await session.GetSessionIdAsync();
+
+                return new LogoutNotificationContext
+                {
+                    SubjectId = sub,
+                    SessionId = sid,
+                    ClientIds = clientIds
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/IdentityServer4/src/Hosting/IdentityServerAuthenticationService.cs
+++ b/src/IdentityServer4/src/Hosting/IdentityServerAuthenticationService.cs
@@ -30,6 +30,7 @@ namespace IdentityServer4.Hosting
         private readonly IAuthenticationSchemeProvider _schemes;
         private readonly ISystemClock _clock;
         private readonly IUserSession _session;
+        private readonly IBackChannelLogoutService _backChannelLogoutService;
         private readonly IdentityServerOptions _options;
         private readonly ILogger<IdentityServerAuthenticationService> _logger;
 
@@ -38,6 +39,7 @@ namespace IdentityServer4.Hosting
             IAuthenticationSchemeProvider schemes,
             ISystemClock clock,
             IUserSession session,
+            IBackChannelLogoutService backChannelLogoutService,
             IdentityServerOptions options,
             ILogger<IdentityServerAuthenticationService> logger)
         {
@@ -46,6 +48,7 @@ namespace IdentityServer4.Hosting
             _schemes = schemes;
             _clock = clock;
             _session = session;
+            _backChannelLogoutService = backChannelLogoutService;
             _options = options;
             _logger = logger;
         }
@@ -83,6 +86,13 @@ namespace IdentityServer4.Hosting
             {
                 // this sets a flag used by the FederatedSignoutAuthenticationHandlerProvider
                 context.SetSignOutCalled();
+                
+                // back channel logout
+                var logoutContext = await _session.GetLogoutNotificationContext();
+                if (logoutContext != null)
+                {
+                    await _backChannelLogoutService.SendLogoutNotificationsAsync(logoutContext);
+                }
                 
                 // this clears our session id cookie so JS clients can detect the user has signed out
                 await _session.RemoveSessionIdCookieAsync();

--- a/src/IdentityServer4/src/IdentityServerConstants.cs
+++ b/src/IdentityServer4/src/IdentityServerConstants.cs
@@ -161,6 +161,7 @@ namespace IdentityServer4
 
         public static class HttpClients
         {
+            public const int DefaultTimeoutSeconds = 10;
             public const string JwtRequestUriHttpClient = "IdentityServer:JwtRequestUriClient";
             public const string BackChannelLogoutHttpClient = "IdentityServer:BackChannelLogoutClient";
         }

--- a/src/IdentityServer4/src/Models/Contexts/LogoutNotificationContext.cs
+++ b/src/IdentityServer4/src/Models/Contexts/LogoutNotificationContext.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 namespace IdentityServer4.Models
 {
     /// <summary>
-    /// Models the data necessary for end session to trigger single signout.
+    /// Provides the context necessary to construct a logout notificaiton.
     /// </summary>
-    public class EndSession
+    public class LogoutNotificationContext
     {
         /// <summary>
         ///  The SubjectId of the user.

--- a/src/IdentityServer4/src/Services/Default/BackChannelLogoutHttpClient.cs
+++ b/src/IdentityServer4/src/Services/Default/BackChannelLogoutHttpClient.cs
@@ -13,20 +13,20 @@ namespace IdentityServer4.Services
     /// <summary>
     /// Models making HTTP requests for back-channel logout notification.
     /// </summary>
-    public class BackChannelLogoutHttpClient
+    public class DefaultBackChannelLogoutHttpClient : IBackChannelLogoutHttpClient
     {
         private readonly HttpClient _client;
-        private readonly ILogger<BackChannelLogoutHttpClient> _logger;
+        private readonly ILogger<DefaultBackChannelLogoutHttpClient> _logger;
 
         /// <summary>
         /// Constructor for BackChannelLogoutHttpClient.
         /// </summary>
         /// <param name="client"></param>
         /// <param name="loggerFactory"></param>
-        public BackChannelLogoutHttpClient(HttpClient client, ILoggerFactory loggerFactory)
+        public DefaultBackChannelLogoutHttpClient(HttpClient client, ILoggerFactory loggerFactory)
         {
             _client = client;
-            _logger = loggerFactory.CreateLogger<BackChannelLogoutHttpClient>();
+            _logger = loggerFactory.CreateLogger<DefaultBackChannelLogoutHttpClient>();
         }
 
         /// <summary>

--- a/src/IdentityServer4/src/Services/Default/DefaultBackChannelLogoutService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultBackChannelLogoutService.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using IdentityModel;
-using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 
@@ -61,9 +60,9 @@ namespace IdentityServer4.Services
         }
 
         /// <inheritdoc/>
-        public virtual Task SendLogoutNotificationsAsync(IEnumerable<BackChannelLogoutModel> clients)
+        public virtual Task SendLogoutNotificationsAsync(IEnumerable<BackChannelLogoutRequest> clients)
         {
-            clients = clients ?? Enumerable.Empty<BackChannelLogoutModel>();
+            clients = clients ?? Enumerable.Empty<BackChannelLogoutRequest>();
             var tasks = clients.Select(SendLogoutNotificationAsync).ToArray();
             return Task.WhenAll(tasks);
         }
@@ -72,7 +71,7 @@ namespace IdentityServer4.Services
         /// Performs the back-channel logout for a single client.
         /// </summary>
         /// <param name="client"></param>
-        protected virtual async Task SendLogoutNotificationAsync(BackChannelLogoutModel client)
+        protected virtual async Task SendLogoutNotificationAsync(BackChannelLogoutRequest client)
         {
             var data = await CreateFormPostPayloadAsync(client);
             await HttpClient.PostAsync(client.LogoutUri, data);
@@ -83,7 +82,7 @@ namespace IdentityServer4.Services
         /// </summary>
         /// <param name="client"></param>
         /// <returns></returns>
-        protected async Task<Dictionary<string, string>> CreateFormPostPayloadAsync(BackChannelLogoutModel client)
+        protected async Task<Dictionary<string, string>> CreateFormPostPayloadAsync(BackChannelLogoutRequest client)
         {
             var token = await CreateTokenAsync(client);
 
@@ -99,7 +98,7 @@ namespace IdentityServer4.Services
         /// </summary>
         /// <param name="client"></param>
         /// <returns>The token.</returns>
-        protected virtual async Task<string> CreateTokenAsync(BackChannelLogoutModel client)
+        protected virtual async Task<string> CreateTokenAsync(BackChannelLogoutRequest client)
         {
             var claims = await CreateClaimsForTokenAsync(client);
             if (claims.Any(x => x.Type == JwtClaimTypes.Nonce))
@@ -115,7 +114,7 @@ namespace IdentityServer4.Services
         /// </summary>
         /// <param name="client"></param>
         /// <returns>The claims to include in the token.</returns>
-        protected Task<IEnumerable<Claim>> CreateClaimsForTokenAsync(BackChannelLogoutModel client)
+        protected Task<IEnumerable<Claim>> CreateClaimsForTokenAsync(BackChannelLogoutRequest client)
         {
             var json = "{\"" + OidcConstants.Events.BackChannelLogout + "\":{} }";
 

--- a/src/IdentityServer4/src/Services/Default/DefaultBackChannelLogoutService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultBackChannelLogoutService.cs
@@ -42,7 +42,7 @@ namespace IdentityServer4.Services
         /// <summary>
         /// HttpClient to make the outbound HTTP calls.
         /// </summary>
-        protected BackChannelLogoutHttpClient HttpClient { get; }
+        protected IBackChannelLogoutHttpClient HttpClient { get; }
 
         /// <summary>
         /// The logger.
@@ -61,7 +61,7 @@ namespace IdentityServer4.Services
             ISystemClock clock,
             IdentityServerTools tools,
             ILogoutNotificationService logoutNotificationService,
-            BackChannelLogoutHttpClient backChannelLogoutHttpClient,
+            IBackChannelLogoutHttpClient backChannelLogoutHttpClient,
             ILogger<IBackChannelLogoutService> logger)
         {
             Clock = clock;

--- a/src/IdentityServer4/src/Services/Default/LogoutNotificationService.cs
+++ b/src/IdentityServer4/src/Services/Default/LogoutNotificationService.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityModel;
+using IdentityServer4.Extensions;
+using IdentityServer4.Models;
+using IdentityServer4.Stores;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.Services
+{
+    /// <summary>
+    /// Default implementation of logout notification service.
+    /// </summary>
+    public class LogoutNotificationService : ILogoutNotificationService
+    {
+        private readonly IClientStore _clientStore;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IBackChannelLogoutService _backChannelLogoutService;
+        private readonly ILogger<LogoutNotificationService> _logger;
+
+
+        /// <summary>
+        /// Ctor.
+        /// </summary>
+        public LogoutNotificationService(
+            IClientStore clientStore,
+            IHttpContextAccessor httpContextAccessor, 
+            IBackChannelLogoutService backChannelLogoutService,
+            ILogger<LogoutNotificationService> logger)
+        {
+            _clientStore = clientStore;
+            _httpContextAccessor = httpContextAccessor;
+            _backChannelLogoutService = backChannelLogoutService;
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<string>> GetFrontChannelLogoutNotificationsUrlsAsync(LogoutNotificationContext context)
+        {
+            var frontChannelUrls = new List<string>();
+            foreach (var clientId in context.ClientIds)
+            {
+                var client = await _clientStore.FindEnabledClientByIdAsync(clientId);
+                if (client != null)
+                {
+                    if (client.FrontChannelLogoutUri.IsPresent())
+                    {
+                        var url = client.FrontChannelLogoutUri;
+
+                        // add session id if required
+                        if (client.ProtocolType == IdentityServerConstants.ProtocolTypes.OpenIdConnect)
+                        {
+                            if (client.FrontChannelLogoutSessionRequired)
+                            {
+                                url = url.AddQueryString(OidcConstants.EndSessionRequest.Sid, context.SessionId);
+                                url = url.AddQueryString(OidcConstants.EndSessionRequest.Issuer, _httpContextAccessor.HttpContext.GetIdentityServerIssuerUri());
+                            }
+                        }
+                        else if (client.ProtocolType == IdentityServerConstants.ProtocolTypes.WsFederation)
+                        {
+                            url = url.AddQueryString(Constants.WsFedSignOut.LogoutUriParameterName, Constants.WsFedSignOut.LogoutUriParameterValue);
+                        }
+
+                        frontChannelUrls.Add(url);
+                    }
+                }
+            }
+
+            if (frontChannelUrls.Any())
+            {
+                var msg = frontChannelUrls.Aggregate((x, y) => x + ", " + y);
+                _logger.LogDebug("Client front-channel logout URLs: {0}", msg);
+            }
+            else
+            {
+                _logger.LogDebug("No client front-channel logout URLs");
+            }
+
+            return frontChannelUrls;
+        }
+
+        /// <inheritdoc/>
+        public async Task SendBackChannelLogoutNotificationsAsync(LogoutNotificationContext context)
+        {
+            var backChannelLogouts = new List<BackChannelLogoutRequest>();
+            foreach (var clientId in context.ClientIds)
+            {
+                var client = await _clientStore.FindEnabledClientByIdAsync(clientId);
+                if (client != null)
+                {
+                    if (client.BackChannelLogoutUri.IsPresent())
+                    {
+                        var back = new BackChannelLogoutRequest
+                        {
+                            ClientId = clientId,
+                            LogoutUri = client.BackChannelLogoutUri,
+                            SubjectId = context.SubjectId,
+                            SessionId = context.SessionId,
+                            SessionIdRequired = client.BackChannelLogoutSessionRequired
+                        };
+
+                        backChannelLogouts.Add(back);
+                    }
+                }
+            }
+
+            if (backChannelLogouts.Any())
+            {
+                var msg = backChannelLogouts.Select(x => x.LogoutUri).Aggregate((x, y) => x + ", " + y);
+                _logger.LogDebug("Client back-channel logout URLs: {0}", msg);
+
+                // best-effort
+                try
+                {
+                    await _backChannelLogoutService.SendLogoutNotificationsAsync(backChannelLogouts);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error calling backchannel sign-out urls");
+                }
+            }
+            else
+            {
+                _logger.LogDebug("No client back-channel logout URLs");
+            }
+        }
+    }
+}

--- a/src/IdentityServer4/src/Services/IBackChannelLogoutHttpClient.cs
+++ b/src/IdentityServer4/src/Services/IBackChannelLogoutHttpClient.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.Services
+{
+    /// <summary>
+    /// Models making HTTP requests for back-channel logout notification.
+    /// </summary>
+    public interface IBackChannelLogoutHttpClient
+    {
+        /// <summary>
+        /// Performs HTTP POST.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="payload"></param>
+        /// <returns></returns>
+        Task PostAsync(string url, Dictionary<string, string> payload);
+    }
+}

--- a/src/IdentityServer4/src/Services/IBackChannelLogoutService.cs
+++ b/src/IdentityServer4/src/Services/IBackChannelLogoutService.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Validation;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -17,6 +16,37 @@ namespace IdentityServer4.Services
         /// Performs the http back-channel logout request notifications for the collection of clients.
         /// </summary>
         /// <param name="clients">The collection of clients that require back channel signout notifications for this session.</param>
-        Task SendLogoutNotificationsAsync(IEnumerable<BackChannelLogoutModel> clients);
+        Task SendLogoutNotificationsAsync(IEnumerable<BackChannelLogoutRequest> clients);
+    }
+
+    /// <summary>
+    /// Information necessary to make a back-channel logout request to a client.
+    /// </summary>
+    public class BackChannelLogoutRequest
+    {
+        /// <summary>
+        /// Gets or sets the client identifier.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets the subject identifier.
+        /// </summary>
+        public string SubjectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the session identifier.
+        /// </summary>
+        public string SessionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the back channel logout URI.
+        /// </summary>
+        public string LogoutUri { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the session identifier is required.
+        /// </summary>
+        public bool SessionIdRequired { get; set; }
     }
 }

--- a/src/IdentityServer4/src/Services/IBackChannelLogoutService.cs
+++ b/src/IdentityServer4/src/Services/IBackChannelLogoutService.cs
@@ -2,51 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using System.Collections.Generic;
+using IdentityServer4.Models;
 using System.Threading.Tasks;
 
 namespace IdentityServer4.Services
 {
     /// <summary>
-    /// The service responsible for performing back-channel signout requests.
+    /// The service responsible for performing back-channel logout notification.
     /// </summary>
     public interface IBackChannelLogoutService
     {
         /// <summary>
-        /// Performs the http back-channel logout request notifications for the collection of clients.
+        /// Performs http back-channel logout notification.
         /// </summary>
-        /// <param name="clients">The collection of clients that require back channel signout notifications for this session.</param>
-        Task SendLogoutNotificationsAsync(IEnumerable<BackChannelLogoutRequest> clients);
+        /// <param name="context">The context of the back channel logout notification.</param>
+        Task SendLogoutNotificationsAsync(LogoutNotificationContext context);
     }
 
-    /// <summary>
-    /// Information necessary to make a back-channel logout request to a client.
-    /// </summary>
-    public class BackChannelLogoutRequest
-    {
-        /// <summary>
-        /// Gets or sets the client identifier.
-        /// </summary>
-        public string ClientId { get; set; }
-
-        /// <summary>
-        /// Gets the subject identifier.
-        /// </summary>
-        public string SubjectId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the session identifier.
-        /// </summary>
-        public string SessionId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the back channel logout URI.
-        /// </summary>
-        public string LogoutUri { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether the session identifier is required.
-        /// </summary>
-        public bool SessionIdRequired { get; set; }
-    }
+    
 }

--- a/src/IdentityServer4/src/Services/ILogoutNotificationService.cs
+++ b/src/IdentityServer4/src/Services/ILogoutNotificationService.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityServer4.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.Services
+{
+    /// <summary>
+    /// Provides features for OIDC signout notifications.
+    /// </summary>
+    public interface ILogoutNotificationService
+    {
+        /// <summary>
+        /// Builds the URLs needed for front-channel logout notification.
+        /// </summary>
+        /// <param name="context">The context for the logout notification.</param>
+        Task<IEnumerable<string>> GetFrontChannelLogoutNotificationsUrlsAsync(LogoutNotificationContext context);
+
+        /// <summary>
+        /// Performs the http back-channel logout request notifications for the collection of clients.
+        /// </summary>
+        /// <param name="context">The context for the logout notification.</param>
+        Task SendBackChannelLogoutNotificationsAsync(LogoutNotificationContext context);
+    }
+}

--- a/src/IdentityServer4/src/Services/ILogoutNotificationService.cs
+++ b/src/IdentityServer4/src/Services/ILogoutNotificationService.cs
@@ -19,9 +19,41 @@ namespace IdentityServer4.Services
         Task<IEnumerable<string>> GetFrontChannelLogoutNotificationsUrlsAsync(LogoutNotificationContext context);
 
         /// <summary>
-        /// Performs the http back-channel logout request notifications for the collection of clients.
+        /// Builds the http back-channel logout request data for the collection of clients.
         /// </summary>
         /// <param name="context">The context for the logout notification.</param>
-        Task SendBackChannelLogoutNotificationsAsync(LogoutNotificationContext context);
+        Task<IEnumerable<BackChannelLogoutRequest>> GetBackChannelLogoutNotificationsAsync(LogoutNotificationContext context);
     }
+
+    /// <summary>
+    /// Information necessary to make a back-channel logout request to a client.
+    /// </summary>
+    public class BackChannelLogoutRequest
+    {
+        /// <summary>
+        /// Gets or sets the client identifier.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets the subject identifier.
+        /// </summary>
+        public string SubjectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the session identifier.
+        /// </summary>
+        public string SessionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the back channel logout URI.
+        /// </summary>
+        public string LogoutUri { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the session identifier is required.
+        /// </summary>
+        public bool SessionIdRequired { get; set; }
+    }
+
 }

--- a/src/IdentityServer4/src/Validation/Models/EndSessionCallbackValidationResult.cs
+++ b/src/IdentityServer4/src/Validation/Models/EndSessionCallbackValidationResult.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Models;
 using System.Collections.Generic;
 
 namespace IdentityServer4.Validation
@@ -14,8 +13,8 @@ namespace IdentityServer4.Validation
     public class EndSessionCallbackValidationResult : ValidationResult
     {
         /// <summary>
-        /// The context of the logout.
+        /// Gets the client front-channel logout urls.
         /// </summary>
-        public LogoutNotificationContext LogoutContext { get; set; }
+        public IEnumerable<string> FrontChannelLogoutUrls { get; set; }
     }
 }

--- a/src/IdentityServer4/src/Validation/Models/EndSessionCallbackValidationResult.cs
+++ b/src/IdentityServer4/src/Validation/Models/EndSessionCallbackValidationResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using IdentityServer4.Models;
 using System.Collections.Generic;
 
 namespace IdentityServer4.Validation
@@ -13,44 +14,8 @@ namespace IdentityServer4.Validation
     public class EndSessionCallbackValidationResult : ValidationResult
     {
         /// <summary>
-        /// Gets the client front-channel logout urls.
+        /// The context of the logout.
         /// </summary>
-        public IEnumerable<string> FrontChannelLogoutUrls { get; set; }
-        
-        /// <summary>
-        /// Gets the client back-channel logouts.
-        /// </summary>
-        public IEnumerable<BackChannelLogoutModel> BackChannelLogouts { get; set; }
-    }
-
-    /// <summary>
-    /// Information necessary to make a back-channel logout request to a client.
-    /// </summary>
-    public class BackChannelLogoutModel
-    {
-        /// <summary>
-        /// Gets or sets the client identifier.
-        /// </summary>
-        public string ClientId { get; set; }
-
-        /// <summary>
-        /// Gets the subject identifier.
-        /// </summary>
-        public string SubjectId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the session identifier.
-        /// </summary>
-        public string SessionId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the back channel logout URI.
-        /// </summary>
-        public string LogoutUri { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether the session identifier is required.
-        /// </summary>
-        public bool SessionIdRequired { get; set; }
+        public LogoutNotificationContext LogoutContext { get; set; }
     }
 }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -143,11 +143,10 @@ namespace IdentityServer.IntegrationTests.Common
             .AddTestUsers(Users)
             .AddDeveloperSigningCredential(persistKey: false);
 
-            services.AddHttpClient()
-                .AddHttpClient<BackChannelLogoutHttpClient>()
+            services.AddHttpClient(IdentityServerConstants.HttpClients.BackChannelLogoutHttpClient)
                 .AddHttpMessageHandler(() => BackChannelMessageHandler);
 
-            services.AddHttpClient<JwtRequestUriHttpClient>()
+            services.AddHttpClient(IdentityServerConstants.HttpClients.JwtRequestUriHttpClient)
                 .AddHttpMessageHandler(() => JwtRequestMessageHandler);
 
             OnPostConfigureServices(services);

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -220,6 +220,7 @@ namespace IdentityServer.IntegrationTests.Common
         {
             LogoutWasCalled = true;
             await ReadLogoutRequest(ctx);
+            await ctx.SignOutAsync();
         }
 
         private async Task ReadLogoutRequest(HttpContext ctx)

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
@@ -545,9 +545,6 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
 
             await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint);
 
-            var signoutFrameUrl = _mockPipeline.LogoutRequest.SignOutIFrameUrl;
-            await _mockPipeline.BrowserClient.GetAsync(signoutFrameUrl);
-
             _mockPipeline.BackChannelMessageHandler.InvokeWasCalled.Should().BeTrue();
         }
 
@@ -569,9 +566,6 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
             response.Should().NotBeNull();
 
             await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint);
-
-            var signoutFrameUrl = _mockPipeline.LogoutRequest.SignOutIFrameUrl;
-            await _mockPipeline.BrowserClient.GetAsync(signoutFrameUrl);
 
             _mockPipeline.BackChannelMessageHandler.InvokeWasCalled.Should().BeTrue();
         }

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Common/MockHttpContextAccessor.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Common/MockHttpContextAccessor.cs
@@ -22,7 +22,7 @@ namespace IdentityServer.UnitTests.Common
         public MockHttpContextAccessor(
             IdentityServerOptions options = null,
             IUserSession userSession = null,
-            IMessageStore<EndSession> endSessionStore = null)
+            IMessageStore<LogoutNotificationContext> endSessionStore = null)
         {
             options = options ?? TestIdentityServerOptions.Create();
 
@@ -48,7 +48,7 @@ namespace IdentityServer.UnitTests.Common
 
             if (endSessionStore == null)
             {
-                services.AddTransient<IMessageStore<EndSession>, ProtectedDataMessageStore<EndSession>>();
+                services.AddTransient<IMessageStore<LogoutNotificationContext>, ProtectedDataMessageStore<LogoutNotificationContext>>();
             }
             else
             {

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Common/MockLogoutNotificationService.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Common/MockLogoutNotificationService.cs
@@ -1,9 +1,7 @@
 ﻿using IdentityServer4.Models;
 using IdentityServer4.Services;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace IdentityServer.UnitTests.Common
@@ -13,18 +11,19 @@ namespace IdentityServer.UnitTests.Common
         public bool GetFrontChannelLogoutNotificationsUrlsCalled { get; set; }
         public List<string> FrontChannelLogoutNotificationsUrls { get; set; } = new List<string>();
 
+        public bool SendBackChannelLogoutNotificationsCalled { get; set; }
+        public List<BackChannelLogoutRequest> BackChannelLogoutRequests { get; set; } = new List<BackChannelLogoutRequest>();
+
         public Task<IEnumerable<string>> GetFrontChannelLogoutNotificationsUrlsAsync(LogoutNotificationContext context)
         {
             GetFrontChannelLogoutNotificationsUrlsCalled = true;
             return Task.FromResult(FrontChannelLogoutNotificationsUrls.AsEnumerable());
         }
 
-        public bool SendBackChannelLogoutNotificationsCalled { get; set; }
-
-        public Task SendBackChannelLogoutNotificationsAsync(LogoutNotificationContext context)
+        public Task<IEnumerable<BackChannelLogoutRequest>> GetBackChannelLogoutNotificationsAsync(LogoutNotificationContext context)
         {
             SendBackChannelLogoutNotificationsCalled = true;
-            return Task.CompletedTask;
+            return Task.FromResult(BackChannelLogoutRequests.AsEnumerable());
         }
     }
 }

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Common/MockLogoutNotificationService.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Common/MockLogoutNotificationService.cs
@@ -1,0 +1,30 @@
+﻿using IdentityServer4.Models;
+using IdentityServer4.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IdentityServer.UnitTests.Common
+{
+    public class MockLogoutNotificationService : ILogoutNotificationService
+    {
+        public bool GetFrontChannelLogoutNotificationsUrlsCalled { get; set; }
+        public List<string> FrontChannelLogoutNotificationsUrls { get; set; } = new List<string>();
+
+        public Task<IEnumerable<string>> GetFrontChannelLogoutNotificationsUrlsAsync(LogoutNotificationContext context)
+        {
+            GetFrontChannelLogoutNotificationsUrlsCalled = true;
+            return Task.FromResult(FrontChannelLogoutNotificationsUrls.AsEnumerable());
+        }
+
+        public bool SendBackChannelLogoutNotificationsCalled { get; set; }
+
+        public Task SendBackChannelLogoutNotificationsAsync(LogoutNotificationContext context)
+        {
+            SendBackChannelLogoutNotificationsCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackEndpointTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackEndpointTests.cs
@@ -17,7 +17,6 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
     {
         private const string Category = "End Session Callback Endpoint";
 
-        MockLogoutNotificationService _mockLogoutNotificationService = new MockLogoutNotificationService();
         StubEndSessionRequestValidator _stubEndSessionRequestValidator = new StubEndSessionRequestValidator();
         EndSessionCallbackEndpoint _subject;
 
@@ -25,44 +24,7 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
         {
             _subject = new EndSessionCallbackEndpoint(
                 _stubEndSessionRequestValidator,
-                _mockLogoutNotificationService,
                 new LoggerFactory().CreateLogger<EndSessionCallbackEndpoint>());
-        }
-
-        [Fact]
-        public async Task callback_validation_success_should_invoke_back_channel_clients()
-        {
-            var ctx = new DefaultHttpContext();
-            ctx.Request.Method = "GET";
-
-            _stubEndSessionRequestValidator.EndSessionCallbackValidationResult.IsError = false;
-            _stubEndSessionRequestValidator.EndSessionCallbackValidationResult.LogoutContext = new LogoutNotificationContext()
-            {
-                SubjectId = "sub", SessionId = "sid", ClientIds = new[] { "client" }
-            };
-
-            var result = await _subject.ProcessAsync(ctx);
-
-            // this is a deliberable hack since we have a fire-and-forget to calling back-channel clients
-            await Task.Delay(100);
-
-            _mockLogoutNotificationService.SendBackChannelLogoutNotificationsCalled.Should().BeTrue();
-        }
-
-        [Fact]
-        public async Task callback_validation_error_should_not_invoke_back_channel_clients()
-        {
-            var ctx = new DefaultHttpContext();
-            ctx.Request.Method = "GET";
-
-            _stubEndSessionRequestValidator.EndSessionCallbackValidationResult.IsError = true;
-
-            var result = await _subject.ProcessAsync(ctx);
-
-            // this is a deliberable hack since we have a fire-and-forget to calling back-channel clients
-            await Task.Delay(100);
-
-            _mockLogoutNotificationService.SendBackChannelLogoutNotificationsCalled.Should().BeFalse();
         }
     }
 }

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackResultTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackResultTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -18,6 +19,7 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
         private const string Category = "End Session Callback Result";
 
         private readonly EndSessionCallbackValidationResult _validationResult;
+        private readonly List<string> _urls = new List<string>();
         private readonly IdentityServerOptions _options;
         private readonly EndSessionCallbackResult _subject;
 
@@ -28,13 +30,13 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
                 IsError = false,
             };
             _options = new IdentityServerOptions();
-            _subject = new EndSessionCallbackResult(_validationResult, _options);
+            _subject = new EndSessionCallbackResult(_validationResult, _urls, _options);
         }
 
         [Fact]
         public async Task default_options_should_emit_frame_src_csp_headers()
         {
-            _validationResult.FrontChannelLogoutUrls = new[] { "http://foo" };
+            _urls.AddRange(new[] { "http://foo" });
 
             var ctx = new DefaultHttpContext();
             ctx.Request.Method = "GET";
@@ -48,7 +50,7 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
         public async Task relax_csp_options_should_prevent_frame_src_csp_headers()
         {
             _options.Authentication.RequireCspFrameSrcForSignout = false;
-            _validationResult.FrontChannelLogoutUrls = new[] { "http://foo" };
+            _urls.AddRange(new[] { "http://foo" });
 
             var ctx = new DefaultHttpContext();
             ctx.Request.Method = "GET";

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackResultTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackResultTests.cs
@@ -19,7 +19,6 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
         private const string Category = "End Session Callback Result";
 
         private readonly EndSessionCallbackValidationResult _validationResult;
-        private readonly List<string> _urls = new List<string>();
         private readonly IdentityServerOptions _options;
         private readonly EndSessionCallbackResult _subject;
 
@@ -30,13 +29,13 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
                 IsError = false,
             };
             _options = new IdentityServerOptions();
-            _subject = new EndSessionCallbackResult(_validationResult, _urls, _options);
+            _subject = new EndSessionCallbackResult(_validationResult, _options);
         }
 
         [Fact]
         public async Task default_options_should_emit_frame_src_csp_headers()
         {
-            _urls.AddRange(new[] { "http://foo" });
+            _validationResult.FrontChannelLogoutUrls = new[] { "http://foo" };
 
             var ctx = new DefaultHttpContext();
             ctx.Request.Method = "GET";
@@ -50,7 +49,7 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
         public async Task relax_csp_options_should_prevent_frame_src_csp_headers()
         {
             _options.Authentication.RequireCspFrameSrcForSignout = false;
-            _urls.AddRange(new[] { "http://foo" });
+            _validationResult.FrontChannelLogoutUrls = new[] { "http://foo" };
 
             var ctx = new DefaultHttpContext();
             ctx.Request.Method = "GET";

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/StubBackChannelLogoutClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/StubBackChannelLogoutClient.cs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
+using IdentityServer4.Models;
 using IdentityServer4.Services;
-using IdentityServer4.Validation;
 
 namespace IdentityServer.UnitTests.Endpoints.EndSession
 {
@@ -13,7 +12,7 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
     {
         public bool SendLogoutsWasCalled { get; set; }
 
-        public Task SendLogoutNotificationsAsync(IEnumerable<BackChannelLogoutRequest> clients)
+        public Task SendLogoutNotificationsAsync(LogoutNotificationContext context)
         {
             SendLogoutsWasCalled = true;
             return Task.CompletedTask;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/StubBackChannelLogoutClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/EndSession/StubBackChannelLogoutClient.cs
@@ -13,7 +13,7 @@ namespace IdentityServer.UnitTests.Endpoints.EndSession
     {
         public bool SendLogoutsWasCalled { get; set; }
 
-        public Task SendLogoutNotificationsAsync(IEnumerable<BackChannelLogoutModel> clients)
+        public Task SendLogoutNotificationsAsync(IEnumerable<BackChannelLogoutRequest> clients)
         {
             SendLogoutsWasCalled = true;
             return Task.CompletedTask;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,7 +23,7 @@ namespace IdentityServer.UnitTests.Endpoints.Results
         private EndSessionCallbackResult _subject;
 
         private EndSessionCallbackValidationResult _result = new EndSessionCallbackValidationResult();
-        private MockUserSession _mockUserSession = new MockUserSession();
+        private List<string> _urls = new List<string>();
         private IdentityServerOptions _options = TestIdentityServerOptions.Create();
 
         private DefaultHttpContext _context = new DefaultHttpContext();
@@ -33,7 +34,7 @@ namespace IdentityServer.UnitTests.Endpoints.Results
             _context.SetIdentityServerBasePath("/");
             _context.Response.Body = new MemoryStream();
 
-            _subject = new EndSessionCallbackResult(_result, _options);
+            _subject = new EndSessionCallbackResult(_result, _urls, _options);
         }
 
         [Fact]
@@ -50,7 +51,7 @@ namespace IdentityServer.UnitTests.Endpoints.Results
         public async Task success_should_render_html_and_iframes()
         {
             _result.IsError = false;
-            _result.FrontChannelLogoutUrls = new string[] { "http://foo.com", "http://bar.com" };
+            _urls.AddRange(new string[] { "http://foo.com", "http://bar.com" });
 
             await _subject.ExecuteAsync(_context);
 

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
@@ -23,7 +23,6 @@ namespace IdentityServer.UnitTests.Endpoints.Results
         private EndSessionCallbackResult _subject;
 
         private EndSessionCallbackValidationResult _result = new EndSessionCallbackValidationResult();
-        private List<string> _urls = new List<string>();
         private IdentityServerOptions _options = TestIdentityServerOptions.Create();
 
         private DefaultHttpContext _context = new DefaultHttpContext();
@@ -34,7 +33,7 @@ namespace IdentityServer.UnitTests.Endpoints.Results
             _context.SetIdentityServerBasePath("/");
             _context.Response.Body = new MemoryStream();
 
-            _subject = new EndSessionCallbackResult(_result, _urls, _options);
+            _subject = new EndSessionCallbackResult(_result, _options);
         }
 
         [Fact]
@@ -51,7 +50,7 @@ namespace IdentityServer.UnitTests.Endpoints.Results
         public async Task success_should_render_html_and_iframes()
         {
             _result.IsError = false;
-            _urls.AddRange(new string[] { "http://foo.com", "http://bar.com" });
+            _result.FrontChannelLogoutUrls = new string[] { "http://foo.com", "http://bar.com" };
 
             await _subject.ExecuteAsync(_context);
 

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultIdentityServerInteractionServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultIdentityServerInteractionServiceTests.cs
@@ -22,7 +22,7 @@ namespace IdentityServer.UnitTests.Services.Default
 
         private IdentityServerOptions _options = new IdentityServerOptions();
         private MockHttpContextAccessor _mockMockHttpContextAccessor;
-        private MockMessageStore<EndSession> _mockEndSessionStore = new MockMessageStore<EndSession>();
+        private MockMessageStore<LogoutNotificationContext> _mockEndSessionStore = new MockMessageStore<LogoutNotificationContext>();
         private MockMessageStore<LogoutMessage> _mockLogoutMessageStore = new MockMessageStore<LogoutMessage>();
         private MockMessageStore<ErrorMessage> _mockErrorMessageStore = new MockMessageStore<ErrorMessage>();
         private MockConsentMessageStore _mockConsentStore = new MockConsentMessageStore();

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/EndSessionRequestValidatorTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/EndSessionRequestValidatorTests.cs
@@ -26,7 +26,7 @@ namespace IdentityServer.UnitTests.Validation.EndSessionRequestValidation
         private StubRedirectUriValidator _stubRedirectUriValidator = new StubRedirectUriValidator();
         private MockHttpContextAccessor _context = new MockHttpContextAccessor();
         private MockUserSession _userSession = new MockUserSession();
-        private MockMessageStore<EndSession> _mockEndSessionMessageStore = new MockMessageStore<EndSession>();
+        private MockMessageStore<LogoutNotificationContext> _mockEndSessionMessageStore = new MockMessageStore<LogoutNotificationContext>();
         private InMemoryClientStore _clientStore;
 
         private ClaimsPrincipal _user;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/EndSessionRequestValidatorTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/EndSessionRequestValidatorTests.cs
@@ -26,15 +26,14 @@ namespace IdentityServer.UnitTests.Validation.EndSessionRequestValidation
         private StubRedirectUriValidator _stubRedirectUriValidator = new StubRedirectUriValidator();
         private MockHttpContextAccessor _context = new MockHttpContextAccessor();
         private MockUserSession _userSession = new MockUserSession();
+        private MockLogoutNotificationService _mockLogoutNotificationService = new MockLogoutNotificationService();
         private MockMessageStore<LogoutNotificationContext> _mockEndSessionMessageStore = new MockMessageStore<LogoutNotificationContext>();
-        private InMemoryClientStore _clientStore;
 
         private ClaimsPrincipal _user;
 
         public EndSessionRequestValidatorTests()
         {
             _user = new IdentityServerUser("alice").CreatePrincipal();
-            _clientStore = new InMemoryClientStore(new Client[0]);
 
             _options = TestIdentityServerOptions.Create();
             _subject = new EndSessionRequestValidator(
@@ -43,7 +42,7 @@ namespace IdentityServer.UnitTests.Validation.EndSessionRequestValidation
                 _stubTokenValidator,
                 _stubRedirectUriValidator,
                 _userSession,
-                _clientStore,
+                _mockLogoutNotificationService,
                 _mockEndSessionMessageStore,
                 TestLogger.Create<EndSessionRequestValidator>());
         }


### PR DESCRIPTION
Mainly to allow back channel signout notifications to be triggered explicitly via the `IBackChannelLogoutService` and provide a formal service to build logout notifications from a sessions via the new `ILogoutNotificationService`. This then allowed rework/cleanup of the existing end session callback flow.