### PR TITLE
Make used HttpClient disposable

### DIFF
--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     });
             }
             
-            builder.Services.AddTransient<IJwtRequestUriHttpClient, DefaultJwtRequestUriHttpClient>(s =>
+            builder.Services.AddTransient<IJwtRequestUriHttpClient>(s =>
             {
                 var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
                 var httpClient = httpClientFactory.CreateClient(name);

--- a/src/IdentityServer4/src/Services/Default/BackChannelLogoutHttpClient.cs
+++ b/src/IdentityServer4/src/Services/Default/BackChannelLogoutHttpClient.cs
@@ -13,7 +13,7 @@ namespace IdentityServer4.Services
     /// <summary>
     /// Models making HTTP requests for back-channel logout notification.
     /// </summary>
-    public class DefaultBackChannelLogoutHttpClient : IBackChannelLogoutHttpClient
+    public class DefaultBackChannelLogoutHttpClient : IBackChannelLogoutHttpClient, IDisposable
     {
         private readonly HttpClient _client;
         private readonly ILogger<DefaultBackChannelLogoutHttpClient> _logger;
@@ -53,6 +53,11 @@ namespace IdentityServer4.Services
             {
                 _logger.LogError(ex, "Exception invoking back-channel logout for url: {url}", url);
             }
+        }
+        
+        public void Dispose()
+        {
+            _client?.Dispose();
         }
     }
 }

--- a/src/IdentityServer4/src/Services/Default/DefaultJwtRequestUriHttpClient.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultJwtRequestUriHttpClient.cs
@@ -15,7 +15,7 @@ namespace IdentityServer4.Services
     /// <summary>
     /// Default JwtRequest client
     /// </summary>
-    public class DefaultJwtRequestUriHttpClient : IJwtRequestUriHttpClient
+    public class DefaultJwtRequestUriHttpClient : IJwtRequestUriHttpClient, IDisposable
     {
         private readonly HttpClient _client;
         private readonly IdentityServerOptions _options;
@@ -62,6 +62,11 @@ namespace IdentityServer4.Services
                 
             _logger.LogError("Invalid http status code {status} from jwt url {url}", response.StatusCode, url);
             return null;
+        }
+
+        public void Dispose()
+        {
+            _client?.Dispose();
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Possibility to dispose `HttpClient` created using `IHttpClientFactory` [See #1](https://github.com/IdentityServer/IdentityServer4/blob/main/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs#L420), [#2](https://github.com/IdentityServer/IdentityServer4/blob/main/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs#L383)

HttpClient which is not disposed cause log spamming.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
```log
[15:18:02 DBG] Microsoft.Extensions.Http.DefaultHttpClientFactory
        HttpMessageHandler expired after 120000ms for client 'IdentityServer:BackChannelLogoutClient'
[15:18:02 DBG] Microsoft.Extensions.Http.DefaultHttpClientFactory
        HttpMessageHandler expired after 120000ms for client 'IdentityServer:JwtRequestUriClient'
[15:18:12 DBG] Microsoft.Extensions.Http.DefaultHttpClientFactory
        Starting HttpMessageHandler cleanup cycle with 2 items
[15:18:12 DBG] Microsoft.Extensions.Http.DefaultHttpClientFactory
        Ending HttpMessageHandler cleanup cycle after 0.6748ms - processed: 0 items - remaining: 2 items
```