### PR TITLE
order by predicate to prevent table scan

### DIFF
--- a/src/EntityFramework.Storage/src/TokenCleanup/TokenCleanupService.cs
+++ b/src/EntityFramework.Storage/src/TokenCleanup/TokenCleanupService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -76,7 +76,7 @@ namespace IdentityServer4.EntityFramework
             {
                 var expiredGrants = await _persistedGrantDbContext.PersistedGrants
                     .Where(x => x.Expiration < DateTime.UtcNow)
-                    .OrderBy(x => x.Key)
+                    .OrderBy(x => x.Expiration)
                     .Take(_options.TokenCleanupBatchSize)
                     .ToArrayAsync();
 
@@ -109,7 +109,7 @@ namespace IdentityServer4.EntityFramework
             {
                 var expiredCodes = await _persistedGrantDbContext.DeviceFlowCodes
                     .Where(x => x.Expiration < DateTime.UtcNow)
-                    .OrderBy(x => x.DeviceCode)
+                    .OrderBy(x => x.Expiration)
                     .Take(_options.TokenCleanupBatchSize)
                     .ToArrayAsync();
 


### PR DESCRIPTION
See https://github.com/IdentityServer/IdentityServer4/issues/5091

This block is resulting in a full scan during clean up:

https://github.com/IdentityServer/IdentityServer4/blob/07898a61dc22ce9a95e5fc5611fa674feac4230e/src/EntityFramework.Storage/src/TokenCleanup/TokenCleanupService.cs#L77-L81

Sorting by the same column used in the predicate fixes it
```
                var expiredGrants = await _persistedGrantDbContext.PersistedGrants
                    .Where(x => x.Expiration < DateTime.UtcNow)
                    .OrderBy(x => x.Expiration)
                    .Take(_options.TokenCleanupBatchSize)
                    .ToArrayAsync();
```