### PR TITLE
Fix key composition when remove AuthorizationParametersMessage from DistributedCache

### DIFF
--- a/src/IdentityServer4/src/Stores/Default/DistributedCacheAuthorizationParametersMessageStore.cs
+++ b/src/IdentityServer4/src/Stores/Default/DistributedCacheAuthorizationParametersMessageStore.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using IdentityModel;
 using IdentityServer4.Models;
@@ -67,7 +67,8 @@ namespace IdentityServer4.Stores.Default
         /// <inheritdoc/>
         public Task DeleteAsync(string id)
         {
-            return _distributedCache.RemoveAsync(id);
+            var cacheKey = $"{CacheKeyPrefix}-{id}";
+            return _distributedCache.RemoveAsync(cacheKey);
         }
     }
 }

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Stores/Default/DistributedCacheAuthorizationParametersMessageStoreTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Stores/Default/DistributedCacheAuthorizationParametersMessageStoreTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Stores.Default;
+using Microsoft.Extensions.Caching.Distributed;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Stores.Default
+{
+    public class DistributedCacheAuthorizationParametersMessageStoreTests
+    {
+        [Fact]
+        public async Task DeleteAsync_should_prefix_id_with_CacheKeyPrefix()
+        {
+            var distributedCache = new MockDistributedCache();
+
+            var messageStore = new DistributedCacheAuthorizationParametersMessageStore(distributedCache, null);
+            await messageStore.DeleteAsync("id");
+
+            distributedCache.LastKeyRemoveRequest.Should().Be("DistributedCacheAuthorizationParametersMessageStore-id");
+        }
+
+        private class MockDistributedCache : IDistributedCache
+        {
+            public string LastKeyRemoveRequest { get; private set; }
+
+            public byte[] Get(string key) => throw new NotImplementedException();
+
+            public Task<byte[]> GetAsync(string key, CancellationToken token = new CancellationToken())
+                => throw new NotImplementedException();
+
+            public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+                => throw new NotImplementedException();
+
+            public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = new CancellationToken())
+                => throw new NotImplementedException();
+
+            public void Refresh(string key) => throw new NotImplementedException();
+
+            public Task RefreshAsync(string key, CancellationToken token = new CancellationToken())
+                => throw new NotImplementedException();
+
+            public void Remove(string key) => throw new NotImplementedException();
+
+            public Task RemoveAsync(string key, CancellationToken token = new CancellationToken())
+            {
+                LastKeyRemoveRequest = key;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**

Hi,

when using ``DistributedCacheAuthorizationParametersMessageStore``, cached messages will not removed from cache when requested. 

The store gets and writes messages with a composed key of ``{CacheKeyPrefix}-{id}`` (e.g. ``DistributedCacheAuthorizationParametersMessageStore-F5131B6E3A15B46D52610CC4BF5F6D08516C47EE2E33B2601B43EDF23A588182``) but does not use the same composed key for removing the message (just ``F5131B6E3A15B46D52610CC4BF5F6D08516C47EE2E33B2601B43EDF23A588182``).

To reproduce:

1. Configure DI to use the store ``DistributedCacheAuthorizationParametersMessageStore``.
2. Configure a client with ``authorization_code`` in AllowedGrantTypes
3. Login with an authorization code flow. This will add a message to the store.
4. When the flow is completed, ``DeleteAsync`` will be called on the store.

The message remains in the distributed cache, because not the same key is used to delete the message.

```C#
public void ConfigureServices(IServiceCollection services)
{
    var builder = services.AddIdentityServer([...]);
    builder.AddAuthorizationParametersMessageStore<DistributedCacheAuthorizationParametersMessageStore>();
    services.AddSingleton<IFileDistributedCache, SomeDistributedCacheImplementation>();
}
````

This PR adds the same composite key logic to ``DeleteAsync`` as used in ``ReadAsync`` and ``WriteAsync``.

**Does this PR introduce a breaking change?**

I assume this creates the functionality that was originally intended. Existing workarounds may break.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
