### PR TITLE
update quickstart 4 to be consistent with the others

### DIFF
--- a/samples/Quickstarts/4_JavaScriptClient/src/Api/Properties/launchSettings.json
+++ b/samples/Quickstarts/4_JavaScriptClient/src/Api/Properties/launchSettings.json
@@ -1,28 +1,12 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:5001",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5001",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "Api": {
+    "SelfHost": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5001"
+      "applicationUrl": "https://localhost:6001"
     }
   }
 }

--- a/samples/Quickstarts/4_JavaScriptClient/src/Api/Startup.cs
+++ b/samples/Quickstarts/4_JavaScriptClient/src/Api/Startup.cs
@@ -15,7 +15,7 @@ namespace Api
             services.AddAuthentication("Bearer")
                 .AddJwtBearer("Bearer", options =>
                 {
-                    options.Authority = "http://localhost:5000";
+                    options.Authority = "https://localhost:5001";
                     options.RequireHttpsMetadata = false;
 
                     options.Audience = "api1";

--- a/samples/Quickstarts/4_JavaScriptClient/src/Client/Program.cs
+++ b/samples/Quickstarts/4_JavaScriptClient/src/Client/Program.cs
@@ -16,7 +16,7 @@ namespace Client
             // discover endpoints from metadata
             var client = new HttpClient();
 
-            var disco = await client.GetDiscoveryDocumentAsync("http://localhost:5000");
+            var disco = await client.GetDiscoveryDocumentAsync("https://localhost:5001");
             if (disco.IsError)
             {
                 Console.WriteLine(disco.Error);
@@ -46,7 +46,7 @@ namespace Client
             var apiClient = new HttpClient();
             apiClient.SetBearerToken(tokenResponse.AccessToken);
 
-            var response = await apiClient.GetAsync("http://localhost:5001/identity");
+            var response = await apiClient.GetAsync("https://localhost:6001/identity");
             if (!response.IsSuccessStatusCode)
             {
                 Console.WriteLine(response.StatusCode);

--- a/samples/Quickstarts/4_JavaScriptClient/src/IdentityServer/Properties/launchSettings.json
+++ b/samples/Quickstarts/4_JavaScriptClient/src/IdentityServer/Properties/launchSettings.json
@@ -1,26 +1,12 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:5000",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
+    "SelfHost": {
+      "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "SelfHost": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "https://localhost:5001"
     }
   }
 }

--- a/samples/Quickstarts/4_JavaScriptClient/src/JavaScriptClient/wwwroot/app.js
+++ b/samples/Quickstarts/4_JavaScriptClient/src/JavaScriptClient/wwwroot/app.js
@@ -19,7 +19,7 @@ document.getElementById("api").addEventListener("click", api, false);
 document.getElementById("logout").addEventListener("click", logout, false);
 
 var config = {
-    authority: "http://localhost:5000",
+    authority: "https://localhost:5001",
     client_id: "js",
     redirect_uri: "http://localhost:5003/callback.html",
     response_type: "code",
@@ -43,7 +43,7 @@ function login() {
 
 function api() {
     mgr.getUser().then(function (user) {
-        var url = "http://localhost:5001/identity";
+        var url = "https://localhost:6001/identity";
 
         var xhr = new XMLHttpRequest();
         xhr.open("GET", url);

--- a/samples/Quickstarts/4_JavaScriptClient/src/MvcClient/Startup.cs
+++ b/samples/Quickstarts/4_JavaScriptClient/src/MvcClient/Startup.cs
@@ -22,7 +22,7 @@ namespace MvcClient
                 .AddCookie("Cookies")
                 .AddOpenIdConnect("oidc", options =>
                 {
-                    options.Authority = "http://localhost:5000";
+                    options.Authority = "https://localhost:5001";
                     options.RequireHttpsMetadata = false;
 
                     options.ClientId = "mvc";


### PR DESCRIPTION
**What issue does this PR address?**

changes API to https://localhost:6001, and IdentityServer to https://localhost:5001, to be consistent with the changes I made to the first 3 quickstarts

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)
n/a

**Other information**:
