### PR TITLE
update docs and samples for Quickstart 2 - also updated launchSetting…

### DIFF
--- a/docs/quickstarts/2_interactive_aspnetcore.rst
+++ b/docs/quickstarts/2_interactive_aspnetcore.rst
@@ -70,7 +70,7 @@ To add support for OpenID Connect authentication to the MVC application, you fir
         .AddCookie("Cookies")
         .AddOpenIdConnect("oidc", options =>
         {
-            options.Authority = "http://localhost:5000";
+            options.Authority = "https://localhost:5001";
             options.RequireHttpsMetadata = false;
 
             options.ClientId = "mvc";
@@ -286,7 +286,7 @@ Adding Google support
 To be able to use Google for authentication, you first need to register with them.
 This is done at their developer `console <https://console.developers.google.com/>`_.
 Create a new project, enable the Google+ API and configure the callback address of your
-local IdentityServer by adding the */signin-google* path to your base-address (e.g. http://localhost:5000/signin-google).
+local IdentityServer by adding the */signin-google* path to your base-address (e.g. https://localhost:5001/signin-google).
 
 The developer console will show you a client ID and secret issued by Google - you will need that in the next step.
 

--- a/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Properties/launchSettings.json
+++ b/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Properties/launchSettings.json
@@ -1,26 +1,12 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:5000",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
+    "SelfHost": {
+      "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "SelfHost": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "https://localhost:5001"
     }
   }
 }

--- a/samples/Quickstarts/2_InteractiveAspNetCore/src/Api/Properties/launchSettings.json
+++ b/samples/Quickstarts/2_InteractiveAspNetCore/src/Api/Properties/launchSettings.json
@@ -1,28 +1,12 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:5001",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5001",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "Api": {
+    "SelfHost": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5001"
+      "applicationUrl": "https://localhost:6001"
     }
   }
 }

--- a/samples/Quickstarts/2_InteractiveAspNetCore/src/Api/Startup.cs
+++ b/samples/Quickstarts/2_InteractiveAspNetCore/src/Api/Startup.cs
@@ -15,7 +15,7 @@ namespace Api
             services.AddAuthentication("Bearer")
                 .AddJwtBearer("Bearer", options =>
                 {
-                    options.Authority = "http://localhost:5000";
+                    options.Authority = "https://localhost:5001";
                     options.RequireHttpsMetadata = false;
 
                     options.Audience = "api1";

--- a/samples/Quickstarts/2_InteractiveAspNetCore/src/Client/Program.cs
+++ b/samples/Quickstarts/2_InteractiveAspNetCore/src/Client/Program.cs
@@ -16,7 +16,7 @@ namespace Client
             // discover endpoints from metadata
             var client = new HttpClient();
 
-            var disco = await client.GetDiscoveryDocumentAsync("http://localhost:5000");
+            var disco = await client.GetDiscoveryDocumentAsync("https://localhost:5001");
             if (disco.IsError)
             {
                 Console.WriteLine(disco.Error);
@@ -46,7 +46,7 @@ namespace Client
             var apiClient = new HttpClient();
             apiClient.SetBearerToken(tokenResponse.AccessToken);
 
-            var response = await apiClient.GetAsync("http://localhost:5001/identity");
+            var response = await apiClient.GetAsync("https://localhost:6001/identity");
             if (!response.IsSuccessStatusCode)
             {
                 Console.WriteLine(response.StatusCode);

--- a/samples/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/Properties/launchSettings.json
+++ b/samples/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/Properties/launchSettings.json
@@ -1,26 +1,12 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:5000",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
+    "SelfHost": {
+      "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "SelfHost": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "https://localhost:5001"
     }
   }
 }

--- a/samples/Quickstarts/2_InteractiveAspNetCore/src/MvcClient/Startup.cs
+++ b/samples/Quickstarts/2_InteractiveAspNetCore/src/MvcClient/Startup.cs
@@ -19,18 +19,18 @@ namespace MvcClient
                 options.DefaultScheme = "Cookies";
                 options.DefaultChallengeScheme = "oidc";
             })
-                .AddCookie("Cookies")
-                .AddOpenIdConnect("oidc", options =>
-                {
-                    options.Authority = "http://localhost:5000";
-                    options.RequireHttpsMetadata = false;
+            .AddCookie("Cookies")
+            .AddOpenIdConnect("oidc", options =>
+            {
+                options.Authority = "https://localhost:5001";
+                options.RequireHttpsMetadata = false;
 
-                    options.ClientId = "mvc";
-                    options.ClientSecret = "secret";
-                    options.ResponseType = "code";
+                options.ClientId = "mvc";
+                options.ClientSecret = "secret";
+                options.ResponseType = "code";
 
-                    options.SaveTokens = true;
-                });
+                options.SaveTokens = true;
+            });
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)


### PR DESCRIPTION
…s for Quickstart 1

**What issue does this PR address?**

- per discussions with Dominick, updating the Quickstart 2 docs and samples to reference https ports instead of http.  Generally:  IdentityServer port has changed to https://localhost:5001, and the API port has changed to https://localhost:6001.  Also fixed that for Quickstart 1 (previously forgot to update the IdentityServer launchSettings.json for Quickstart 1).

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

(n/a - only updating docs and samples)

**Other information**:
