### PR TITLE
Change name of legacy audience option

### DIFF
--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -34,7 +34,7 @@ namespace IdentityServer4.Configuration
         /// <summary>
         /// Emits an aud claim with the format issuer/resources. That's needed for some older access token validation plumbing. Defaults to false.
         /// </summary>
-        public bool EmitLegacyResourceAudienceClaim { get; set; } = false;
+        public bool EmitStaticAudienceClaim { get; set; } = false;
 
         /// <summary>
         /// Specifies whether scopes in JWTs are emitted as array or string

--- a/src/IdentityServer4/src/Extensions/IdentityServerToolsExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/IdentityServerToolsExtensions.cs
@@ -56,7 +56,7 @@ namespace IdentityServer4
                 }
             }
 
-            if (options.EmitLegacyResourceAudienceClaim)
+            if (options.EmitStaticAudienceClaim)
             {
                 claims.Add(new Claim(JwtClaimTypes.Audience, string.Format(IdentityServerConstants.AccessTokenAudience, tools.ContextAccessor.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash())));
             }

--- a/src/IdentityServer4/src/Services/Default/DefaultTokenService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultTokenService.cs
@@ -225,7 +225,7 @@ namespace IdentityServer4.Services
                 token.Audiences.Add(aud);
             }
 
-            if (Options.EmitLegacyResourceAudienceClaim)
+            if (Options.EmitStaticAudienceClaim)
             {
                 token.Audiences.Add(string.Format(IdentityServerConstants.AccessTokenAudience, issuer.EnsureTrailingSlash()));
             }


### PR DESCRIPTION
Functionality has not changed - but name has changed to `EmitStaticAudienceClaim`.

It's an option to insert a static audience if you are using scopes only and no API resources.