### PR TITLE
Added method to create temporary key material

### DIFF
--- a/docs/quickstarts/1_client_credentials.rst
+++ b/docs/quickstarts/1_client_credentials.rst
@@ -113,6 +113,7 @@ Loading the resource and client definitions happens in `Startup.cs <https://gith
     public void ConfigureServices(IServiceCollection services)
     {
         var builder = services.AddIdentityServer()
+            .AddDeveloperSigningCredential()        //This is for dev only scenarios when you don’t have a certificate to use.
             .AddInMemoryApiScopes(Config.ApiScopes)
             .AddInMemoryClients(Config.Clients);
 


### PR DESCRIPTION
Added AddDeveloperSigningCredential() method to create temporary key material at startup time. This is for dev only scenarios when user don’t have a certificate to use. 
https://docs.identityserver.io/en/dev/topics/startup.html

**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**
If a developer has no certificate to use, the console app in quick start get the error _"Keyset is missing"_

**Does this PR introduce a breaking change?**
No breaking changes, just suggested a minor update to help developers to run the code in development machine

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
