### PR TITLE
Docs - fix the names of aud claims to match API resource names

### DIFF
--- a/docs/topics/resources.rst
+++ b/docs/topics/resources.rst
@@ -261,7 +261,7 @@ Using the API resource grouping gives you the following additional features
 
 * support for the JWT *aud* claim. The value(s) of the audience claim will be the name of the API resource(s)
 * support for adding common user claims across all contained scopes
-* support for introspection by assigning a API secret to the resource
+* support for introspection by assigning an API secret to the resource
 * support for configuring the access token signing algorithm for the resource
 
 Let's have a look at some example access tokens for the above resource configuration.
@@ -275,7 +275,7 @@ Let's have a look at some example access tokens for the above resource configura
         "client_id": "client",
         "sub": "123",
 
-        "aud": "invoice",
+        "aud": "invoices",
         "scope": "invoice.read invoice.pay"
     }
 
@@ -288,7 +288,7 @@ Let's have a look at some example access tokens for the above resource configura
         "client_id": "client",
         "sub": "123",
 
-        "aud": [ "invoice", "customer" ]
+        "aud": [ "invoices", "customers" ]
         "scope": "invoice.read customer.read"
     }
 
@@ -301,7 +301,7 @@ Let's have a look at some example access tokens for the above resource configura
         "client_id": "client",
         "sub": "123",
 
-        "aud": [ "invoice", "customer" ]
+        "aud": [ "invoices", "customers" ]
         "scope": "manage"
     }
 


### PR DESCRIPTION
**What issue does this PR address?**

`aud` claims used for access tokens in the API Resources section were in the singular, while the API resource names were defined in the plural.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
