### PR TITLE
Update cors.rst for .NET Core 3.1

### DIFF
--- a/docs/topics/cors.rst
+++ b/docs/topics/cors.rst
@@ -32,11 +32,12 @@ If you simply wish to hard-code a set of allowed origins, then there is a pre-bu
 This would be configured as a singleton in DI, and hard-coded with its ``AllowedOrigins`` collection, or setting the flag ``AllowAll`` to ``true`` to allow all origins.
 For example, in ``ConfigureServices``::
 
-    var cors = new DefaultCorsPolicyService(_loggerFactory.CreateLogger<DefaultCorsPolicyService>())
-    {
-        AllowedOrigins = { "https://foo", "https://bar" }
-    };
-    services.AddSingleton<ICorsPolicyService>(cors);
+    services.AddSingleton<ICorsPolicyService>((container) => {
+        var logger = container.GetRequiredService<ILogger<DefaultCorsPolicyService>>();
+        return new DefaultCorsPolicyService(logger) {
+            AllowedOrigins = { "https://foo", "https://bar" }
+        };
+    });
 
 .. Note:: Use ``AllowAll`` with caution.
 


### PR DESCRIPTION
The current recommendations for adding DefaultCorsPolicyService in ConfigureServices don't work in .NET Core 3.1.  My change fixes that.  However, it probably breaks for older versions of .NET Core.

**What issue does this PR address?**


**Does this PR introduce a breaking change?**


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
