### PR TITLE
Allow setting SameSite mode of the SessionId cookie

### DIFF
--- a/docs/reference/options.rst
+++ b/docs/reference/options.rst
@@ -56,6 +56,9 @@ Authentication
 * ``CheckSessionCookieDomain``
     The domain of the cookie used for the check session endpoint.
 
+* ``CheckSessionCookieSameSiteMode``
+    The SameSite mode of the cookie used for the check session endpoint.
+
 * ``RequireCspFrameSrcForSignout``
     If set, will require frame-src CSP headers being emitting on the end session callback endpoint which renders iframes to clients for front-channel signout notification. Defaults to true.
 

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
@@ -52,6 +52,11 @@ namespace IdentityServer4.Configuration
         public string CheckSessionCookieDomain { get; set; }
 
         /// <summary>
+        /// Gets or sets the SameSite mode of the cookie used for the check session endpoint. Defaults to SameSiteMode.None.
+        /// </summary>
+        public SameSiteMode CheckSessionCookieSameSiteMode { get; set; } = SameSiteMode.None;
+
+        /// <summary>
         /// If set, will require frame-src CSP headers being emitting on the end session callback endpoint which renders iframes to clients for front-channel signout notification.
         /// </summary>
         public bool RequireCspFrameSrcForSignout { get; set; } = true;

--- a/src/IdentityServer4/src/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultUserSession.cs
@@ -68,6 +68,14 @@ namespace IdentityServer4.Services
         protected string CheckSessionCookieDomain => Options.Authentication.CheckSessionCookieDomain;
 
         /// <summary>
+        /// Gets the SameSite mode of the check session cookie.
+        /// </summary>
+        /// <value>
+        /// The SameSite mode of the check session cookie.
+        /// </value>
+        protected SameSiteMode CheckSessionCookieSameSiteMode => Options.Authentication.CheckSessionCookieSameSiteMode;
+
+        /// <summary>
         /// The principal
         /// </summary>
         protected ClaimsPrincipal Principal;
@@ -238,7 +246,7 @@ namespace IdentityServer4.Services
                 Path = path,
                 IsEssential = true,
                 Domain = CheckSessionCookieDomain,
-                SameSite = SameSiteMode.None
+                SameSite = CheckSessionCookieSameSiteMode
             };
 
             return options;


### PR DESCRIPTION
**What issue does this PR address?**
The SameSite mode of the sessionId cookie can be configured with this PR. It was hardcoded to `SameSiteMode.None` before.

We set this to `SameSiteMode.Lax` for serving via http for local development (in a docker instance), where SameSite=None cookies get ignored (Chrome 84). SameSite=None only works for Secure cookies.

**Does this PR introduce a breaking change?**
No. The default is still `SameSiteMode.None`

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
