### PR TITLE
Missing comma ',' in ApiResource example.

### DIFF
--- a/docs/topics/resources.rst
+++ b/docs/topics/resources.rst
@@ -233,7 +233,7 @@ In IdentityServer, the ``ApiResource`` class allows some additional organization
 
             // customer API specific scopes
             new ApiScope(name: "customer.read",    displayName: "Reads you customers information."),
-            new ApiScope(name: "customer.contact", displayName: "Allows contacting one of your customers.")
+            new ApiScope(name: "customer.contact", displayName: "Allows contacting one of your customers."),
 
             // shared scope
             new ApiScope(name: "manage", displayName: "Provides administrative access to invoice and customer data.")


### PR DESCRIPTION
**What issue does this PR address?**
A missing comma in the documentation

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [Yes] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [NA] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
