### PR TITLE
UserInfoResponseGenerator, remove duplicate claim types from log

### DIFF
--- a/src/IdentityServer4/src/ResponseHandling/Default/UserInfoResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/UserInfoResponseGenerator.cs
@@ -90,7 +90,7 @@ namespace IdentityServer4.ResponseHandling
             else
             {
                 outgoingClaims.AddRange(profileClaims);
-                Logger.LogInformation("Profile service returned the following claim types: {types}", profileClaims.Select(c => c.Type).ToSpaceSeparatedString());
+                Logger.LogInformation("Profile service returned the following claim types: {types}", string.Join(" ", profileClaims.Select(c => c.Type).Distinct()));
             }
 
             var subClaim = outgoingClaims.SingleOrDefault(x => x.Type == JwtClaimTypes.Subject);


### PR DESCRIPTION
Message Profile service returned the following claim types updated to remove duplicate claims from logs.

**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**
The log message is very verbose.
Example:
Profile service returned the following claim types: family_name, given_name, r**ole, role, role, role, role, role, role, role, role, role, role,** 
role repeated many times

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other Information**:
This is just a small improvement to make log records nice and clean