### PR TITLE
Minor Clarification Update to Profile Service Docs

### DIFF
--- a/docs/reference/profileservice.rst
+++ b/docs/reference/profileservice.rst
@@ -42,8 +42,8 @@ The scopes requested by the client control what user claims are returned in the 
 The ``GetProfileDataAsync`` method is responsible for dynamically obtaining those claims based on the ``RequestedClaimTypes`` collection on the ``ProfileDataRequestContext``.
 
 The ``RequestedClaimTypes`` collection is populated based on the user claims defined on the :ref:`resources <refResources>` that model the scopes.
-If the scopes requested are an :ref:`identity resources <refIdentityResource>`, then the claims in the ``RequestedClaimTypes`` will be populated based on the user claim types defined in the ``IdentityResource``.
-If the scopes requested are an :ref:`API resources <refApiResource>`, then the claims in the ``RequestedClaimTypes`` will be populated based on the user claim types defined in the ``ApiResource`` and/or the ``Scope``.
+If requesting an identity token and the scopes requested are an :ref:`identity resources <refIdentityResource>`, then the claims in the ``RequestedClaimTypes`` will be populated based on the user claim types defined in the ``IdentityResource``.
+If requesting an access token and the scopes requested are an :ref:`API resources <refApiResource>`, then the claims in the ``RequestedClaimTypes`` will be populated based on the user claim types defined in the ``ApiResource`` and/or the ``Scope``. This applies for both identity tokens and access tokens.
 
 IsActiveContext
 ^^^^^^^^^^^^^^^

--- a/docs/reference/profileservice.rst
+++ b/docs/reference/profileservice.rst
@@ -43,7 +43,7 @@ The ``GetProfileDataAsync`` method is responsible for dynamically obtaining thos
 
 The ``RequestedClaimTypes`` collection is populated based on the user claims defined on the :ref:`resources <refResources>` that model the scopes.
 If requesting an identity token and the scopes requested are an :ref:`identity resources <refIdentityResource>`, then the claims in the ``RequestedClaimTypes`` will be populated based on the user claim types defined in the ``IdentityResource``.
-If requesting an access token and the scopes requested are an :ref:`API resources <refApiResource>`, then the claims in the ``RequestedClaimTypes`` will be populated based on the user claim types defined in the ``ApiResource`` and/or the ``Scope``. This applies for both identity tokens and access tokens.
+If requesting an access token and the scopes requested are an :ref:`API resources <refApiResource>`, then the claims in the ``RequestedClaimTypes`` will be populated based on the user claim types defined in the ``ApiResource`` and/or the ``Scope``.
 
 IsActiveContext
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Updated profile service docs.

Misleading, as going by the [code](https://github.com/IdentityServer/IdentityServer4/blob/7cf6192d0aceb48f8c938e828bf8c4f4c1b0fba3/src/IdentityServer4/src/Services/Default/DefaultClaimsService.cs#L113), access tokens doesn't actually get their claims via Identity Resources. It only gets them via API Resources.

Vice versa as well. Identity tokens doesn't actually get their claims via API Resources. It only gets them via Identity Resources.

**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**

Misleading documentation.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] ~Unit Tests for the changes have been added (for bug fixes / features)~ N/A

**Other information**:
