### PR TITLE
Correct brackets in CORS docs example

### DIFF
--- a/docs/topics/cors.rst
+++ b/docs/topics/cors.rst
@@ -33,12 +33,11 @@ This would be configured as a singleton in DI, and hard-coded with its ``Allowed
 For example, in ``ConfigureServices``::
 
     services.AddSingleton<ICorsPolicyService>((container) => {
-    {
         var logger = container.GetRequiredService<ILogger<DefaultCorsPolicyService>>();
         return new DefaultCorsPolicyService(logger) {
             AllowedOrigins = { "https://foo", "https://bar" }
         };
-    };
+    });
 
 .. Note:: Use ``AllowAll`` with caution.
 


### PR DESCRIPTION
**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**
A minor bracket issue in an example in the CORS documentation.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
