### PR TITLE
avoid "email" claim duplication when using AspNetIdentity with option…

### DIFF
--- a/src/AspNetIdentity/src/UserClaimsFactory.cs
+++ b/src/AspNetIdentity/src/UserClaimsFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -49,15 +49,16 @@ namespace IdentityServer4.AspNetIdentity
 
             if (_userManager.SupportsUserEmail)
             {
-                var email = await _userManager.GetEmailAsync(user);
+                var identityEmail = identity.FindFirst(x => x.Type == JwtClaimTypes.Email)?.Value; 
+                var email = identityEmail ?? await _userManager.GetEmailAsync(user);
                 if (!String.IsNullOrWhiteSpace(email))
                 {
-                    identity.AddClaims(new[]
+                    if (String.IsNullOrWhiteSpace(identityEmail))
                     {
-                        new Claim(JwtClaimTypes.Email, email),
-                        new Claim(JwtClaimTypes.EmailVerified,
-                            await _userManager.IsEmailConfirmedAsync(user) ? "true" : "false", ClaimValueTypes.Boolean)
-                    });
+                        identity.AddClaim(new Claim(JwtClaimTypes.Email, email));
+                    }
+
+                    identity.AddClaim(new Claim(JwtClaimTypes.EmailVerified, await _userManager.IsEmailConfirmedAsync(user) ? "true" : "false", ClaimValueTypes.Boolean));
                 }
             }
 


### PR DESCRIPTION
…s.ClaimsIdentity.EmailClaimType = JwtClaimTypes.Email;

**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**
avoid "email" claim duplication when using AspNetIdentity with options.ClaimsIdentity.EmailClaimType = JwtClaimTypes.Email;

**Does this PR introduce a breaking change?**
nope, it will save from extra db call and avoid email claim duplication.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
