### PR TITLE
[QS] Fix redirect to Challenge.External param name

### DIFF
--- a/samples/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/Quickstart/Account/AccountController.cs
+++ b/samples/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/Quickstart/Account/AccountController.cs
@@ -64,7 +64,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (vm.IsExternalLoginOnly)
             {
                 // we only have one option for logging in and it's an external provider
-                return RedirectToAction("Challenge", "External", new { provider = vm.ExternalLoginScheme, returnUrl });
+                return RedirectToAction("Challenge", "External", new { scheme = vm.ExternalLoginScheme, returnUrl });
             }
 
             return View(vm);

--- a/samples/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/Quickstart/Account/AccountController.cs
+++ b/samples/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/Quickstart/Account/AccountController.cs
@@ -64,7 +64,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (vm.IsExternalLoginOnly)
             {
                 // we only have one option for logging in and it's an external provider
-                return RedirectToAction("Challenge", "External", new { provider = vm.ExternalLoginScheme, returnUrl });
+                return RedirectToAction("Challenge", "External", new { scheme = vm.ExternalLoginScheme, returnUrl });
             }
 
             return View(vm);

--- a/samples/Quickstarts/4_JavaScriptClient/src/IdentityServer/Quickstart/Account/AccountController.cs
+++ b/samples/Quickstarts/4_JavaScriptClient/src/IdentityServer/Quickstart/Account/AccountController.cs
@@ -64,7 +64,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (vm.IsExternalLoginOnly)
             {
                 // we only have one option for logging in and it's an external provider
-                return RedirectToAction("Challenge", "External", new { provider = vm.ExternalLoginScheme, returnUrl });
+                return RedirectToAction("Challenge", "External", new { scheme = vm.ExternalLoginScheme, returnUrl });
             }
 
             return View(vm);

--- a/samples/Quickstarts/5_EntityFramework/src/IdentityServer/Quickstart/Account/AccountController.cs
+++ b/samples/Quickstarts/5_EntityFramework/src/IdentityServer/Quickstart/Account/AccountController.cs
@@ -64,7 +64,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (vm.IsExternalLoginOnly)
             {
                 // we only have one option for logging in and it's an external provider
-                return RedirectToAction("Challenge", "External", new { provider = vm.ExternalLoginScheme, returnUrl });
+                return RedirectToAction("Challenge", "External", new { scheme = vm.ExternalLoginScheme, returnUrl });
             }
 
             return View(vm);

--- a/samples/Quickstarts/6_AspNetIdentity/src/IdentityServerAspNetIdentity/Quickstart/Account/AccountController.cs
+++ b/samples/Quickstarts/6_AspNetIdentity/src/IdentityServerAspNetIdentity/Quickstart/Account/AccountController.cs
@@ -59,7 +59,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (vm.IsExternalLoginOnly)
             {
                 // we only have one option for logging in and it's an external provider
-                return RedirectToAction("Challenge", "External", new { provider = vm.ExternalLoginScheme, returnUrl });
+                return RedirectToAction("Challenge", "External", new { scheme = vm.ExternalLoginScheme, returnUrl });
             }
 
             return View(vm);

--- a/src/AspNetIdentity/host/Quickstart/Account/AccountController.cs
+++ b/src/AspNetIdentity/host/Quickstart/Account/AccountController.cs
@@ -59,7 +59,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (vm.IsExternalLoginOnly)
             {
                 // we only have one option for logging in and it's an external provider
-                return RedirectToAction("Challenge", "External", new { provider = vm.ExternalLoginScheme, returnUrl });
+                return RedirectToAction("Challenge", "External", new { scheme = vm.ExternalLoginScheme, returnUrl });
             }
 
             return View(vm);

--- a/src/EntityFramework/host/Quickstart/Account/AccountController.cs
+++ b/src/EntityFramework/host/Quickstart/Account/AccountController.cs
@@ -64,7 +64,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (vm.IsExternalLoginOnly)
             {
                 // we only have one option for logging in and it's an external provider
-                return RedirectToAction("Challenge", "External", new { provider = vm.ExternalLoginScheme, returnUrl });
+                return RedirectToAction("Challenge", "External", new { scheme = vm.ExternalLoginScheme, returnUrl });
             }
 
             return View(vm);


### PR DESCRIPTION
+ Use parameter name: `scheme` instead of `provider` to avoid a `null` scheme in the action `External.Challenge`
+ Fixes #4596

**What issue does this PR address?**

When using any of the quickstart templates and disabling the local login (by setting [`AccountOptions.AllowLocalLogin`](https://github.com/IdentityServer/IdentityServer4/blob/4624ed0aed7f3f3ce9fb2f15147fdf95338e8802/samples/Quickstarts/6_AspNetIdentity/src/IdentityServerAspNetIdentity/Quickstart/Account/AccountOptions.cs#L11) to false), and only using external providers, the server will go into an infinite redirect loop when trying to login with the log displaying the following:
```
[11:24:30 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:30 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:30 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:38 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:38 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:38 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:38 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:38 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:38 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:38 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.

[11:24:38 Information] Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler
AuthenticationScheme: Identity.Application was challenged.
```

The problem (as I explained here https://github.com/IdentityServer/IdentityServer4/issues/4596#issuecomment-651884265) is the following:
> I just stumbled upon a similar issue, the problem for me was this bug in the quickstart code (all of the examples 1-6) here:
> https://github.com/IdentityServer/IdentityServer4/blob/4624ed0aed7f3f3ce9fb2f15147fdf95338e8802/samples/Quickstarts/6_AspNetIdentity/src/IdentityServerAspNetIdentity/Quickstart/Account/AccountController.cs#L61-L62
> 
> The `RedirectToAction` assumes that the first route value is called `provider`, when in fact its called `scheme` (this rename change was introduced recently in [6924ff0](https://github.com/IdentityServer/IdentityServer4/commit/6924ff0454f02cb3265c2eb251a1f3d387251e1e) and [4624ed0](https://github.com/IdentityServer/IdentityServer4/commit/4624ed0aed7f3f3ce9fb2f15147fdf95338e8802))
> 
> This name mismatch causes the `scheme` in the `Challenge` call to be `null` here:
> https://github.com/IdentityServer/IdentityServer4/blob/6924ff0454f02cb3265c2eb251a1f3d387251e1e/samples/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/Quickstart/Account/ExternalController.cs#L51
> 
> I'm not sure why the `scheme` is not checked for `null` in the action, but basically since its null, the challenge call below will just cause a redirect to the login action (now with a `returnUrl` set to `External/Challenge`) which causes a loop of redirects.
> 
> https://github.com/IdentityServer/IdentityServer4/blob/6924ff0454f02cb3265c2eb251a1f3d387251e1e/samples/Quickstarts/3_AspNetCoreAndApis/src/IdentityServer/Quickstart/Account/ExternalController.cs#L73
> 
> For now I just fixed it by renamming `provider` to `scheme` [here](https://github.com/IdentityServer/IdentityServer4/blob/4624ed0aed7f3f3ce9fb2f15147fdf95338e8802/samples/Quickstarts/6_AspNetIdentity/src/IdentityServerAspNetIdentity/Quickstart/Account/AccountController.cs#L62) (since it seems that's the new intended name for that value), but maybe a null check should be added to make sure that the `scheme` is always set? or maybe just drop the name since its an anonymous type? I can open a PR with this fix, just let me know what's the expected behavior here.


**Does this PR introduce a breaking change?**

I don't think so, but please let me know if it does

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

Should we add a null check for `scheme` in [`ExternalController.Challenge`](https://github.com/IdentityServer/IdentityServer4/blob/6924ff0454f02cb3265c2eb251a1f3d387251e1e/samples/Quickstarts/2_InteractiveAspNetCore/src/IdentityServer/Quickstart/Account/ExternalController.cs#L51)?