### PR TITLE
Update refresh_tokens.rst

### DIFF
--- a/docs/topics/refresh_tokens.rst
+++ b/docs/topics/refresh_tokens.rst
@@ -46,7 +46,7 @@ This will result in a new token response containing a new access token and its e
 
 .. Note:: You can use the `IdentityModel <https://github.com/IdentityModel/IdentityModel>`_ client library to programmatically access the token endpoint from .NET code. For more information check the IdentityModel `docs <https://identitymodel.readthedocs.io/en/latest/client/token.html>`_.
 
-.. Note:: The refresh token, must be valid or an invalid_grant error is returned.
+.. Note:: The refresh token, must be valid or an invalid_grant error is returned.  By default, a refresh_token can only be used once.  Using an already used refresh_token will result in an invalid_grant error.
 
 Customizing refresh token behavior
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/topics/refresh_tokens.rst
+++ b/docs/topics/refresh_tokens.rst
@@ -46,6 +46,8 @@ This will result in a new token response containing a new access token and its e
 
 .. Note:: You can use the `IdentityModel <https://github.com/IdentityModel/IdentityModel>`_ client library to programmatically access the token endpoint from .NET code. For more information check the IdentityModel `docs <https://identitymodel.readthedocs.io/en/latest/client/token.html>`_.
 
+.. Note:: The refresh token, must be valid or an invalid_grant error is returned.
+
 Customizing refresh token behavior
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 All refresh token handling is implemented in the ``DefaultRefreshTokenService`` (which is the default implementation of the ``IRefreshTokenService`` interface)::


### PR DESCRIPTION
Been caught with this twice now.

If you leave the refresh token empty or use an old refresh_token an invalid_grant error is returned.  This is not helpful as I spent ages double checking everything about the request. 

I think a simple note is a good stop gap, because a more accurate fix would require a new error_type to be added which is possibly not wanted at this point 

(If a bigger fix is required, respond to PR and I will try and fix it )

Using an old refresh token gives an invalid_grant error, presuming this is correct behaviour,  the reader needs to be informed that the refresh_token must be valid

**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**
Inaccurate documentation 

**Does this PR introduce a breaking change?**
No 

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
