### PR TITLE
DefaultClaimsService.GetIdentityTokenClaimsAsync uses wrong Resource parameter for ProfileData

### DIFF
--- a/src/IdentityServer4/src/Services/Default/DefaultClaimsService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultClaimsService.cs
@@ -81,7 +81,7 @@ namespace IdentityServer4.Services
                     IdentityServerConstants.ProfileDataCallers.ClaimsProviderIdentityToken,
                     additionalClaimTypes)
                 {
-                    RequestedResources = request.ValidatedResources,
+                    RequestedResources = resources,
                     ValidatedRequest = request
                 };
 


### PR DESCRIPTION
#4900
