### PR TITLE
remove redundant secret description access

### DIFF
--- a/src/IdentityServer4/src/Validation/Default/X509NameSecretValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/X509NameSecretValidator.cs
@@ -58,8 +58,6 @@ namespace IdentityServer4.Validation
 
             foreach (var nameSecret in nameSecrets)
             {
-                var secretDescription = string.IsNullOrEmpty(nameSecret.Description) ? "no description" : nameSecret.Description;
-
                 if (name.Equals(nameSecret.Value, StringComparison.Ordinal))
                 {
                     var result = new SecretValidationResult

--- a/src/IdentityServer4/src/Validation/Default/X509ThumbprintSecretValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/X509ThumbprintSecretValidator.cs
@@ -58,8 +58,6 @@ namespace IdentityServer4.Validation
 
             foreach (var thumbprintSecret in thumbprintSecrets)
             {
-                var secretDescription = string.IsNullOrEmpty(thumbprintSecret.Description) ? "no description" : thumbprintSecret.Description;
-
                 if (thumbprint.Equals(thumbprintSecret.Value, StringComparison.OrdinalIgnoreCase))
                 {
                     var result = new SecretValidationResult


### PR DESCRIPTION
A little refactoring, to prevent unnecessary checking and access to a secret description