### PR TITLE
Correct the response for a token when a user signs in with in an inac…

### DIFF
--- a/src/IdentityServer4/src/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/TokenRequestValidator.cs
@@ -335,7 +335,7 @@ namespace IdentityServer4.Validation
             if (isActiveCtx.IsActive == false)
             {
                 LogError("User has been disabled", new { subjectId = _validatedRequest.AuthorizationCode.Subject.GetSubjectId() });
-                return Invalid(OidcConstants.TokenErrors.InvalidGrant);
+                return Invalid(OidcConstants.TokenErrors.AccessDenied);
             }
 
             _logger.LogDebug("Validation of authorization code token request success");
@@ -485,7 +485,7 @@ namespace IdentityServer4.Validation
                 LogError("User has been disabled", new { subjectId = resourceOwnerContext.Result.Subject.GetSubjectId() });
                 await RaiseFailedResourceOwnerAuthenticationEventAsync(userName, "user is inactive", resourceOwnerContext.Request.Client.ClientId);
 
-                return Invalid(OidcConstants.TokenErrors.InvalidGrant);
+                return Invalid(OidcConstants.TokenErrors.AccessDenied);
             }
 
             _validatedRequest.UserName = userName;
@@ -645,7 +645,7 @@ namespace IdentityServer4.Validation
                     // todo: raise event?
 
                     LogError("User has been disabled", new { subjectId = result.Subject.GetSubjectId() });
-                    return Invalid(OidcConstants.TokenErrors.InvalidGrant);
+                    return Invalid(OidcConstants.TokenErrors.AccessDenied);
                 }
 
                 _validatedRequest.Subject = result.Subject;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_Code_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_Code_Invalid.cs
@@ -404,7 +404,7 @@ namespace IdentityServer.UnitTests.Validation.TokenRequest_Validation
             var result = await validator.ValidateRequestAsync(parameters, client.ToValidationResult());
 
             result.IsError.Should().BeTrue();
-            result.Error.Should().Be(OidcConstants.TokenErrors.InvalidGrant);
+            result.Error.Should().Be(OidcConstants.TokenErrors.AccessDenied);
         }
     }
 }

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceOwner_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceOwner_Invalid.cs
@@ -222,7 +222,7 @@ namespace IdentityServer.UnitTests.Validation.TokenRequest_Validation
             var result = await validator.ValidateRequestAsync(parameters, client.ToValidationResult());
 
             result.IsError.Should().BeTrue();
-            result.Error.Should().Be(OidcConstants.TokenErrors.InvalidGrant);
+            result.Error.Should().Be(OidcConstants.TokenErrors.AccessDenied);
         }
 
         [Fact]


### PR DESCRIPTION
**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**
#5134 When a user is disabled via IProfileServices.IsActive() and logging in via ResourceOwnerCredentials, Identityserver returns invalid_grant.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
