### PR TITLE
Example request: included content-type info

### DIFF
--- a/docs/endpoints/token.rst
+++ b/docs/endpoints/token.rst
@@ -42,6 +42,7 @@ Example
 ::
 
     POST /connect/token
+    CONTENT-TYPE application/x-www-form-urlencoded
 
         client_id=client1&
         client_secret=secret&


### PR DESCRIPTION
I´ve lost precious minutes trying to figure out what was causing this response below:
{
    "error": "invalid_request"
}

This change will make content-type clearer.

**What issue does this PR address?**
Add one single line to token endpoint docs, showing content-type needed to a successful request.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [ x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
