### PR TITLE
Update 5_entityframework.rst

### DIFF
--- a/docs/quickstarts/5_entityframework.rst
+++ b/docs/quickstarts/5_entityframework.rst
@@ -132,11 +132,11 @@ In `Startup.cs` add this method to help initialize the database::
                 context.SaveChanges();
             }
 
-            if (!context.ApiResources.Any())
+            if (!context.ApiScopes.Any())
             {
-                foreach (var resource in Config.Apis)
+                foreach (var scope in Config.ApiScopes)
                 {
-                    context.ApiResources.Add(resource.ToEntity());
+                    context.ApiScopes.Add(scope.ToEntity());
                 }
                 context.SaveChanges();
             }


### PR DESCRIPTION
In the is4ef template there is no ApiResources, therefore it causes the error below and it will be impossible to follow the tutorial :
'Config' does not contain a definition for 'Apis'

Since ApiScopes exists in that template it should be replaces by   ApiResources

