### PR TITLE
Update 1_client_credentials.rst

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -89,7 +89,7 @@ For this, add a client definition::
                 ClientId = "client",
 
                 // no interactive user, use the clientid/secret for authentication
-                AllowedGrantTypes = GrantTypes.ClientCredentials,
+                AllowedGrantTypes = { GrantTypes.ClientCredentials },
 
                 // secret for authentication
                 ClientSecrets =


### PR DESCRIPTION
When defining new Client, we need to assign array type since AllowedGrantTypes is a type of Collection.

**What issue does this PR address?**
The code example is wrong (or outdated? I have never worked with previous version of IS so I wouldn't know). The AllowedGrantTypes is a Collection so we can't just assign a simple variable.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
