### PR TITLE
Fix build to work with spaces in the path

### DIFF
--- a/src/build/Program.Partial.cs
+++ b/src/build/Program.Partial.cs
@@ -58,7 +58,7 @@ namespace build
             {
                 var project = Directory.GetFiles("./src", "*.csproj", SearchOption.TopDirectoryOnly).OrderBy(_ => _).First();
 
-                Run("dotnet", $"pack {project} -c Release -o {Directory.CreateDirectory(packOutput).FullName} --no-build --nologo", echoPrefix: Prefix);
+                Run("dotnet", $"pack {project} -c Release -o \"{Directory.CreateDirectory(packOutput).FullName}\" --no-build --nologo", echoPrefix: Prefix);
             });
 
             Target(Targets.SignPackage, DependsOn(Targets.Pack), () =>


### PR DESCRIPTION
Quote the output directory passed to `dotnet pack`

**What issue does this PR address?** https://github.com/IdentityServer/IdentityServer4/issues/5064

**Does this PR introduce a breaking change?** No
