### PR TITLE
Adding note about trusting certificates.

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -250,6 +250,7 @@ IdentityModel includes a client library to use with the discovery endpoint. This
         Console.WriteLine(disco.Error);
         return;
     }
+.. note:: If you get an error connecting it may be that you are running `https` and the development certificate for ``localhost`` is not trusted. You can run ``dotnet dev-certs https --trust`` in order to trust the development certificate. This only needs to be done once.
 
 Next you can use the information from the discovery document to request a token to IdentityServer to access ``api1``::
 


### PR DESCRIPTION
The quickstart uses `https` instead of `http` but the client in the quickstart will fail if the developer has not trusted the development certificate. Visual Studio is smart enough to prompt you to trust the localhost cert, but VS Code (which is what I was using) does not. I am proposing adding a note to explain this step. (also thanks to Daniel Tabuenca who helped me through this!)

**What issue does this PR address?**
The Quickstart documentation. No code changes.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [ x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
