### PR TITLE
Change from Encoding.UTF8.GetBytes to Convert.FromBase64String

### DIFF
--- a/docs/topics/mtls.rst
+++ b/docs/topics/mtls.rst
@@ -43,7 +43,7 @@ If you are using Nginx (which we found is the most flexible hosting option), you
 
             if(!string.IsNullOrWhiteSpace(headerValue))
             {
-                var bytes = Encoding.UTF8.GetBytes(Uri.UnescapeDataString(headerValue));
+                var bytes = Convert.FromBase64String(Uri.UnescapeDataString(headerValue));
                 clientCertificate = new X509Certificate2(bytes);
             }
 


### PR DESCRIPTION
Change from Encoding.UTF8.GetBytes to Convert.FromBase64String as Encoding.UTF8.GetBytes causes following error on Linux:
Interop+Crypto+OpenSslCryptographicException: error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1

**What issue does this PR address?**
Issue with wrong sample for application working on both Windows and Linux

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
