### PR TITLE
Update 5_entityframework.rst

### DIFF
--- a/docs/quickstarts/5_entityframework.rst
+++ b/docs/quickstarts/5_entityframework.rst
@@ -132,11 +132,11 @@ In `Startup.cs` add this method to help initialize the database::
                 context.SaveChanges();
             }
 
-            if (!context.ApiResources.Any())
+            if (!context.ApiScopes.Any())
             {
-                foreach (var resource in Config.Apis)
+                foreach (var resource in Config.ApiScopes)
                 {
-                    context.ApiResources.Add(resource.ToEntity());
+                    context.ApiScopes.Add(resource.ToEntity());
                 }
                 context.SaveChanges();
             }


### PR DESCRIPTION
Update documentation to use `ApiScopes` instead of `ApiResources`

**What issue does this PR address?**
Use the new ApiScopes from the `Config.Apis` to `Config.ApiScopes` and change the `context.ApiResources` to `context.ApiScopes` 

**Does this PR introduce a breaking change?**
No only updated the documentation

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
PRs #4784 and #4792 only update partial information, so created this PR which is basically a merge of both PRs