### PR TITLE
Update signin_external_providers.rst

### DIFF
--- a/docs/topics/signin_external_providers.rst
+++ b/docs/topics/signin_external_providers.rst
@@ -128,7 +128,12 @@ On the callback page your typical tasks are:
 **Clean-up and sign-in**::
 
     // issue authentication cookie for user
-    await HttpContext.SignInAsync(user.SubjectId, user.Username, provider, props, additionalClaims.ToArray());
+    await HttpContext.SignInAsync(new IdentityServerUser(user.SubjectId) {
+        DisplayName = user.Username,
+        IdentityProvider = provider,
+        AdditionalClaims = additionalClaims,
+        AuthenticationTime = DateTime.Now
+    });
 
     // delete temporary cookie used during external authentication
     await HttpContext.SignOutAsync(IdentityServerConstants.ExternalCookieAuthenticationScheme);


### PR DESCRIPTION
SignInAsync extension methods seems to have changed, the one in the docs here doesn't work. Changed line 131 to new method.

**What issue does this PR address?**

Documentation references an extension method signature that no longer exists in current version.

**Does this PR introduce a breaking change?**

No, it fixes documentation on a breaking change.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
