### PR TITLE
Reset `ConsumedTime` when saving soon-to-be-new refresh token

### DIFF
--- a/src/IdentityServer4/src/Services/Default/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultRefreshTokenService.cs
@@ -256,6 +256,8 @@ namespace IdentityServer4.Services
 
             if (needsCreate)
             {
+                // set it to null so that we save non-consumed token
+                refreshToken.ConsumedTime = null;
                 handle = await RefreshTokenStore.StoreRefreshTokenAsync(refreshToken);
                 Logger.LogDebug("Created refresh token in store");
             }


### PR DESCRIPTION
**What issue does this PR address?**
None.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
When using one-time refresh tokens, the code re-uses the `RefreshToken` instance to create new token. Unfortunately, this means that it also re-uses the `ConsumedTime` property. It isn't saved to the database directly (there will be `null` in the column), but it will get serialized to the `Data` JSON that is then used to detect if the token has been consumed.
This effectively block token refreshes after the first refresh.

In this PR I just reset the `ConsumedTime` back to null before storing the new token.
