### PR TITLE
Updated GrantType.ClientCredentials to {GrantType.ClientCredentials}

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -89,7 +89,7 @@ For this, add a client definition::
                 ClientId = "client",
 
                 // no interactive user, use the clientid/secret for authentication
-                AllowedGrantTypes = GrantTypes.ClientCredentials,
+                AllowedGrantTypes = {GrantTypes.ClientCredentials},
 
                 // secret for authentication
                 ClientSecrets =


### PR DESCRIPTION
AllowedGrantTypes ={ GrantType.ClientCredentials }
seams to be an ICollection<string> so a single string is not enough

**What issue does this PR address?**


**Does this PR introduce a breaking change?**


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
