### PR TITLE
Use ASP.NET Core Endpoint Routing system instead of EndpointRouter

### DIFF
--- a/src/IdentityServer4/host/Startup.cs
+++ b/src/IdentityServer4/host/Startup.cs
@@ -124,6 +124,8 @@ namespace IdentityServerHost
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapIdentityServer();
+
                 endpoints.MapDefaultControllerRoute();
             });
         }

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -91,6 +91,8 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.AddEndpoint<TokenEndpoint>(EndpointNames.Token, ProtocolRoutePaths.Token.EnsureLeadingSlash());
             builder.AddEndpoint<UserInfoEndpoint>(EndpointNames.UserInfo, ProtocolRoutePaths.UserInfo.EnsureLeadingSlash());
 
+            builder.Services.AddSingleton<IdentityServerEndpointDataSource>();
+
             return builder;
         }
 

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -135,5 +135,10 @@ namespace IdentityServer4.Configuration
         /// Gets or sets the mutual TLS options.
         /// </summary>
         public MutualTlsOptions MutualTls { get; set; } = new MutualTlsOptions();
+
+        /// <summary>
+        /// Gets or sets the endpoint routing usage.
+        /// </summary>
+        internal bool UseEndpointRouting { get; set; }
     }
 }

--- a/src/IdentityServer4/src/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,31 @@
+using IdentityServer4.Configuration;
+using IdentityServer4.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IdentityServer4.Extensions
+{
+    /// <summary>
+    /// Provide extensions for IdentityServer endpoint routing.
+    /// </summary>
+    public static class EndpointRouteBuilderExtensions
+    {
+        /// <summary>
+        /// Adds <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that handles IdentityServer4 requests.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        public static IEndpointConventionBuilder MapIdentityServer(
+            this IEndpointRouteBuilder endpoints)
+        {
+            var dataSource = endpoints.ServiceProvider.GetRequiredService<IdentityServerEndpointDataSource>();
+            endpoints.DataSources.Add(dataSource);
+
+            var options = endpoints.ServiceProvider.GetRequiredService<IdentityServerOptions>();
+            options.UseEndpointRouting = true;
+
+            return dataSource;
+        }
+    }
+}

--- a/src/IdentityServer4/src/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/EndpointRouteBuilderExtensions.cs
@@ -1,10 +1,9 @@
 using IdentityServer4.Configuration;
 using IdentityServer4.Hosting;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace IdentityServer4.Extensions
+namespace Microsoft.AspNetCore.Builder
 {
     /// <summary>
     /// Provide extensions for IdentityServer endpoint routing.

--- a/src/IdentityServer4/src/Hosting/EndpointRouter.cs
+++ b/src/IdentityServer4/src/Hosting/EndpointRouter.cs
@@ -27,7 +27,18 @@ namespace IdentityServer4.Hosting
         public IEndpointHandler Find(HttpContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
+
+            // If endpoint routing for IdentityServer is used,
+            // the endpoints will be handled in previous execution,
+            // so no need to match it twice.
             if (_options.UseEndpointRouting) return null;
+
+            // If endpoint routing for IdentityServer is not used,
+            // we can skip matching when an endpoint is selected
+            // to be executed. This may cause behavior change when
+            // accessing endpoints both created by IdentityServer and
+            // user's service. In fact, this will execute user's one.
+            if (context.GetEndpoint() != null) return null;
 
             foreach(var endpoint in _endpoints)
             {

--- a/src/IdentityServer4/src/Hosting/EndpointRouter.cs
+++ b/src/IdentityServer4/src/Hosting/EndpointRouter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -27,6 +27,7 @@ namespace IdentityServer4.Hosting
         public IEndpointHandler Find(HttpContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (_options.UseEndpointRouting) return null;
 
             foreach(var endpoint in _endpoints)
             {

--- a/src/IdentityServer4/src/Hosting/IdentityServerEndpointDataSource.cs
+++ b/src/IdentityServer4/src/Hosting/IdentityServerEndpointDataSource.cs
@@ -129,7 +129,7 @@ namespace IdentityServer4.Hosting
             }
         }
 
-        public void Add(Action<EndpointBuilder> convention)
+        void IEndpointConventionBuilder.Add(Action<EndpointBuilder> convention)
         {
             _conventions.Add(convention);
         }

--- a/src/IdentityServer4/src/Hosting/IdentityServerEndpointDataSource.cs
+++ b/src/IdentityServer4/src/Hosting/IdentityServerEndpointDataSource.cs
@@ -1,0 +1,142 @@
+using IdentityServer4.Configuration;
+using IdentityServer4.Events;
+using IdentityServer4.Extensions;
+using IdentityServer4.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using HttpEndpoint = Microsoft.AspNetCore.Http.Endpoint;
+
+namespace IdentityServer4.Hosting
+{
+    internal sealed class IdentityServerEndpointDataSource : EndpointDataSource, IEndpointConventionBuilder
+    {
+        private readonly IEnumerable<Endpoint> _idsendpoints;
+        private readonly List<Action<EndpointBuilder>> _conventions;
+        private readonly object _locker;
+        private readonly IdentityServerOptions _options;
+        private readonly ILogger<Item> _logger;
+        private IReadOnlyList<HttpEndpoint> _endpoints;
+
+        private struct Item { }
+
+        public IdentityServerEndpointDataSource(IEnumerable<Endpoint> endpoints, IdentityServerOptions options, ILoggerFactory logger)
+        {
+            _idsendpoints = endpoints;
+            _conventions = new List<Action<EndpointBuilder>>();
+            _locker = new object();
+            _options = options;
+            _logger = logger.CreateLogger<Item>();
+        }
+
+        public override IReadOnlyList<HttpEndpoint> Endpoints
+        {
+            get
+            {
+                Initialize();
+                Debug.Assert(_endpoints != null);
+                return _endpoints;
+            }
+        }
+
+        private void Initialize()
+        {
+            if (_endpoints == null)
+            {
+                lock (_locker)
+                {
+                    if (_endpoints == null)
+                    {
+                        UpdateEndpoints();
+                    }
+                }
+            }
+        }
+
+        private async Task HandleEndpoint(HttpContext context, Endpoint endpoint)
+        {
+            var events = context.RequestServices.GetRequiredService<IEventService>();
+            IEndpointHandler handler;
+
+            if (_options.Endpoints.IsEndpointEnabled(endpoint))
+            {
+                if (context.RequestServices.GetService(endpoint.Handler) is IEndpointHandler handler2)
+                {
+                    _logger.LogDebug("Endpoint enabled: {endpoint}, successfully created handler: {endpointHandler}", endpoint.Name, endpoint.Handler.FullName);
+                    handler = handler2;
+                }
+                else
+                {
+                    _logger.LogDebug("Endpoint enabled: {endpoint}, failed to create handler: {endpointHandler}", endpoint.Name, endpoint.Handler.FullName);
+                    context.Response.StatusCode = 500;
+                    return;
+                }
+            }
+            else
+            {
+                _logger.LogWarning("Endpoint disabled: {endpoint}", endpoint.Name);
+                context.Response.StatusCode = 404;
+                return;
+            }
+
+            try
+            {
+                _logger.LogInformation("Invoking IdentityServer endpoint: {endpointType} for {url}", endpoint.GetType().FullName, context.Request.Path.ToString());
+
+                var result = await handler.ProcessAsync(context);
+
+                if (result != null)
+                {
+                    _logger.LogTrace("Invoking result: {type}", result.GetType().FullName);
+                    await result.ExecuteAsync(context);
+                }
+            }
+            catch (Exception ex)
+            {
+                await events.RaiseAsync(new UnhandledExceptionEvent(ex));
+                _logger.LogCritical(ex, "Unhandled exception: {exception}", ex.Message);
+                throw;
+            }
+        }
+
+        private void UpdateEndpoints()
+        {
+            lock (_locker)
+            {
+                var endpoints = new List<HttpEndpoint>();
+                var order = 0;
+
+                foreach (var endpoint in _idsendpoints)
+                {
+                    RequestDelegate handler = context => HandleEndpoint(context, endpoint);
+                    var pattern = RoutePatternFactory.Parse(endpoint.Path.Value);
+                    var builder = new RouteEndpointBuilder(handler, pattern, ++order);
+                    _conventions.ForEach(a => a.Invoke(builder));
+                    builder.DisplayName = endpoint.Name;
+                    endpoints.Add(builder.Build());
+                }
+
+                _endpoints = endpoints;
+            }
+        }
+
+        public void Add(Action<EndpointBuilder> convention)
+        {
+            _conventions.Add(convention);
+        }
+
+        public override IChangeToken GetChangeToken()
+        {
+            return NullChangeToken.Singleton;
+        }
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
A potential performance issue with EndpointRouter implemention.
Previously it will compare the request path for at least 10 times when a request comes in.

This PR makes a `IdentityServerEndpointDataSource`. Only when `IEndpointRouteBuilder.MapIdentityServer()` is called will IdentityServer endpoints be added into the endpoint routing system and routed at `EndpointRoutingMiddleware`. If that is not called, matching will be done by `EndpointRouter`.

This PR also disables matching in `EndpointRouter` when an endpoint is matched in `EndpointRoutingMiddleware`.
This is a breaking change because when user project creates an controller action using the same URL with IdentityServer endpoints, the matching of IdentityServer endpoints will be skipped. However, if `IEndpointRouteBuilder.MapIdentityServer()` is called, an exception denoting multiple matches will be thrown in `EndpointRoutingMiddleware`.
If you don't want this breaking change, we can remove the line of `context.GetEndpoint()` so code will run like before.

**Does this PR introduce a breaking change?**
Yes.
Detail comments are added in `/src/IdentityServer4/src/Hosting/EndpointRouter.cs`.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
I need some help in writing unit tests.
Is there some scenarios I should add in the test of `EndpointRouter`?