### PR TITLE
RefreshToken store fix

### DIFF
--- a/src/IdentityServer4/src/ResponseHandling/Default/TokenResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/TokenResponseGenerator.cs
@@ -204,6 +204,7 @@ namespace IdentityServer4.ResponseHandling
 
             var oldAccessToken = request.ValidatedRequest.RefreshToken.AccessToken;
             string accessTokenString;
+            Models.Token newAccessToken = null;
 
             if (request.ValidatedRequest.Client.UpdateAccessTokenClaimsOnRefresh)
             {
@@ -222,7 +223,7 @@ namespace IdentityServer4.ResponseHandling
                     ValidatedResources = validatedResources
                 };
 
-                var newAccessToken = await TokenService.CreateAccessTokenAsync(creationRequest);
+                newAccessToken = await TokenService.CreateAccessTokenAsync(creationRequest);
                 accessTokenString = await TokenService.CreateSecurityTokenAsync(newAccessToken);
             }
             else
@@ -233,7 +234,7 @@ namespace IdentityServer4.ResponseHandling
                 accessTokenString = await TokenService.CreateSecurityTokenAsync(oldAccessToken);
             }
 
-            var handle = await RefreshTokenService.UpdateRefreshTokenAsync(request.ValidatedRequest.RefreshTokenHandle, request.ValidatedRequest.RefreshToken, request.ValidatedRequest.Client);
+            var handle = await RefreshTokenService.UpdateRefreshTokenAsync(request.ValidatedRequest.RefreshTokenHandle, request.ValidatedRequest.RefreshToken, request.ValidatedRequest.Client, newAccessToken);
 
             return new TokenResponse
             {

--- a/src/IdentityServer4/src/Services/Default/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultRefreshTokenService.cs
@@ -211,11 +211,12 @@ namespace IdentityServer4.Services
         /// <param name="handle">The handle.</param>
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="client">The client.</param>
+        /// <param name="newAccessToken">New access token to store with refresh token</param>
         /// <returns>
         /// The refresh token handle
         /// </returns>
         public virtual async Task<string> UpdateRefreshTokenAsync(string handle, RefreshToken refreshToken,
-            Client client)
+            Client client, Models.Token newAccessToken)
         {
             Logger.LogDebug("Updating refresh token");
 
@@ -266,11 +267,16 @@ namespace IdentityServer4.Services
             {
                 // set it to null so that we save non-consumed token
                 refreshToken.ConsumedTime = null;
+                if (newAccessToken != null)
+                    refreshToken.AccessToken = newAccessToken;
                 handle = await RefreshTokenStore.StoreRefreshTokenAsync(refreshToken);
                 Logger.LogDebug("Created refresh token in store");
             }
             else if (needsUpdate)
             {
+                if (newAccessToken != null)
+                    refreshToken.AccessToken = newAccessToken;
+
                 await RefreshTokenStore.UpdateRefreshTokenAsync(handle, refreshToken);
                 Logger.LogDebug("Updated refresh token in store");
             }

--- a/src/IdentityServer4/src/Services/Default/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultRefreshTokenService.cs
@@ -216,7 +216,7 @@ namespace IdentityServer4.Services
         /// The refresh token handle
         /// </returns>
         public virtual async Task<string> UpdateRefreshTokenAsync(string handle, RefreshToken refreshToken,
-            Client client, Models.Token newAccessToken)
+            Client client, Models.Token newAccessToken = null)
         {
             Logger.LogDebug("Updating refresh token");
 

--- a/src/IdentityServer4/src/Services/IRefreshTokenService.cs
+++ b/src/IdentityServer4/src/Services/IRefreshTokenService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -39,9 +39,10 @@ namespace IdentityServer4.Services
         /// <param name="handle">The handle.</param>
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="client">The client.</param>
+        /// <param name="newAccessToken">New access token to store with refresh token</param>
         /// <returns>
         /// The refresh token handle
         /// </returns>
-        Task<string> UpdateRefreshTokenAsync(string handle, RefreshToken refreshToken, Client client);
+        Task<string> UpdateRefreshTokenAsync(string handle, RefreshToken refreshToken, Client client, Token newAccessToken = null);
     }
 }


### PR DESCRIPTION
**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**
Upon "grant_type" of "refresh_token", newly generated refresh token was being save with OLD access token. This PR fix this issue and now it will store new access token with new refresh token

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ Yes] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
-
- [x] Unit Tests for the changes have been added (for bug fixes / features)
Verified
**Other information**:
