### PR TITLE
Update 5_entityframework.rst

### DIFF
--- a/docs/quickstarts/5_entityframework.rst
+++ b/docs/quickstarts/5_entityframework.rst
@@ -134,9 +134,9 @@ In `Startup.cs` add this method to help initialize the database::
 
             if (!context.ApiResources.Any())
             {
-                foreach (var resource in Config.Apis)
+                foreach (var resource in Config.ApiScopes)
                 {
-                    context.ApiResources.Add(resource.ToEntity());
+                    context.ApiScopes.Add(resource.ToEntity());
                 }
                 context.SaveChanges();
             }


### PR DESCRIPTION
Changed `InitializeDatabase` code snippet to use `ApiScopes` instead of `ApiResources`. 

**What issue does this PR address?**
The last code snippet on the page references `Config.Apis` and `context.ApiResources`. Because this QuickStart builds on top of the previous examples, the reference to `Apis` and `ApiResources` does not work without further changes. 

**Does this PR introduce a breaking change?**
No, documentation only.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
`ApiResources` may be a better security choice for most scenarios it does not work within the context of a _Quickstart_, should be introduced as a topic or replaced with `Config.ApiScopes` and `context.ApiScopes` that works directly on top of the previously built components. 