### PR TITLE
Correcting documentation issue with Windows Authentication

### DIFF
--- a/docs/topics/windows.rst
+++ b/docs/topics/windows.rst
@@ -78,7 +78,7 @@ trigger authentication, and if successful convert the information into a standar
             
 
             await HttpContext.SignInAsync(
-                IdentityServerConstants.ExternalCookieAuthenticationScheme,
+                IdentityConstants.ExternalScheme,
                 new ClaimsPrincipal(id),
                 props);
             return Redirect(props.RedirectUri);


### PR DESCRIPTION
IdentityServerConstants.ExternalCookieAuthenticationScheme ("idsrv.external") causes failure in the Callback action whose first line calls HttpContext.AuthencicateAsync(IdentityConstants.ExternalScheme);

Changing to 
await HttpContext.SignInAsync(
                IdentityConstants.ExternalScheme,

allows it to succeed.