### PR TITLE
Change .NET CLI command on quickstarts document

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -306,7 +306,7 @@ Authorization at the API
 Right now, the API accepts any access token issued by your identity server.
 
 In the following we will add code that allows checking for the presence of the scope in the access token that the client asked for (and got granted).
-For this we will use the ASP.NET Core authorization policy system. Add the following to the ``Configure`` method in ``Startup``::
+For this we will use the ASP.NET Core authorization policy system. Add the following to the ``ConfigureServices`` method in ``Startup``::
 
     services.AddAuthorization(options =>
     {

--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -134,7 +134,7 @@ Next, add an API to your solution.
 You can either use the ASP.NET Core Web API template from Visual Studio or use the .NET CLI to create the API project as we do here.
 Run from within the ``src`` folder the following command::
 
-    dotnet new web -n Api
+    dotnet new webapi -n Api
 
 Then add it to the solution by running the following commands::
 


### PR DESCRIPTION
Change .NET CLI command to create "ASP.NET Core Web API" instead of "ASP.NET Core Empty"

**What issue does this PR address?**
https://github.com/IdentityServer/IdentityServer4/issues/4614
https://github.com/IdentityServer/IdentityServer4/issues/4613

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
- This PR contains 2 changes on documents which requires no unit test
- Verified the .NET CLI command change locally, attached the result   

<img width="445" alt="Screen Shot 2020-07-24 at 2 21 05 PM" src="https://user-images.githubusercontent.com/4095071/88422945-fec19f00-cdb8-11ea-96e7-db38fbe90937.png">
<img width="492" alt="Screen Shot 2020-07-24 at 2 21 25 PM" src="https://user-images.githubusercontent.com/4095071/88422947-fec19f00-cdb8-11ea-92db-4e90c6917977.png">


@brockallen 