### PR TITLE
fix multiple WWW-Authenticate header to one

### DIFF
--- a/src/IdentityServer4/src/Endpoints/Results/ProtectedResourceErrorResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/ProtectedResourceErrorResult.cs
@@ -42,12 +42,12 @@ namespace IdentityServer4.Endpoints.Results
             var errorString = string.Format($"error=\"{Error}\"");
             if (ErrorDescription.IsMissing())
             {
-                context.Response.Headers.Add(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString }));
+                context.Response.Headers.Add(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString }).ToString());
             }
             else
             {
                 var errorDescriptionString = string.Format($"error_description=\"{ErrorDescription}\"");
-                context.Response.Headers.Add(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString, errorDescriptionString }));
+                context.Response.Headers.Add(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString, errorDescriptionString }).ToString());
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
WWW-Authenticate header should only have one

**What issue does this PR address?**
every WWW-Authenticate header should atleast have one auth schema, because we only used bearer token authentication, we should only have one WWW-Authenticate header.Currently it returns two likes below

> WWW-Authenticate: Bearer
> WWW-Authenticate: error="invalid_token"

test on https://demo.identityserver.io/connect/userinfo

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
