### PR TITLE
Fix exception when using multiple uris in one client

### DIFF
--- a/src/IdentityServer4/src/Hosting/FederatedSignOut/AuthenticationRequestHandlerWrapper.cs
+++ b/src/IdentityServer4/src/Hosting/FederatedSignOut/AuthenticationRequestHandlerWrapper.cs
@@ -60,7 +60,6 @@ namespace IdentityServer4.Hosting.FederatedSignOut
             }
             catch
             {
-                _logger?.LogInformation((_inner as MicrosoftAccountHandler).Scheme.DisplayName);
                 return false;
             }
             return result;

--- a/src/IdentityServer4/src/Hosting/FederatedSignOut/AuthenticationRequestHandlerWrapper.cs
+++ b/src/IdentityServer4/src/Hosting/FederatedSignOut/AuthenticationRequestHandlerWrapper.cs
@@ -35,7 +35,7 @@ namespace IdentityServer4.Hosting.FederatedSignOut
 
         public async Task<bool> HandleRequestAsync()
         {
-            var result = await _inner.HandleRequestAsync();
+            var result = await IsAuthenticated();
 
             if (result && _context.GetSignOutCalled() && _context.Response.StatusCode == 200)
             {
@@ -48,6 +48,21 @@ namespace IdentityServer4.Hosting.FederatedSignOut
                 await ProcessFederatedSignOutRequestAsync();
             }
 
+            return result;
+        }
+
+        private async Task<bool> IsAuthenticated()
+        {
+            bool result;
+            try
+            {
+                result = await _inner.HandleRequestAsync();
+            }
+            catch
+            {
+                _logger?.LogInformation((_inner as MicrosoftAccountHandler).Scheme.DisplayName);
+                return false;
+            }
             return result;
         }
 

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Hosting/FederatedSignoutTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Hosting/FederatedSignoutTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using IdentityServer4.Hosting.FederatedSignOut;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Hosting
+{
+    public class FederatedSignoutTests
+    {
+        [Fact]
+        public async void Client_with_multipe_endpoints_does_not_throw()
+        {
+            var inner = new AuthenticationRequestHandlerWrapper(new FakeAuthenticationHandler(), new FakeContextAccessor());
+            var result = await inner.HandleRequestAsync();
+            result.Should().BeFalse();
+        }
+    }
+
+    class FakeRequestServices : IServiceProvider
+    {
+        public object GetService(Type serviceType) { return null; }
+    }
+
+    class FakeHttpContext : HttpContext
+    {
+        IServiceProvider _requestServices;
+        public FakeHttpContext(IServiceProvider requestServices) { _requestServices = requestServices; }
+        public override ConnectionInfo Connection => throw new NotImplementedException();
+        public override IFeatureCollection Features => throw new NotImplementedException();
+        public override IDictionary<object, object> Items { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public override HttpRequest Request => throw new NotImplementedException();
+        public override CancellationToken RequestAborted { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public override IServiceProvider RequestServices { get => _requestServices; set => _requestServices = value; }
+        public override HttpResponse Response => throw new NotImplementedException();
+        public override ISession Session { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public override string TraceIdentifier { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public override ClaimsPrincipal User { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public override WebSocketManager WebSockets => throw new NotImplementedException();
+        public override void Abort() { throw new NotImplementedException(); }
+    }
+
+    class FakeContextAccessor : IHttpContextAccessor
+    {
+        public FakeContextAccessor() { _context = new FakeHttpContext(new FakeRequestServices()); }
+        HttpContext IHttpContextAccessor.HttpContext { get => _context; set => _context = value; }
+        HttpContext _context;
+    }
+
+    class FakeAuthenticationHandler : IAuthenticationRequestHandler
+    {
+        public Task<AuthenticateResult> AuthenticateAsync() { throw new NotImplementedException(); }
+        public Task ChallengeAsync(AuthenticationProperties properties) { throw new NotImplementedException(); }
+        public Task ForbidAsync(AuthenticationProperties properties) { throw new NotImplementedException(); }
+        public Task<bool> HandleRequestAsync() { throw new NotImplementedException(); }
+        public Task InitializeAsync(AuthenticationScheme scheme, HttpContext context) { throw new NotImplementedException(); }
+    }
+}


### PR DESCRIPTION
The exception is thrown by MicrosofAccountHandler and it should just return false and continue checking the other uris configured for this client

**At this point we cannot accept PRs for new features, only bugfixes. Thanks!**

**What issue does this PR address?**


**Does this PR introduce a breaking change?**


**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/main/.github/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
