### PR TITLE
#5022 Adding more data to the DeviceAuthorizationSuccessEvent

### DIFF
--- a/src/IdentityServer4/src/Events/DeviceAuthorizationSuccessEvent.cs
+++ b/src/IdentityServer4/src/Events/DeviceAuthorizationSuccessEvent.cs
@@ -9,9 +9,10 @@ using IdentityServer4.Validation;
 namespace IdentityServer4.Events
 {
     /// <summary>
-    /// Event for device authorization failure
+    /// Event for device authorization success. After this event the user has to grant access for this device.
     /// </summary>
     /// <seealso cref="IdentityServer4.Events.Event" />
+    /// <remarks>rfc8628</remarks>
     public class DeviceAuthorizationSuccessEvent : Event
     {
         /// <summary>
@@ -26,6 +27,10 @@ namespace IdentityServer4.Events
             ClientName = request.ValidatedRequest.Client?.ClientName;
             Endpoint = Constants.EndpointNames.DeviceAuthorization;
             Scopes = request.ValidatedRequest.ValidatedResources?.RawScopeValues.ToSpaceSeparatedString();
+            UserCode = response.UserCode;
+            VerificationUri = response.VerificationUri;
+            VerificationUriComplete = response.VerificationUriComplete;
+            DeviceCodeLifetime = response.DeviceCodeLifetime;
         }
 
         /// <summary>
@@ -71,5 +76,25 @@ namespace IdentityServer4.Events
         /// The scopes.
         /// </value>
         public string Scopes { get; set; }
+        
+        /// <summary>
+        /// The code which the user has to enter to allow this device.
+        /// </summary>
+        public string UserCode { get; set; }
+        
+        /// <summary>
+        /// VerificationUri to be opened in browser without UserCode
+        /// </summary>
+        public string VerificationUri { get; set; }
+
+        /// <summary>
+        /// VerificationUri to be opened in browser including the UserCode
+        /// </summary>
+        public string VerificationUriComplete { get; set; }
+        
+        /// <summary>
+        /// Lifetime in seconds until this device flow request expires.
+        /// </summary>
+        public int DeviceCodeLifetime { get; set; }
     }
 }

--- a/src/IdentityServer4/src/ResponseHandling/Models/DeviceAuthorizationResponse.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Models/DeviceAuthorizationResponse.cs
@@ -6,14 +6,39 @@
 
 namespace IdentityServer4.ResponseHandling
 {
+    /// <summary>
+    /// Response to request of device flow rfc8628
+    /// </summary>
     public class DeviceAuthorizationResponse
     {
+        /// <summary>
+        /// Code not shown to the user but used to attempt to retrieve tokens via token endpoint with grant type urn:ietf:params:oauth:grant-type:device_code
+        /// </summary>
         public string DeviceCode { get; set; }
+        
+        /// <summary>
+        /// The code which the user has to enter to allow this device.
+        /// </summary>
         public string UserCode { get; set; }
+        
+        /// <summary>
+        /// VerificationUri to be opened in browser without UserCode
+        /// </summary>
         public string VerificationUri { get; set; }
 
+        /// <summary>
+        /// VerificationUri to be opened in browser including the UserCode
+        /// </summary>
         public string VerificationUriComplete { get; set; }
+        
+        /// <summary>
+        /// Lifetime in seconds until this device flow request expires.
+        /// </summary>
         public int DeviceCodeLifetime { get; set; }
+        
+        /// <summary>
+        /// The minimum amount of time in seconds needs to wait between polling requests to the token endpoint.
+        /// </summary>
         public int Interval { get; set; }
     }
 }


### PR DESCRIPTION
To allow the use case described in #5022 it is necessary to get more data into the DeviceAuthorizationSuccessEvent

**What issue does this PR address?**
#5022 

**Does this PR introduce a breaking change?**
No breaking changes. No major code changes.

