### PR TITLE
Introduce LoggingOptions.AuthorizeRequestSensitiveValuesFilter

### DIFF
--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/LoggingOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/LoggingOptions.cs
@@ -24,5 +24,14 @@ namespace IdentityServer4.Configuration
                 OidcConstants.TokenRequest.RefreshToken,
                 OidcConstants.TokenRequest.DeviceCode
             };
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ICollection<string> AuthorizeRequestSensitiveValuesFilter { get; set; } = 
+            new HashSet<string>
+            {
+                OidcConstants.AuthorizeRequest.IdTokenHint
+            };
     }
 }

--- a/src/IdentityServer4/src/Endpoints/AuthorizeCallbackEndpoint.cs
+++ b/src/IdentityServer4/src/Endpoints/AuthorizeCallbackEndpoint.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using System.Net;
 using System.Threading.Tasks;
+using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
@@ -25,13 +26,14 @@ namespace IdentityServer4.Endpoints
         public AuthorizeCallbackEndpoint(
             IEventService events,
             ILogger<AuthorizeCallbackEndpoint> logger,
+            IdentityServerOptions options,
             IAuthorizeRequestValidator validator,
             IAuthorizeInteractionResponseGenerator interactionGenerator,
             IAuthorizeResponseGenerator authorizeResponseGenerator,
             IUserSession userSession,
             IConsentMessageStore consentResponseStore,
             IAuthorizationParametersMessageStore authorizationParametersMessageStore = null)
-            : base(events, logger, validator, interactionGenerator, authorizeResponseGenerator, userSession)
+            : base(events, logger, options, validator, interactionGenerator, authorizeResponseGenerator, userSession)
         {
             _consentResponseStore = consentResponseStore;
             _authorizationParametersMessageStore = authorizationParametersMessageStore;

--- a/src/IdentityServer4/src/Endpoints/AuthorizeEndpoint.cs
+++ b/src/IdentityServer4/src/Endpoints/AuthorizeEndpoint.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using System.Net;
 using System.Threading.Tasks;
+using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
@@ -20,11 +21,12 @@ namespace IdentityServer4.Endpoints
         public AuthorizeEndpoint(
            IEventService events,
            ILogger<AuthorizeEndpoint> logger,
+           IdentityServerOptions options,
            IAuthorizeRequestValidator validator,
            IAuthorizeInteractionResponseGenerator interactionGenerator,
            IAuthorizeResponseGenerator authorizeResponseGenerator,
            IUserSession userSession)
-            : base(events, logger, validator, interactionGenerator, authorizeResponseGenerator, userSession)
+            : base(events, logger, options, validator, interactionGenerator, authorizeResponseGenerator, userSession)
         {
         }
 

--- a/src/IdentityServer4/src/Endpoints/AuthorizeEndpointBase.cs
+++ b/src/IdentityServer4/src/Endpoints/AuthorizeEndpointBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using IdentityModel;
+using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;
@@ -25,6 +26,7 @@ namespace IdentityServer4.Endpoints
         private readonly IAuthorizeResponseGenerator _authorizeResponseGenerator;
 
         private readonly IEventService _events;
+        private readonly IdentityServerOptions _options;
 
         private readonly IAuthorizeInteractionResponseGenerator _interactionGenerator;
 
@@ -33,12 +35,14 @@ namespace IdentityServer4.Endpoints
         protected AuthorizeEndpointBase(
             IEventService events,
             ILogger<AuthorizeEndpointBase> logger,
+            IdentityServerOptions options,
             IAuthorizeRequestValidator validator,
             IAuthorizeInteractionResponseGenerator interactionGenerator,
             IAuthorizeResponseGenerator authorizeResponseGenerator,
             IUserSession userSession)
         {
             _events = events;
+            _options = options;
             Logger = logger;
             _validator = validator;
             _interactionGenerator = interactionGenerator;
@@ -119,7 +123,7 @@ namespace IdentityServer4.Endpoints
 
             if (request != null)
             {
-                var details = new AuthorizeRequestValidationLog(request);
+                var details = new AuthorizeRequestValidationLog(request, _options.Logging.AuthorizeRequestSensitiveValuesFilter);
                 Logger.LogInformation("{@validationDetails}", details);
             }
 
@@ -137,7 +141,7 @@ namespace IdentityServer4.Endpoints
 
         private void LogRequest(ValidatedAuthorizeRequest request)
         {
-            var details = new AuthorizeRequestValidationLog(request);
+            var details = new AuthorizeRequestValidationLog(request, _options.Logging.AuthorizeRequestSensitiveValuesFilter);
             Logger.LogDebug(nameof(ValidatedAuthorizeRequest) + Environment.NewLine + "{@validationDetails}", details);
         }
 

--- a/src/IdentityServer4/src/Logging/Models/AuthorizeRequestValidationLog.cs
+++ b/src/IdentityServer4/src/Logging/Models/AuthorizeRequestValidationLog.cs
@@ -35,9 +35,9 @@ namespace IdentityServer4.Logging.Models
 
         public Dictionary<string, string> Raw { get; set; }
 
-        public AuthorizeRequestValidationLog(ValidatedAuthorizeRequest request)
+        public AuthorizeRequestValidationLog(ValidatedAuthorizeRequest request, IEnumerable<string> sensitiveValuesFilter)
         {
-            Raw = request.Raw.ToScrubbedDictionary(OidcConstants.AuthorizeRequest.IdTokenHint);
+            Raw = request.Raw.ToScrubbedDictionary(sensitiveValuesFilter.ToArray());
 
             if (request.Client != null)
             {

--- a/src/IdentityServer4/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -835,13 +835,13 @@ namespace IdentityServer4.Validation
 
         private void LogError(string message, ValidatedAuthorizeRequest request)
         {
-            var requestDetails = new AuthorizeRequestValidationLog(request);
+            var requestDetails = new AuthorizeRequestValidationLog(request, _options.Logging.AuthorizeRequestSensitiveValuesFilter);
             _logger.LogError(message + "\n{@requestDetails}", requestDetails);
         }
 
         private void LogError(string message, string detail, ValidatedAuthorizeRequest request)
         {
-            var requestDetails = new AuthorizeRequestValidationLog(request);
+            var requestDetails = new AuthorizeRequestValidationLog(request, _options.Logging.AuthorizeRequestSensitiveValuesFilter);
             _logger.LogError(message + ": {detail}\n{@requestDetails}", detail, requestDetails);
         }
     }

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeCallbackEndpointTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeCallbackEndpointTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4;
+using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Extensions;
@@ -27,6 +28,8 @@ namespace IdentityServer.UnitTests.Endpoints.Authorize
         private TestEventService _fakeEventService = new TestEventService();
 
         private ILogger<AuthorizeCallbackEndpoint> _fakeLogger = TestLogger.Create<AuthorizeCallbackEndpoint>();
+
+        private IdentityServerOptions _options = new IdentityServerOptions();
 
         private MockConsentMessageStore _mockUserConsentResponseMessageStore = new MockConsentMessageStore();
 
@@ -225,6 +228,7 @@ namespace IdentityServer.UnitTests.Endpoints.Authorize
             _subject = new AuthorizeCallbackEndpoint(
                 _fakeEventService,
                 _fakeLogger,
+                _options,
                 _stubAuthorizeRequestValidator,
                 _stubInteractionGenerator,
                 _stubAuthorizeResponseGenerator,

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4;
+using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Hosting;
@@ -29,6 +30,8 @@ namespace IdentityServer.UnitTests.Endpoints.Authorize
         private TestEventService _fakeEventService = new TestEventService();
 
         private ILogger<TestAuthorizeEndpoint> _fakeLogger = TestLogger.Create<TestAuthorizeEndpoint>();
+
+        private IdentityServerOptions _options = new IdentityServerOptions();
 
         private MockUserSession _mockUserSession = new MockUserSession();
 
@@ -180,6 +183,7 @@ namespace IdentityServer.UnitTests.Endpoints.Authorize
             _subject = new TestAuthorizeEndpoint(
                 _fakeEventService,
                 _fakeLogger,
+                _options,
                 _stubAuthorizeRequestValidator,
                 _stubInteractionGenerator,
                 _stubAuthorizeResponseGenerator,
@@ -191,11 +195,12 @@ namespace IdentityServer.UnitTests.Endpoints.Authorize
             public TestAuthorizeEndpoint(
               IEventService events,
               ILogger<TestAuthorizeEndpoint> logger,
+              IdentityServerOptions options,
               IAuthorizeRequestValidator validator,
               IAuthorizeInteractionResponseGenerator interactionGenerator,
               IAuthorizeResponseGenerator authorizeResponseGenerator,
               IUserSession userSession)
-            : base(events, logger, validator, interactionGenerator, authorizeResponseGenerator, userSession)
+            : base(events, logger, options, validator, interactionGenerator, authorizeResponseGenerator, userSession)
             {
             }
 

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4;
+using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Models;
@@ -27,6 +28,8 @@ namespace IdentityServer.UnitTests.Endpoints.Authorize
         private TestEventService _fakeEventService = new TestEventService();
 
         private ILogger<AuthorizeEndpoint> _fakeLogger = TestLogger.Create<AuthorizeEndpoint>();
+
+        private IdentityServerOptions _options = new IdentityServerOptions();
 
         private MockUserSession _mockUserSession = new MockUserSession();
 
@@ -100,6 +103,7 @@ namespace IdentityServer.UnitTests.Endpoints.Authorize
             _subject = new AuthorizeEndpoint(
                 _fakeEventService,
                 _fakeLogger,
+                _options,
                 _stubAuthorizeRequestValidator,
                 _stubInteractionGenerator,
                 _stubAuthorizeResponseGenerator,


### PR DESCRIPTION
We take some sensitive parameters with the "AuthorizeRequest" endpoint with some ICustomAuthorizeRequestValidator implementation to validate them.

We don't want those sensitive parameters be logged when the validation fails.

This commit introduces `AuthorizeRequestSensitiveValuesFilter` similar to `TokenRequestSensitiveValuesFilter`. This will allow us customize which parameter gets scrubbed.