### PR TITLE
Docs: Specify "ASP.NET Identity" as "ASP.NET Core Identity"

### DIFF
--- a/docs/quickstarts/6_aspnet_identity.rst
+++ b/docs/quickstarts/6_aspnet_identity.rst
@@ -5,24 +5,24 @@ Using ASP.NET Core Identity
 .. note:: For any pre-requisites (like e.g. templates) have a look at the :ref:`overview <refQuickstartOverview>` first.
 
 IdentityServer is designed for flexibility and part of that is allowing you to use any database you want for your users and their data (including passwords).
-If you are starting with a new user database, then ASP.NET Identity is one option you could choose.
-This quickstart shows how to use ASP.NET Identity with IdentityServer.
+If you are starting with a new user database, then ASP.NET Core Identity is one option you could choose.
+This quickstart shows how to use ASP.NET Core Identity with IdentityServer.
 
-The approach this quickstart takes to using ASP.NET Identity is to create a new project for the IdentityServer host.
+The approach this quickstart takes to using ASP.NET Core Identity is to create a new project for the IdentityServer host.
 This new project will replace the prior IdentityServer project we built up in the previous quickstarts.
-The reason for this new project is due to the differences in UI assets when using ASP.NET Identity (mainly around the differences in login and logout).
+The reason for this new project is due to the differences in UI assets when using ASP.NET Core Identity (mainly around the differences in login and logout).
 All the other projects in this solution (for the clients and the API) will remain the same.
 
-.. Note:: This quickstart assumes you are familiar with how ASP.NET Identity works. If you are not, it is recommended that you first `learn about it <https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity>`_.
+.. Note:: This quickstart assumes you are familiar with how ASP.NET Core Identity works. If you are not, it is recommended that you first `learn about it <https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity>`_.
 
-New Project for ASP.NET Identity
+New Project for ASP.NET Core Identity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The first step is to add a new project for ASP.NET Identity to your solution.
-We provide a template that contains the minimal UI assets needed to ASP.NET Identity with IdentityServer.
+The first step is to add a new project for ASP.NET Core Identity to your solution.
+We provide a template that contains the minimal UI assets needed to ASP.NET Core Identity with IdentityServer.
 You will eventually delete the old project for IdentityServer, but there are some items that you will need to migrate over.
 
-Start by creating a new IdentityServer project that will use ASP.NET Identity::
+Start by creating a new IdentityServer project that will use ASP.NET Core Identity::
     
     cd quickstart/src
     dotnet new is4aspid -n IdentityServerAspNetIdentity
@@ -43,18 +43,18 @@ IdentityServerAspNetIdentity.csproj
 -----------------------------------
 
 Notice the reference to `IdentityServer4.AspNetIdentity`. 
-This NuGet package contains the ASP.NET Identity integration components for IdentityServer.
+This NuGet package contains the ASP.NET Core Identity integration components for IdentityServer.
 
 Startup.cs
 ----------
 
-In `ConfigureServices` notice the necessary ``AddDbContext<ApplicationDbContext>`` and ``AddIdentity<ApplicationUser, IdentityRole>`` calls are done to configure ASP.NET Identity.
+In `ConfigureServices` notice the necessary ``AddDbContext<ApplicationDbContext>`` and ``AddIdentity<ApplicationUser, IdentityRole>`` calls are done to configure ASP.NET Core Identity.
 
 Also notice that much of the same IdentityServer configuration you did in the previous quickstarts is already done.
 The template uses the in-memory style for clients and resources, and those are sourced from `Config.cs`.
 
 Finally, notice the addition of the new call to ``AddAspNetIdentity<ApplicationUser>``.
-``AddAspNetIdentity`` adds the integration layer to allow IdentityServer to access the user data for the ASP.NET Identity user database.
+``AddAspNetIdentity`` adds the integration layer to allow IdentityServer to access the user data for the ASP.NET Core Identity user database.
 This is needed when IdentityServer must add claims for the users into tokens.
 
 Note that ``AddIdentity<ApplicationUser, IdentityRole>`` must be invoked before ``AddIdentityServer``.
@@ -126,7 +126,7 @@ Program.cs and SeedData.cs
 --------------------------
 
 `Program.cs`'s ``Main`` is a little different than most ASP.NET Core projects.
-Notice how this looks for a command line argument called `/seed` which is used as a flag to seed the users in the ASP.NET Identity database.
+Notice how this looks for a command line argument called `/seed` which is used as a flag to seed the users in the ASP.NET Core Identity database.
 
 Look at the ``SeedData`` class' code to see how the database is created and the first users are created.
 
@@ -135,7 +135,7 @@ AccountController
 
 The last code to inspect in this template is the ``AccountController``. 
 This contains a slightly different login and logout code than the prior quickstart and templates.
-Notice the use of the ``SignInManager<ApplicationUser>`` and ``UserManager<ApplicationUser>`` from ASP.NET Identity to validate credentials and manage the authentication session.
+Notice the use of the ``SignInManager<ApplicationUser>`` and ``UserManager<ApplicationUser>`` from ASP.NET Core Identity to validate credentials and manage the authentication session.
 
 Much of the rest of the code is the same from the prior quickstarts and templates.
 
@@ -149,7 +149,7 @@ Launch the MVC client application, and you should be able to click the "Secure" 
 
 .. image:: images/aspid_mvc_client.png
 
-You should be redirected to the ASP.NET Identity login page.
+You should be redirected to the ASP.NET Core Identity login page.
 Login with your newly created user:
 
 .. image:: images/aspid_login.png
@@ -163,14 +163,14 @@ You should also be able to click "Call API using application identity" to invoke
 
 .. image:: images/aspid_api_claims.png
 
-And now you're using users from ASP.NET Identity in IdentityServer.
+And now you're using users from ASP.NET Core Identity in IdentityServer.
 
 What's Missing?
 ^^^^^^^^^^^^^^^
 
 Much of the rest of the code in this template is similar to the other quickstart and templates we provide.
-The one thing you will notice that is missing from this template is UI code for user registration, password reset, and the other things you might expect from the Visual Studio ASP.NET Identity template.
+The one thing you will notice that is missing from this template is UI code for user registration, password reset, and the other things you might expect from the Visual Studio ASP.NET Core Identity template.
 
-Given the variety of requirements and different approaches to using ASP.NET Identity, our template deliberately does not provide those features.
-You are expected to know how ASP.NET Identity works sufficiently well to add those features to your project.
-Alternatively, you can create a new project based on the Visual Studio ASP.NET Identity template and add the IdentityServer features you have learned about in these quickstarts to that project.
+Given the variety of requirements and different approaches to using ASP.NET Core Identity, our template deliberately does not provide those features.
+You are expected to know how ASP.NET Core Identity works sufficiently well to add those features to your project.
+Alternatively, you can create a new project based on the Visual Studio ASP.NET Core Identity template and add the IdentityServer features you have learned about in these quickstarts to that project.


### PR DESCRIPTION
I landed on this helpdoc as I'm trying to understand the relationship between ASP.NET Core Identity and IdentityServer4. I noticed in this doc a lot of references to "ASP.NET Identity", I believe it's being used as shorthand for "ASP.NET Core Identity". This PR specifies the term as "ASP.NET Core Identity" to remove the ambiguity.

**What issue does this PR address?**

Documentation


**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [`x`] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [`n/a`] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Information at the top of the comment.