### PR TITLE
Fix authority URL in the quickstart guide 1

### DIFF
--- a/samples/Quickstarts/1_ClientCredentials/src/Api/Startup.cs
+++ b/samples/Quickstarts/1_ClientCredentials/src/Api/Startup.cs
@@ -15,7 +15,7 @@ namespace Api
             services.AddAuthentication("Bearer")
                 .AddJwtBearer("Bearer", options =>
                 {
-                    options.Authority = "http://localhost:5000";
+                    options.Authority = "https://localhost:5001";
                     options.RequireHttpsMetadata = false;
 
                     options.Audience = "api1";


### PR DESCRIPTION
**What issue does this PR address?**

It addresses a misconfiguration in the first quickstart guide. The authority URL is not correct in the Api project's Startup.cs file.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

N/A
