### PR TITLE
update Quickstart 3 to use https, and new port(s)

### DIFF
--- a/docs/quickstarts/3_aspnetcore_and_apis.rst
+++ b/docs/quickstarts/3_aspnetcore_and_apis.rst
@@ -51,7 +51,7 @@ All that's left to do now in the client is to ask for the additional resources v
         .AddCookie("Cookies")
         .AddOpenIdConnect("oidc", options =>
         {
-            options.Authority = "http://localhost:5000";
+            options.Authority = "https://localhost:5001";
             options.RequireHttpsMetadata = false;
 
             options.ClientId = "mvc";
@@ -82,7 +82,7 @@ For accessing the API using the access token, all you need to do is retrieve the
 
         var client = new HttpClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        var content = await client.GetStringAsync("http://localhost:5001/identity");
+        var content = await client.GetStringAsync("https://localhost:6001/identity");
 
         ViewBag.Json = JArray.Parse(content).ToString();
         return View("json");

--- a/samples/Quickstarts/3_AspNetCoreAndApis/src/Api/Properties/launchSettings.json
+++ b/samples/Quickstarts/3_AspNetCoreAndApis/src/Api/Properties/launchSettings.json
@@ -1,28 +1,12 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:5001",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5001",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "Api": {
+    "SelfHost": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5001"
+      "applicationUrl": "https://localhost:6001"
     }
   }
 }

--- a/samples/Quickstarts/3_AspNetCoreAndApis/src/Api/Startup.cs
+++ b/samples/Quickstarts/3_AspNetCoreAndApis/src/Api/Startup.cs
@@ -15,7 +15,7 @@ namespace Api
             services.AddAuthentication("Bearer")
                 .AddJwtBearer("Bearer", options =>
                 {
-                    options.Authority = "http://localhost:5000";
+                    options.Authority = "https://localhost:5001";
                     options.RequireHttpsMetadata = false;
 
                     options.Audience = "api1";

--- a/samples/Quickstarts/3_AspNetCoreAndApis/src/Client/Program.cs
+++ b/samples/Quickstarts/3_AspNetCoreAndApis/src/Client/Program.cs
@@ -16,7 +16,7 @@ namespace Client
             // discover endpoints from metadata
             var client = new HttpClient();
 
-            var disco = await client.GetDiscoveryDocumentAsync("http://localhost:5000");
+            var disco = await client.GetDiscoveryDocumentAsync("https://localhost:5001");
             if (disco.IsError)
             {
                 Console.WriteLine(disco.Error);
@@ -46,7 +46,7 @@ namespace Client
             var apiClient = new HttpClient();
             apiClient.SetBearerToken(tokenResponse.AccessToken);
 
-            var response = await apiClient.GetAsync("http://localhost:5001/identity");
+            var response = await apiClient.GetAsync("https://localhost:6001/identity");
             if (!response.IsSuccessStatusCode)
             {
                 Console.WriteLine(response.StatusCode);

--- a/samples/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/Properties/launchSettings.json
+++ b/samples/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/Properties/launchSettings.json
@@ -1,26 +1,12 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:5000",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
+    "SelfHost": {
+      "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "SelfHost": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "https://localhost:5001"
     }
   }
 }

--- a/samples/Quickstarts/3_AspNetCoreAndApis/src/MvcClient/Controllers/HomeController.cs
+++ b/samples/Quickstarts/3_AspNetCoreAndApis/src/MvcClient/Controllers/HomeController.cs
@@ -30,7 +30,7 @@ namespace MvcClient.Controllers
 
             var client = new HttpClient();
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-            var content = await client.GetStringAsync("http://localhost:5001/identity");
+            var content = await client.GetStringAsync("https://localhost:6001/identity");
 
             ViewBag.Json = JArray.Parse(content).ToString();
             return View("json");

--- a/samples/Quickstarts/3_AspNetCoreAndApis/src/MvcClient/Startup.cs
+++ b/samples/Quickstarts/3_AspNetCoreAndApis/src/MvcClient/Startup.cs
@@ -22,7 +22,7 @@ namespace MvcClient
                 .AddCookie("Cookies")
                 .AddOpenIdConnect("oidc", options =>
                 {
-                    options.Authority = "http://localhost:5000";
+                    options.Authority = "https://localhost:5001";
                     options.RequireHttpsMetadata = false;
 
                     options.ClientId = "mvc";


### PR DESCRIPTION
**What issue does this PR address?**

updates Quickstart number 3 to be consistent with 1 and 2 - uses https://localhost:5001 for IdentityServer, and uses https://localhost:6001 for the API - updates docs and samples accordingly

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)
(n/a)

**Other information**:
