### PR TITLE
Updated ApiScope to ApiResource

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -62,10 +62,10 @@ The Config.cs is already created for you. Open it, update the code to look like 
 
     public static class Config
     {
-        public static IEnumerable<ApiScope> ApiScopes =>
-            new List<ApiScope>
+        public static IEnumerable<ApiResource> ApiScopes =>
+            new List<ApiResource>
             {
-                new ApiScope("api1", "My API")
+                new ApiResource("api1", "My API")
             };
     }
 


### PR DESCRIPTION
I could not find any ApiScope variables in the project. I think the name has changed to ApiResource. have made the change above.

**What issue does this PR address?**

Its a simple class name change. It's the very first code addition and it does not work as per the existing document. its a quick fix. 

**Does this PR introduce a breaking change?**

It does not. 

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

I hope I am not missing something obvious here. I searched throughout the project and I have been using this identity server code for some time. there is no class called ApiScope anywhere in the project. 