### PR TITLE
Added cd to change to MVCClient dir

### DIFF
--- a/docs/quickstarts/2_interactive_aspnetcore.rst
+++ b/docs/quickstarts/2_interactive_aspnetcore.rst
@@ -52,6 +52,7 @@ Once you've created the project, configure the application to run on port 5002.
 
 To add support for OpenID Connect authentication to the MVC application, you first need to add the nuget package containing the OpenID Connect handler to your project, e.g.::
 
+    cd src\MVCClient
     dotnet add package Microsoft.AspNetCore.Authentication.OpenIdConnect
 
 ..then add the following to ``ConfigureServices`` in ``Startup``::


### PR DESCRIPTION
To make use of the following command:
dotnet add package Microsoft.AspNetCore.Authentication.OpenIdConnect

It is necessary to change directory to src\MVCClient

using:

cd src\MVCClient

**What issue does this PR address?**


**Does this PR introduce a breaking change?**


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
