### PR TITLE
Update broken links affected by branch renaming

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 
 
 **Please check if the PR fulfills these requirements**
-- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
+- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
 - [ ] Unit Tests for the changes have been added (for bug fixes / features)
 
 **Other information**:

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ It is part of the [.NET Foundation](https://www.dotnetfoundation.org/), and oper
 
 For project documentation, please visit [readthedocs](https://identityserver4.readthedocs.io).
 
-[![Build Status](https://dev.azure.com/netidentity/IdentityServer/_apis/build/status/IdentityServer4?branchName=master)](https://dev.azure.com/netidentity/IdentityServer/_build/latest?definitionId=1&branchName=master)
+[![Build Status](https://dev.azure.com/netidentity/IdentityServer/_apis/build/status/IdentityServer4?branchName=main)](https://dev.azure.com/netidentity/IdentityServer/_build/latest?definitionId=1&branchName=main)
 [![Documentation Status](https://readthedocs.org/projects/identityserver4/badge/?version=latest)](http://docs.identityserver.io/en/latest/?badge=latest)
 
 ## Branch structure
-Active development happens on the master branch. This always contains the latest version. Each (pre-) release is tagged with the corresponding version. The [aspnetcore1](https://github.com/IdentityServer/IdentityServer4/tree/aspnetcore1) and [aspnetcore2](https://github.com/IdentityServer/IdentityServer4/tree/aspnetcore2) branches contain the latest versions of the older ASP.NET Core based versions.
+Active development happens on the main branch. This always contains the latest version. Each (pre-) release is tagged with the corresponding version. The [aspnetcore1](https://github.com/IdentityServer/IdentityServer4/tree/aspnetcore1) and [aspnetcore2](https://github.com/IdentityServer/IdentityServer4/tree/aspnetcore2) branches contain the latest versions of the older ASP.NET Core based versions.
 
 ## How to build
 IdentityServer is built against the latest ASP.NET Core 3.
 
-* [Install](https://www.microsoft.com/net/download/core#/current) the [required](https://github.com/IdentityServer/IdentityServer4/blob/master/global.json) .NET Core SDK
+* [Install](https://www.microsoft.com/net/download/core#/current) the [required](https://github.com/IdentityServer/IdentityServer4/blob/main/global.json) .NET Core SDK
 * Install Git
 * Run `build.ps1` or `build.sh` in the root of the repo
 
@@ -48,7 +48,7 @@ This will help us devote more time to answering questions and doing feature deve
 [ExtraNetUserManager](https://www.extranetusermanager.com/)  
 [Knab](https://www.knab.nl/)
 
-You can see a list of our current sponsors [here](https://github.com/IdentityServer/IdentityServer4/blob/master/SPONSORS.md) - and for companies we have some nice advertisement options as well.
+You can see a list of our current sponsors [here](https://github.com/IdentityServer/IdentityServer4/blob/main/SPONSORS.md) - and for companies we have some nice advertisement options as well.
 
 ## Acknowledgements
 IdentityServer4 is built using the following great open source projects and free services:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Welcome to IdentityServer4 (latest)
 
 IdentityServer4 is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core.
 
-.. note:: This docs cover the latest version on master. This might not be released yet. Use the version picker in the lower left corner to select docs for a specific version.
+.. note:: This docs cover the latest version on main branch. This might not be released yet. Use the version picker in the lower left corner to select docs for a specific version.
 
 It enables the following features in your applications:
 

--- a/docs/quickstarts/0_overview.rst
+++ b/docs/quickstarts/0_overview.rst
@@ -13,7 +13,7 @@ it is recommended you do them in order.
 * adding support for ASP.NET Identity
 
 Every quickstart has a reference solution - you can find the code in the 
-`samples <https://github.com/IdentityServer/IdentityServer4/tree/master/samples/Quickstarts>`_ folder.
+`samples <https://github.com/IdentityServer/IdentityServer4/tree/main/samples/Quickstarts>`_ folder.
 
 Preparation
 ^^^^^^^^^^^

--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -13,7 +13,7 @@ The client will request an access token from the Identity Server using its clien
 
 Source Code
 ^^^^^^^^^^^
-As with all of these quickstarts you can find the source code for it in the `IdentityServer4 <https://github.com/IdentityServer/IdentityServer4/blob/master/samples>`_ repository. The project for this quickstart is `Quickstart #1: Securing an API using Client Credentials <https://github.com/IdentityServer/IdentityServer4/tree/master/samples/Quickstarts/1_ClientCredentials>`_
+As with all of these quickstarts you can find the source code for it in the `IdentityServer4 <https://github.com/IdentityServer/IdentityServer4/blob/main/samples>`_ repository. The project for this quickstart is `Quickstart #1: Securing an API using Client Credentials <https://github.com/IdentityServer/IdentityServer4/tree/main/samples/Quickstarts/1_ClientCredentials>`_
 
 Preparation
 ^^^^^^^^^^^
@@ -69,7 +69,7 @@ The Config.cs is already created for you. Open it, update the code to look like 
             };
     }
 
-(see the full file `here <https://github.com/IdentityServer/IdentityServer4/blob/master/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Config.cs>`_).
+(see the full file `here <https://github.com/IdentityServer/IdentityServer4/blob/main/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Config.cs>`_).
 	
 .. note:: If you will be using this in production it is important to give your API a logical name. Developers will be using this to connect to your api though your Identity server.  It should describe your api in simple terms to both developers and users.
 
@@ -107,7 +107,7 @@ You can think of the ClientId and the ClientSecret as the login and password for
 	
 Configuring IdentityServer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Loading the resource and client definitions happens in `Startup.cs <https://github.com/IdentityServer/IdentityServer4/blob/master/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Startup.cs>`_ - update the code to look like this::
+Loading the resource and client definitions happens in `Startup.cs <https://github.com/IdentityServer/IdentityServer4/blob/main/samples/Quickstarts/1_ClientCredentials/src/IdentityServer/Startup.cs>`_ - update the code to look like this::
 
     public void ConfigureServices(IServiceCollection services)
     {
@@ -140,7 +140,7 @@ Then add it to the solution by running the following commands::
     cd ..
     dotnet sln add .\src\Api\Api.csproj
 
-Configure the API application to run on ``https://localhost:6001`` only. You can do this by editing the `launchSettings.json <https://github.com/IdentityServer/IdentityServer4/blob/master/samples/Quickstarts/1_ClientCredentials/src/Api/Properties/launchSettings.json>`_ file inside the Properties folder. Change the application URL setting to be::
+Configure the API application to run on ``https://localhost:6001`` only. You can do this by editing the `launchSettings.json <https://github.com/IdentityServer/IdentityServer4/blob/main/samples/Quickstarts/1_ClientCredentials/src/Api/Properties/launchSettings.json>`_ file inside the Properties folder. Change the application URL setting to be::
 
     "applicationUrl": "https://localhost:6001"
 
@@ -266,7 +266,7 @@ Next you can use the information from the discovery document to request a token 
 
     Console.WriteLine(tokenResponse.Json);
 
-(full file can be found `here <https://github.com/IdentityServer/IdentityServer4/blob/master/samples/Quickstarts/1_ClientCredentials/src/Client/Program.cs>`_)
+(full file can be found `here <https://github.com/IdentityServer/IdentityServer4/blob/main/samples/Quickstarts/1_ClientCredentials/src/Client/Program.cs>`_)
 
 .. note:: Copy and paste the access token from the console to `jwt.ms <https://jwt.ms>`_ to inspect the raw token.
 

--- a/docs/quickstarts/2_interactive_aspnetcore.rst
+++ b/docs/quickstarts/2_interactive_aspnetcore.rst
@@ -18,7 +18,7 @@ You need to provide the necessary UI parts for login, logout, consent and error.
 While the look & feel as well as the exact workflows will probably always differ in every
 IdentityServer implementation, we provide an MVC-based sample UI that you can use as a starting point.
 
-This UI can be found in the `Quickstart UI repo <https://github.com/IdentityServer/IdentityServer4.Quickstart.UI/tree/master>`_.
+This UI can be found in the `Quickstart UI repo <https://github.com/IdentityServer/IdentityServer4.Quickstart.UI/tree/main>`_.
 You can clone or download this repo and drop the controllers, views, models and CSS into your IdentityServer web application.
 
 Alternatively you can use the .NET CLI (run from within the ``src/IdentityServer`` folder)::
@@ -269,7 +269,7 @@ The process for defining an identity resource is as follows:
 
 It is also noteworthy, that the retrieval of claims for tokens is an extensibility point - ``IProfileService``.
 Since we are using ``AddTestUsers``, the ``TestUserProfileService`` is used by default.
-You can inspect the source code `here <https://github.com/IdentityServer/IdentityServer4/blob/master/src/IdentityServer4/src/Test/TestUserProfileService.cs>`_
+You can inspect the source code `here <https://github.com/IdentityServer/IdentityServer4/blob/main/src/IdentityServer4/src/Test/TestUserProfileService.cs>`_
 to see how it works.
 
 .. _refExternalAuthenticationQuickstart:
@@ -348,4 +348,4 @@ Add the OpenId Connect handler to DI::
 
 And now a user should be able to use the cloud-hosted demo identity provider.
 
-.. note:: The quickstart UI auto-provisions external users. As an external user logs in for the first time, a new local user is created, and all the external claims are copied over and associated with the new user. The way you deal with such a situation is completely up to you though. Maybe you want to show some sort of registration UI first. The source code for the default quickstart can be found `here <https://github.com/IdentityServer/IdentityServer4.Quickstart.UI>`_. The controller where auto-provisioning is executed can be found `here <https://github.com/IdentityServer/IdentityServer4.Quickstart.UI/blob/master/Quickstart/Account/ExternalController.cs>`_.
+.. note:: The quickstart UI auto-provisions external users. As an external user logs in for the first time, a new local user is created, and all the external claims are copied over and associated with the new user. The way you deal with such a situation is completely up to you though. Maybe you want to show some sort of registration UI first. The source code for the default quickstart can be found `here <https://github.com/IdentityServer/IdentityServer4.Quickstart.UI>`_. The controller where auto-provisioning is executed can be found `here <https://github.com/IdentityServer/IdentityServer4.Quickstart.UI/blob/main/Quickstart/Account/ExternalController.cs>`_.

--- a/docs/quickstarts/5_entityframework.rst
+++ b/docs/quickstarts/5_entityframework.rst
@@ -45,7 +45,7 @@ As you use ``IdentityServer4.EntityFramework.Storage`` and upgrade over time, yo
 One approach for managing those changes is to use `EF migrations <https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/index>`_, which is what we’ll use in this quickstart.
 If migrations are not your preference, then you can manage the schema changes in any way you see fit.
 
-.. Note:: You can find the `latest SQL scripts <https://github.com/IdentityServer/IdentityServer4/tree/master/src/EntityFramework.Storage/migrations/SqlServer/Migrations>`_ for SqlServer in the IdentityServer4.EntityFramework.Storage repository.
+.. Note:: You can find the `latest SQL scripts <https://github.com/IdentityServer/IdentityServer4/tree/main/src/EntityFramework.Storage/migrations/SqlServer/Migrations>`_ for SqlServer in the IdentityServer4.EntityFramework.Storage repository.
 
 Configuring the Stores
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/quickstarts/community.rst
+++ b/docs/quickstarts/community.rst
@@ -10,7 +10,7 @@ https://github.com/leastprivilege/AspNetCoreSecuritySamples
 
 IdentityServer4 EF and ASP.NET Identity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`This <https://github.com/IdentityServer/IdentityServer4/tree/master/samples/Quickstarts/9_Combined_AspId_and_EFStorage>`_ sample combines the EF and ASP.NET Identity quickstarts.
+`This <https://github.com/IdentityServer/IdentityServer4/tree/main/samples/Quickstarts/9_Combined_AspId_and_EFStorage>`_ sample combines the EF and ASP.NET Identity quickstarts.
 
 Co-hosting IdentityServer4 and a Web API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/ef.rst
+++ b/docs/reference/ef.rst
@@ -5,7 +5,7 @@ Entity Framework Support
 An EntityFramework-based implementation is provided for the configuration and operational data extensibility points in IdentityServer.
 The use of EntityFramework allows any EF-supported database to be used with this library.
 
-The code for this library is located `here <https://github.com/IdentityServer/IdentityServer4/tree/master/src/EntityFramework>`_ (with the underlying storage code `here <https://github.com/IdentityServer/IdentityServer4/tree/master/src/EntityFramework.Storage>`_) and the NuGet package is `here <https://www.nuget.org/packages/IdentityServer4.EntityFramework>`_.
+The code for this library is located `here <https://github.com/IdentityServer/IdentityServer4/tree/main/src/EntityFramework>`_ (with the underlying storage code `here <https://github.com/IdentityServer/IdentityServer4/tree/main/src/EntityFramework.Storage>`_) and the NuGet package is `here <https://www.nuget.org/packages/IdentityServer4.EntityFramework>`_.
 
 The features provided by this library are broken down into two main areas: configuration store and operational store support.
 These two different areas can be used independently or together, based upon the needs of the hosting application.
@@ -112,4 +112,4 @@ You are expected to manage the database creation, schema changes, and data migra
 Using EF migrations is one possible approach to this. 
 If you do wish to use migrations, then see the :ref:`EF quickstart <refEntityFrameworkQuickstart>` for samples on how to get started, or consult the Microsoft `documentation on EF migrations <https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/index>`_.
 
-We also publish `sample SQL scripts <https://github.com/IdentityServer/IdentityServer4/tree/master/src/EntityFramework.Storage/migrations/SqlServer/Migrations>`_ for the current version of the database schema.
+We also publish `sample SQL scripts <https://github.com/IdentityServer/IdentityServer4/tree/main/src/EntityFramework.Storage/migrations/SqlServer/Migrations>`_ for the current version of the database schema.

--- a/docs/topics/signin_external_providers.rst
+++ b/docs/topics/signin_external_providers.rst
@@ -150,7 +150,7 @@ The OpenID Connect authentication handler provided by ASP.NET Core utilizes this
 
 The problem with storing state in a request parameter is that the request URL can get too large (over the common limit of 2000 characters).
 The OpenID Connect authentication handler does provide an extensibility point to store the state in your server, rather than in the request URL. 
-You can implement this yourself by implementing ``ISecureDataFormat<AuthenticationProperties>`` and configuring it on the `OpenIdConnectOptions <https://github.com/aspnet/AspNetCore/blob/master/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs#L249>`_.
+You can implement this yourself by implementing ``ISecureDataFormat<AuthenticationProperties>`` and configuring it on the `OpenIdConnectOptions <https://github.com/aspnet/AspNetCore/blob/main/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs#L249>`_.
 
 Fortunately, IdentityServer provides an implementation of this for you, backed by the ``IDistributedCache`` implementation registered in the DI container (e.g. the standard ``MemoryDistributedCache``).
 To use the IdentityServer provided secure data format implementation, simply call the ``AddOidcStateDataFormatterCache`` extension method on the ``IServiceCollection`` when configuring DI.

--- a/samples/Clients/readme.md
+++ b/samples/Clients/readme.md
@@ -1,3 +1,3 @@
 The client samples are designed to be used with the host in this repo:
 
-https://github.com/IdentityServer/IdentityServer4/tree/master/src/IdentityServer4
+https://github.com/IdentityServer/IdentityServer4/tree/main/src/IdentityServer4

--- a/samples/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/Views/Home/Index.cshtml
+++ b/samples/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <p>
                 Here are links to the
                 <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
             </p>
         </div>
     </div>

--- a/samples/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/Views/Home/Index.cshtml
+++ b/samples/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <p>
                 Here are links to the
                 <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
             </p>
         </div>
     </div>

--- a/samples/Quickstarts/4_JavaScriptClient/src/IdentityServer/Views/Home/Index.cshtml
+++ b/samples/Quickstarts/4_JavaScriptClient/src/IdentityServer/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <p>
                 Here are links to the
                 <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
             </p>
         </div>
     </div>

--- a/samples/Quickstarts/5_EntityFramework/src/IdentityServer/Views/Home/Index.cshtml
+++ b/samples/Quickstarts/5_EntityFramework/src/IdentityServer/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <p>
                 Here are links to the
                 <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
             </p>
         </div>
     </div>

--- a/samples/Quickstarts/6_AspNetIdentity/src/IdentityServerAspNetIdentity/Views/Home/Index.cshtml
+++ b/samples/Quickstarts/6_AspNetIdentity/src/IdentityServerAspNetIdentity/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <p>
                 Here are links to the
                 <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
             </p>
         </div>
     </div>

--- a/samples/Quickstarts/deprecated/8_AspNetIdentity/src/IdentityServerAspNetIdentity/Views/Home/Index.cshtml
+++ b/samples/Quickstarts/deprecated/8_AspNetIdentity/src/IdentityServerAspNetIdentity/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <p>
                 Here are links to the
                 <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
             </p>
         </div>
     </div>

--- a/samples/Quickstarts/deprecated/9_Combined_AspId_and_EFStorage/src/IdentityServer/Views/Home/Index.cshtml
+++ b/samples/Quickstarts/deprecated/9_Combined_AspId_and_EFStorage/src/IdentityServer/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <p>
                 Here are links to the
                 <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+                and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
             </p>
         </div>
     </div>

--- a/src/AspNetIdentity/host/Views/Home/Index.cshtml
+++ b/src/AspNetIdentity/host/Views/Home/Index.cshtml
@@ -26,7 +26,7 @@
         <li>
             Here are links to the
             <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-            and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+            and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
         </li>
     </ul>
 </div>

--- a/src/EntityFramework/host/Views/Home/Index.cshtml
+++ b/src/EntityFramework/host/Views/Home/Index.cshtml
@@ -26,7 +26,7 @@
         <li>
             Here are links to the
             <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-            and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+            and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
         </li>
     </ul>
 </div>

--- a/src/IdentityServer4/host/Views/Home/Index.cshtml
+++ b/src/IdentityServer4/host/Views/Home/Index.cshtml
@@ -26,7 +26,7 @@
         <li>
             Here are links to the
             <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-            and <a href="https://github.com/IdentityServer/IdentityServer4/tree/master/samples">ready to use samples</a>.
+            and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
         </li>
     </ul>
 </div>


### PR DESCRIPTION
**What issue does this PR address?**
Update broken links in docs, quickstarts, readme and other files affected by renaming 'master' branch to 'main'.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
